### PR TITLE
feat: add host.arch resource attribute

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add "host.arch" attribute into the `HostResourceDetector`.
 - Added `HostResourceDetector` which populates "host.id" attribute. Currently only Linux is supported.
 
 ## v0.1.0

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -17,3 +17,4 @@ Community supported Resource detectors implementations for applications instrume
 | ProcessResourceDetector | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
 | OsResourceDetector      | OS_TYPE | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
 | HostResourceDetector    | HOST_ID | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
+| HostResourceDetector    | HOST_ARCH | all        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -63,7 +63,6 @@ impl Default for HostResourceDetector {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[cfg(test)]
 mod tests {
     use super::HostResourceDetector;
@@ -71,6 +70,7 @@ mod tests {
     use opentelemetry_sdk::resource::ResourceDetector;
     use std::time::Duration;
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_host_resource_detector() {
         let resource = HostResourceDetector::default().detect(Duration::from_secs(0));
@@ -80,11 +80,37 @@ mod tests {
                 opentelemetry_semantic_conventions::resource::HOST_ID
             ))
             .is_some());
+        assert!(resource
+            .get(Key::from_static_str(
+                opentelemetry_semantic_conventions::resource::HOST_ARCH
+            ))
+            .is_some())
+    }
+
+    #[test]
+    fn test_resource_host_arch_value() {
+        let resource = HostResourceDetector::default().detect(Duration::from_secs(0));
+
+        assert!(resource
+            .get(Key::from_static_str(
+                opentelemetry_semantic_conventions::resource::HOST_ARCH
+            ))
+            .is_some());
+
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             resource.get(Key::from_static_str(
                 opentelemetry_semantic_conventions::resource::HOST_ARCH
             )),
             Some(Value::from("x86_64"))
+        );
+
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            resource.get(Key::from_static_str(
+                opentelemetry_semantic_conventions::resource::HOST_ARCH
+            )),
+            Some(Value::from("aarch64"))
         )
     }
 }

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -4,30 +4,41 @@
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::ResourceDetector;
 use opentelemetry_sdk::Resource;
+use std::env::consts::ARCH;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::time::Duration;
 
-/// Detect the unique host ID.
+/// Detect host information.
 ///
-/// This detector looks up the host id using the sources defined
-/// in the OpenTelemetry semantic conventions [`host.id from non-containerized systems`].
+/// This resource detector returns the following information:
 ///
-/// [`host.id from non-containerized systems`]: https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems
+/// - [`host.id from non-containerized systems`]: https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems
+/// - Host architecture (host.arch).
 pub struct HostResourceDetector {
     host_id_detect: fn() -> Option<String>,
 }
 
 impl ResourceDetector for HostResourceDetector {
     fn detect(&self, _timeout: Duration) -> Resource {
-        (self.host_id_detect)()
-            .map(|host_id| {
-                Resource::new(vec![KeyValue::new(
-                    opentelemetry_semantic_conventions::resource::HOST_ID,
-                    host_id,
-                )])
-            })
-            .unwrap_or(Resource::new(vec![]))
+        Resource::new(
+            [
+                // Get host.id
+                (self.host_id_detect)().map(|host_id| {
+                    KeyValue::new(
+                        opentelemetry_semantic_conventions::resource::HOST_ID,
+                        host_id,
+                    )
+                }),
+                // Get host.arch
+                Some(KeyValue::new(
+                    opentelemetry_semantic_conventions::resource::HOST_ARCH,
+                    ARCH,
+                )),
+            ]
+            .into_iter()
+            .flatten(),
+        )
     }
 }
 
@@ -56,18 +67,24 @@ impl Default for HostResourceDetector {
 #[cfg(test)]
 mod tests {
     use super::HostResourceDetector;
-    use opentelemetry::Key;
+    use opentelemetry::{Key, Value};
     use opentelemetry_sdk::resource::ResourceDetector;
     use std::time::Duration;
 
     #[test]
     fn test_host_resource_detector() {
         let resource = HostResourceDetector::default().detect(Duration::from_secs(0));
-        assert_eq!(resource.len(), 1);
+        assert_eq!(resource.len(), 2);
         assert!(resource
             .get(Key::from_static_str(
                 opentelemetry_semantic_conventions::resource::HOST_ID
             ))
-            .is_some())
+            .is_some());
+        assert_eq!(
+            resource.get(Key::from_static_str(
+                opentelemetry_semantic_conventions::resource::HOST_ARCH
+            )),
+            Some(Value::from("x86_64"))
+        )
     }
 }


### PR DESCRIPTION
# Changes

Adds the "host.arch" resource attribute to the Host detector.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
