### PR TITLE
Make binary propagator take byte slice instead of vec

### DIFF
--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Update `BinaryFormat::deserialize_from_bytes` to take a byte slice instead of a Vec [#32](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/32)
+
 ## v0.13.0
 
 ### Changed

--- a/opentelemetry-contrib/src/trace/propagator/binary/base64_format.rs
+++ b/opentelemetry-contrib/src/trace/propagator/binary/base64_format.rs
@@ -32,7 +32,7 @@ where
 
     fn deserialize_from_base64(&self, base64: &str) -> SpanContext {
         if let Ok(bytes) = decode(base64.as_bytes()) {
-            self.deserialize_from_bytes(bytes)
+            self.deserialize_from_bytes(&bytes)
         } else {
             SpanContext::empty_context()
         }

--- a/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
+++ b/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
@@ -15,7 +15,7 @@ pub trait BinaryFormat {
     fn serialize_into_bytes(&self, context: &SpanContext) -> [u8; 29];
 
     /// Deserializes a span context from a byte array.
-    fn deserialize_from_bytes(&self, bytes: Vec<u8>) -> SpanContext;
+    fn deserialize_from_bytes(&self, bytes: &[u8]) -> SpanContext;
 }
 
 /// Extracts and injects `SpanContext`s from byte arrays.
@@ -46,7 +46,7 @@ impl BinaryFormat for BinaryPropagator {
     }
 
     /// Deserializes a span context from a byte array.
-    fn deserialize_from_bytes(&self, bytes: Vec<u8>) -> SpanContext {
+    fn deserialize_from_bytes(&self, bytes: &[u8]) -> SpanContext {
         if bytes.is_empty() {
             return SpanContext::empty_context();
         }
@@ -172,7 +172,7 @@ mod tests {
         let propagator = BinaryPropagator::new();
 
         for (context, data) in from_bytes_data() {
-            assert_eq!(propagator.deserialize_from_bytes(data), context)
+            assert_eq!(propagator.deserialize_from_bytes(&data), context)
         }
     }
 }


### PR DESCRIPTION
Fixes #31 

## Changes

Updates `deserialize_from_bytes` to take a byte slice instead of an owned vec.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
