### PR TITLE
stackdriver: parse trace context without regex

### DIFF
--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -25,8 +25,6 @@ thiserror = "1.0.30"
 tonic = { version = "0.11", features = ["gzip", "tls", "transport"] }
 yup-oauth2 = { version = "8.1.0", optional = true }
 once_cell = { version = "1.19", optional = true }
-# we don't need unicode support
-regex = { version = "1.10", default-features = false, features = ["std", "perf"], optional = true }
 
 # Futures
 futures-core = "0.3"
@@ -38,7 +36,7 @@ default = ["yup-authorizer", "tls-native-roots"]
 yup-authorizer = ["hyper-rustls", "yup-oauth2"]
 tls-native-roots = ["tonic/tls-roots"]
 tls-webpki-roots = ["tonic/tls-webpki-roots"]
-propagator = ["once_cell", "regex"]
+propagator = ["once_cell"]
 
 [dev-dependencies]
 reqwest = "0.11.9"

--- a/opentelemetry-stackdriver/src/google_trace_context_propagator.rs
+++ b/opentelemetry-stackdriver/src/google_trace_context_propagator.rs
@@ -31,11 +31,6 @@ static TRACE_CONTEXT_HEADER_FIELDS: Lazy<[String; 1]> =
     Lazy::new(|| [CLOUD_TRACE_CONTEXT_HEADER.to_owned()]);
 
 impl GoogleTraceContextPropagator {
-    /// Create a new `GoogleTraceContextPropagator`.
-    pub fn new() -> Self {
-        GoogleTraceContextPropagator { _private: () }
-    }
-
     fn extract_span_context(&self, extractor: &dyn Extractor) -> Result<SpanContext, ()> {
         let header_value = extractor
             .get(CLOUD_TRACE_CONTEXT_HEADER)
@@ -103,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_extract_span_context_valid() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         headers.insert(
             // hashmap implementation of Extractor trait uses lowercase keys
@@ -122,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_extract_span_context_valid_without_options() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         headers.insert(
             // hashmap implementation of Extractor trait uses lowercase keys
@@ -141,7 +136,7 @@ mod tests {
 
     #[test]
     fn test_extract_span_context_valid_not_sampled() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         headers.insert(
             // hashmap implementation of Extractor trait uses lowercase keys
@@ -160,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_extract_span_context_invalid() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let headers = HashMap::new();
 
         assert!(propagator.extract_span_context(&headers).is_err());
@@ -168,7 +163,7 @@ mod tests {
 
     #[test]
     fn test_inject_context_valid() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         let span = TestSpan(SpanContext::new(
             TraceId::from_hex("105445aa7843bc8bf206b12000100000").unwrap(),
@@ -189,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_extract_with_context_valid() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         headers.insert(
             CLOUD_TRACE_CONTEXT_HEADER.to_string().to_lowercase(),
@@ -207,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_extract_with_context_invalid_trace_id() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         // Insert a trace ID with less than 32 characters
         headers.insert(
@@ -223,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_extract_with_context_invalid_span_id() {
-        let propagator = GoogleTraceContextPropagator::new();
+        let propagator = GoogleTraceContextPropagator::default();
         let mut headers = HashMap::new();
         // Insert a trace ID with less than 32 characters
         headers.insert(

--- a/opentelemetry-stackdriver/src/google_trace_context_propagator.rs
+++ b/opentelemetry-stackdriver/src/google_trace_context_propagator.rs
@@ -240,12 +240,16 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert(
             CLOUD_TRACE_CONTEXT_HEADER.to_string().to_lowercase(),
-            "105445aa7843bc8bf206b12000100000/1;o=1".to_string(),
+            "105445aa7843bc8bf206b12000100000/10;o=1".to_string(),
         );
         let cx = Context::current();
 
         let new_cx = propagator.extract_with_context(&cx, &headers);
         assert!(new_cx.span().span_context().is_valid());
+        assert_eq!(
+            new_cx.span().span_context().span_id().to_string(),
+            "000000000000000a"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Simplify parsing trace context to avoid the complexity of regular expressions (and the added dependency).

Follow-up for #25.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
