### PR TITLE
chore(deps): bump yup-oauth2 and hyper-rustls version

### DIFF
--- a/opentelemetry-etw-logs/src/logs/converters.rs
+++ b/opentelemetry-etw-logs/src/logs/converters.rs
@@ -54,40 +54,39 @@ mod tests {
         let result = vec.as_json_value();
         assert_eq!(result, json!([1, 2, 3, 0, -2]));
 
-        let vec = vec![];
-        let result = vec.as_json_value();
+        let result = [].as_json_value();
         assert_eq!(result, json!([]));
 
-        let vec = vec![AnyValue::ListAny(vec![
+        let array = [AnyValue::ListAny(vec![
             AnyValue::Int(1),
             AnyValue::Int(2),
             AnyValue::Int(3),
         ])];
-        let result = vec.as_json_value();
+        let result = array.as_json_value();
         assert_eq!(result, json!([[1, 2, 3]]));
 
-        let vec = vec![
+        let array = [
             AnyValue::ListAny(vec![AnyValue::Int(1), AnyValue::Int(2)]),
             AnyValue::ListAny(vec![AnyValue::Int(3), AnyValue::Int(4)]),
         ];
-        let result = vec.as_json_value();
+        let result = array.as_json_value();
         assert_eq!(result, json!([[1, 2], [3, 4]]));
 
-        let vec = vec![AnyValue::Boolean(true), AnyValue::Boolean(false)];
-        let result = vec.as_json_value();
+        let array = [AnyValue::Boolean(true), AnyValue::Boolean(false)];
+        let result = array.as_json_value();
         assert_eq!(result, json!([true, false]));
 
-        let vec = vec![
+        let array = [
             AnyValue::Double(1.0),
             AnyValue::Double(-1.0),
             AnyValue::Double(0.0),
             AnyValue::Double(0.1),
             AnyValue::Double(-0.5),
         ];
-        let result = vec.as_json_value();
+        let result = array.as_json_value();
         assert_eq!(result, json!([1.0, -1.0, 0.0, 0.1, -0.5]));
 
-        let vec = vec![
+        let array = [
             AnyValue::String("".into()),
             AnyValue::String("a".into()),
             AnyValue::String(r#"""#.into()),
@@ -95,7 +94,7 @@ mod tests {
             AnyValue::String(r#"foo bar"#.into()),
             AnyValue::String(r#""foo bar""#.into()),
         ];
-        let result = vec.as_json_value();
+        let result = array.as_json_value();
         assert_eq!(
             result,
             json!(["", "a", "\"", "\"\"", "foo bar", "\"foo bar\""])
@@ -105,11 +104,11 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_convert_bytes_panics() {
-        let vec = vec![
+        let array = [
             AnyValue::Bytes(vec![97u8, 98u8, 99u8]),
             AnyValue::Bytes(vec![]),
         ];
-        let result = vec.as_json_value();
+        let result = array.as_json_value();
         assert_eq!(result, json!(["abc", ""]));
     }
 

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Bump yup-oauth2 to 8.3.3 [#58](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/58)
+- Bump hyper-rustls to 0.25 [#58](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/58)
+
 ## v0.19.1
 
 ### Fixed

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -15,7 +15,7 @@ gcp_auth = { version = "0.11", optional = true }
 hex = "0.4"
 http = "0.2"
 hyper = "0.14.2"
-hyper-rustls = { version = "0.24", optional = true }
+hyper-rustls = { version = "0.25", optional = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["trace"] }
 opentelemetry-semantic-conventions = { workspace = true }
@@ -23,7 +23,7 @@ prost = "0.12"
 prost-types = "0.12"
 thiserror = "1.0.30"
 tonic = { version = "0.11", features = ["gzip", "tls", "transport"] }
-yup-oauth2 = { version = "8.1.0", optional = true }
+yup-oauth2 = { version = "8.3.3", optional = true }
 once_cell = { version = "1.19", optional = true }
 
 # Futures


### PR DESCRIPTION

Fixes: 

- https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/57#issuecomment-2015740499
- Clippy: useless vector

## Changes

Bump corresponding crates.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
