### PR TITLE
Prepare for release user_events_metrics exporter 0.3.0

### DIFF
--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.3.0
+
+### Changed
+
+- Bump opentelemetry version to 0.22, opentelemetry_sdk version to 0.22,
+  opentelemetry-proto version to 0.5.
+
 ## v0.2.2
 
 - Fixed a bug which caused Histogram, Gauge metrics to be dropped.

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-user-events-metrics"
-version = "0.2.2"
+version = "0.3.0"
 description = "OpenTelemetry metrics exporter to user events"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"


### PR DESCRIPTION
Prepare changelog and version to release user_events metrics exporter.
I think there should be a release done for all other crates as well.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
