### PR TITLE
feat: Add host.id resource detector

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.0
+## vNext
 
 ### Added
 

--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0
+
+### Added
+
+- Host resource detector
+
 ## v0.1.0
 
 ### Added

--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Host resource detector
+- Added `HostResourceDetector` which populates "host.id" attribute. Currently only Linux is supported.
 
 ## v0.1.0
 

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-resource-detectors"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 description = "A collection of community supported resource detectors for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-resource-detectors"

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-resource-detectors"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A collection of community supported resource detectors for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-resource-detectors"

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -12,8 +12,8 @@ Community supported Resource detectors implementations for applications instrume
 
 ## Features
 
-| Detector                | Implemented Resources                               | Semantic Conventions       |
-|-------------------------| --------------------------------------------------- | -------------------------- |
-| ProcessResourceDetector | PROCESS_COMMAND_ARGS, PROCESS_PID | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/process.md |
-| OsResourceDetector      | OS_TYPE | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/os.md |
-| HostResourceDetector    | HOST_ID | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/host.md |
+| Detector                | Implemented Resources                               | OS Supported | Semantic Conventions                                                                      |
+|-------------------------| --------------------------------------------------- |--------------|-------------------------------------------------------------------------------------------|
+| ProcessResourceDetector | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
+| OsResourceDetector      | OS_TYPE | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
+| HostResourceDetector    | HOST_ID | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -12,7 +12,8 @@ Community supported Resource detectors implementations for applications instrume
 
 ## Features
 
-| Detector       | Implemented Resources                               | Semantic Conventions       |
-| -------------- | --------------------------------------------------- | -------------------------- |
+| Detector                | Implemented Resources                               | Semantic Conventions       |
+|-------------------------| --------------------------------------------------- | -------------------------- |
 | ProcessResourceDetector | PROCESS_COMMAND_ARGS, PROCESS_PID | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/process.md |
