### PR TITLE
stackdriver: fix Cargo features for GcpAuthorizer

### DIFF
--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.19.1
+
+### Fixed
+
+- Fixed Cargo features for `GcpAuthorizer` [#51](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/51)
+
 ## v0.19.0
 
 ### Added

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -32,7 +32,8 @@ futures-util = { version = "0.3", default-features = false, features = ["alloc"]
 futures-channel = { version = "0.3", default-features = false, features = ["std"] }
 
 [features]
-default = ["dep:gcp_auth", "tls-native-roots"]
+default = ["gcp-authorizer", "tls-native-roots"]
+gcp-authorizer = ["dep:gcp_auth"]
 yup-authorizer = ["hyper-rustls", "dep:yup-oauth2"]
 tls-native-roots = ["tonic/tls-roots"]
 tls-webpki-roots = ["tonic/tls-webpki-roots"]

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stackdriver"
-version = "0.19.0"
+version = "0.19.1"
 description = "A Rust opentelemetry exporter that uploads traces to Google Stackdriver trace."
 documentation = "https://docs.rs/opentelemetry-stackdriver/"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib"

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -38,7 +38,7 @@ use opentelemetry_sdk::{
 };
 use opentelemetry_semantic_conventions as semconv;
 use thiserror::Error;
-#[cfg(any(feature = "yup-authorizer", feature = "gcp_auth"))]
+#[cfg(any(feature = "yup-authorizer", feature = "gcp-authorizer"))]
 use tonic::metadata::MetadataValue;
 use tonic::{
     transport::{Channel, ClientTlsConfig},
@@ -453,13 +453,13 @@ impl Authorizer for YupAuthorizer {
     }
 }
 
-#[cfg(feature = "gcp_auth")]
+#[cfg(feature = "gcp-authorizer")]
 pub struct GcpAuthorizer {
     manager: gcp_auth::AuthenticationManager,
     project_id: String,
 }
 
-#[cfg(feature = "gcp_auth")]
+#[cfg(feature = "gcp-authorizer")]
 impl GcpAuthorizer {
     pub async fn new() -> Result<Self, Error> {
         let manager = gcp_auth::AuthenticationManager::new()
@@ -484,7 +484,7 @@ impl GcpAuthorizer {
     }
 }
 
-#[cfg(feature = "gcp_auth")]
+#[cfg(feature = "gcp-authorizer")]
 #[async_trait]
 impl Authorizer for GcpAuthorizer {
     type Error = Error;


### PR DESCRIPTION
## Changes

#50 regressed the support for actually using the `GcpAuthorizer`: it used the `dep:gcp_auth` syntax for enabling the dependency by default, but the actual `GcpAuthorizer` code was guarded by a `gcp_auth` **feature** which didn't exist anymore. Bring back a named feature for this (now called `gcp-authorizer` to match `yup-authorizer`).

This time I will start a PR for my work repository based on my branch to make sure it actually works.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)