### PR TITLE
Datadog Source Code Integration

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -8,6 +8,7 @@ use std::time::SystemTime;
 use super::unified_tags::{UnifiedTagField, UnifiedTags};
 
 const SPAN_NUM_ELEMENTS: u32 = 12;
+const GIT_META_TAGS_COUNT: u32 = if matches!((option_env!("DD_GIT_REPOSITORY_URL"), option_env!("DD_GIT_COMMIT_SHA")), (Some(_), Some(_))) { 2 } else { 0 };
 
 // Protocol documentation sourced from https://github.com/DataDog/datadog-agent/blob/c076ea9a1ffbde4c76d35343dbc32aecbbf99cb9/pkg/trace/api/version.go
 //
@@ -189,7 +190,6 @@ where
                 },
             )?;
 
-            const GIT_META_TAGS_COUNT: u32 = if matches!((option_env!("DD_GIT_REPOSITORY_URL"), option_env!("DD_GIT_COMMIT_SHA")), (Some(_), Some(_))) { 2 } else { 0 };
             rmp::encode::write_map_len(
                 &mut encoded,
                 (span.attributes.len() + span.resource.len()) as u32


### PR DESCRIPTION
## Changes

This pull request introduces part of  [Datadog Source Code Integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=go)
Added compile time env variables: `DD_GIT_REPOSITORY_URL` and `DD_GIT_COMMIT_SHA`. Exporter will send this information in sampled traces.

## Example of usage

```
DD_GIT_REPOSITORY_URL="git@github.com:Hartigan/opentelemetry-rust-contrib.git" DD_GIT_COMMIT_SHA="e4b2b10970d10237457a3d1a87a3e75cf41488ad" cargo build
```