-| OsResourceDetector  | OS_TYPE | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/os.md |
+| OsResourceDetector      | OS_TYPE | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/os.md |
+| HostResourceDetector    | HOST_ID | https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/resource/semantic_conventions/host.md |

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -56,7 +56,7 @@ impl Default for HostResourceDetector {
 #[cfg(test)]
 mod tests {
     use super::HostResourceDetector;
-    use opentelemetry::{Key, Value};
+    use opentelemetry::Key;
     use opentelemetry_sdk::resource::ResourceDetector;
     use std::time::Duration;
 

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -37,6 +37,7 @@ fn host_id_detect() -> Option<String> {
     read_to_string(machine_id_path).or_else(|_|{read_to_string(dbus_machine_id_path)}).ok()
 }
 
+// TODO: Implement non-linux platforms
 #[cfg(not(target_os = "linux"))]
 fn host_id_detect() -> Option<String> {
     None

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -1,0 +1,71 @@
+//! HOST resource detector
+//!
+//! Detect the unique host ID.
+use std::error::Error;
+use std::fs::read_to_string;
+use std::path::Path;
+use std::time::Duration;
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::resource::ResourceDetector;
+
+/// Detect the unique host ID.
+///
+/// This detector looks up the host id using the sources defined
+/// in the OpenTelemetry semantic conventions [`host.id from non-containerized systems`].
+///
+/// [`host.id from non-containerized systems`]: https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems
+pub struct HostResourceDetector {
+    host_id_detect: fn() -> Option<String>
+}
+
+impl ResourceDetector for HostResourceDetector {
+    fn detect(&self, _timeout: Duration) -> Resource {
+        (self.host_id_detect)().map(|host_id| {
+            Resource::new(vec![KeyValue::new(
+                opentelemetry_semantic_conventions::resource::HOST_ID,
+                host_id,
+            )])
+        }).unwrap_or(Resource::new(vec![]))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn host_id_detect() -> Option<String> {
+    let machine_id_path  = Path::new("/etc/machine-id");
+    let dbus_machine_id_path = Path::new("/var/lib/dbus/machine-id");
+    read_to_string(machine_id_path).or_else(|_|{read_to_string(dbus_machine_id_path)}).ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn host_id_detect() -> Option<String> {
+    None
+}
+
+impl Default for HostResourceDetector {
+    fn default() -> Self {
+        Self {
+            host_id_detect
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use opentelemetry::{Key, Value};
+    use opentelemetry_sdk::resource::ResourceDetector;
+    use super::HostResourceDetector;
+
+    #[test]
+    fn test_host_resource_detector() {
+        let resource =  HostResourceDetector::default().detect(Duration::from_secs(0));
+        assert_eq!(resource.len(), 1);
+        assert!(
+            resource.get(Key::from_static_str(
+                opentelemetry_semantic_conventions::resource::HOST_ID
+            )).is_some()
+        )
+    }
+}

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -1,13 +1,13 @@
 //! HOST resource detector
 //!
 //! Detect the unique host ID.
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::resource::ResourceDetector;
+use opentelemetry_sdk::Resource;
 use std::error::Error;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::time::Duration;
-use opentelemetry::KeyValue;
-use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::resource::ResourceDetector;
 
 /// Detect the unique host ID.
 ///
@@ -16,25 +16,29 @@ use opentelemetry_sdk::resource::ResourceDetector;
 ///
 /// [`host.id from non-containerized systems`]: https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems
 pub struct HostResourceDetector {
-    host_id_detect: fn() -> Option<String>
+    host_id_detect: fn() -> Option<String>,
 }
 
 impl ResourceDetector for HostResourceDetector {
     fn detect(&self, _timeout: Duration) -> Resource {
-        (self.host_id_detect)().map(|host_id| {
-            Resource::new(vec![KeyValue::new(
-                opentelemetry_semantic_conventions::resource::HOST_ID,
-                host_id,
-            )])
-        }).unwrap_or(Resource::new(vec![]))
+        (self.host_id_detect)()
+            .map(|host_id| {
+                Resource::new(vec![KeyValue::new(
+                    opentelemetry_semantic_conventions::resource::HOST_ID,
+                    host_id,
+                )])
+            })
+            .unwrap_or(Resource::new(vec![]))
     }
 }
 
 #[cfg(target_os = "linux")]
 fn host_id_detect() -> Option<String> {
-    let machine_id_path  = Path::new("/etc/machine-id");
+    let machine_id_path = Path::new("/etc/machine-id");
     let dbus_machine_id_path = Path::new("/var/lib/dbus/machine-id");
-    read_to_string(machine_id_path).or_else(|_|{read_to_string(dbus_machine_id_path)}).ok()
+    read_to_string(machine_id_path)
+        .or_else(|_| read_to_string(dbus_machine_id_path))
+        .ok()
 }
 
 // TODO: Implement non-linux platforms
@@ -45,28 +49,26 @@ fn host_id_detect() -> Option<String> {
 
 impl Default for HostResourceDetector {
     fn default() -> Self {
-        Self {
-            host_id_detect
-        }
+        Self { host_id_detect }
     }
 }
 
 #[cfg(target_os = "linux")]
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use super::HostResourceDetector;
     use opentelemetry::{Key, Value};
     use opentelemetry_sdk::resource::ResourceDetector;
-    use super::HostResourceDetector;
+    use std::time::Duration;
 
     #[test]
     fn test_host_resource_detector() {
-        let resource =  HostResourceDetector::default().detect(Duration::from_secs(0));
+        let resource = HostResourceDetector::default().detect(Duration::from_secs(0));
         assert_eq!(resource.len(), 1);
-        assert!(
-            resource.get(Key::from_static_str(
+        assert!(resource
+            .get(Key::from_static_str(
                 opentelemetry_semantic_conventions::resource::HOST_ID
-            )).is_some()
-        )
+            ))
+            .is_some())
     }
 }

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -4,7 +4,6 @@
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::ResourceDetector;
 use opentelemetry_sdk::Resource;
-use std::error::Error;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::time::Duration;

--- a/opentelemetry-resource-detectors/src/lib.rs
+++ b/opentelemetry-resource-detectors/src/lib.rs
@@ -5,8 +5,11 @@
 //!
 //! - [`OsResourceDetector`] - detect OS from runtime.
 //! - [`ProcessResourceDetector`] - detect process information.
+//! - [`HostResourceDetector`] - detect unique host ID.
 mod os;
 mod process;
+mod host;
 
 pub use os::OsResourceDetector;
 pub use process::ProcessResourceDetector;
+pub use host::HostResourceDetector;

--- a/opentelemetry-resource-detectors/src/lib.rs
+++ b/opentelemetry-resource-detectors/src/lib.rs
@@ -6,10 +6,10 @@
 //! - [`OsResourceDetector`] - detect OS from runtime.
 //! - [`ProcessResourceDetector`] - detect process information.
 //! - [`HostResourceDetector`] - detect unique host ID.
+mod host;
 mod os;
 mod process;
-mod host;
 
+pub use host::HostResourceDetector;
 pub use os::OsResourceDetector;
 pub use process::ProcessResourceDetector;
-pub use host::HostResourceDetector;


### PR DESCRIPTION
## Changes

Add the Host Resource detector retrieving the "host.id" as defined in: https://opentelemetry.io/docs/specs/semconv/resource/host/

Defined in #56 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

Co-authored-by: rogercoll <rogercoll@users.noreply.github.com>