### PR TITLE
Prepare for v0.4 release for  user_events exporters for metrics and logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ resolver = "2"
 debug = 1
 
 [workspace.dependencies]
-opentelemetry = "0.22"
-opentelemetry-appender-tracing = "0.3"
-opentelemetry-http = "0.11"
-opentelemetry-proto = { version = "0.5", default-features = false }
-opentelemetry_sdk = { version = "0.22", default-features = false }
-opentelemetry-stdout = "0.3"
-opentelemetry-semantic-conventions = "0.14"
+opentelemetry = "0.23"
+opentelemetry-appender-tracing = "0.4"
+opentelemetry-http = "0.12"
+opentelemetry-proto = { version = "0.6", default-features = false }
+opentelemetry_sdk = { version = "0.23", default-features = false }
+opentelemetry-stdout = "0.4"
+opentelemetry-semantic-conventions = "0.15"

--- a/opentelemetry-etw-logs/src/logs/exporter.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter.rs
@@ -223,7 +223,8 @@ impl ETWExporter {
         let event_time: SystemTime = log_data
             .record
             .timestamp
-            .unwrap_or(log_data.record.observed_timestamp);
+            .or_else(|| log_data.record.observed_timestamp)
+            .unwrap_or_else(SystemTime::now); // observerd_timestamp will never be None as per otel specs
 
         const COUNT_TIME: u8 = 1u8;
         const PART_A_COUNT: u8 = COUNT_TIME;
@@ -430,7 +431,6 @@ mod tests {
         let log_data = LogData {
             instrumentation: Default::default(),
             record: Default::default(),
-            resource: Default::default(),
         };
 
         let result = exporter.export_log_data(&log_data);

--- a/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
@@ -44,7 +44,7 @@ impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
 
     // This is a no-op no special cleanup is required before
     // shutdown.
-    fn shutdown(&mut self) -> LogResult<()> {
+    fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 

--- a/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
@@ -100,7 +100,6 @@ mod tests {
         let log_data = LogData {
             instrumentation: Default::default(),
             record: Default::default(),
-            resource: Default::default(),
         };
 
         processor.emit(log_data);

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -23,7 +23,7 @@ prost = "0.12"
 prost-types = "0.12"
 thiserror = "1.0.30"
 tonic = { version = "0.11", features = ["gzip", "tls", "transport"] }
-yup-oauth2 = { version = "9.0.0", optional = true }
+yup-oauth2 = { version = "8.3.3", optional = true }
 once_cell = { version = "1.19", optional = true }
 
 # Futures

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -23,7 +23,7 @@ prost = "0.12"
 prost-types = "0.12"
 thiserror = "1.0.30"
 tonic = { version = "0.11", features = ["gzip", "tls", "transport"] }
-yup-oauth2 = { version = "8.3.3", optional = true }
+yup-oauth2 = { version = "9.0.0", optional = true }
 once_cell = { version = "1.19", optional = true }
 
 # Futures

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.4.0
+
+### Changed
+
+- Bump opentelemetry version to 0.23, opentelemetry_sdk version to 0.23
+
 ## v0.3.0
 
 ### Changed

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Bump opentelemetry version to 0.23, opentelemetry_sdk version to 0.23
+- Bump opentelemetry, opentelemetry_sdk  version to 0.23.
 
 ## v0.3.0
 

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["opentelemetry", "log", "trace", "user_events"]
 license = "Apache-2.0"
 
 [dependencies]
-eventheader = "0.3.2"
-eventheader_dynamic = "0.3.3"
+eventheader = "0.4.0"
+eventheader_dynamic = "0.4.0"
 opentelemetry = { workspace = true, features = ["logs"] }
 opentelemetry_sdk = { workspace = true, features = ["logs"] }
 async-std = { version="1.6" }

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -202,7 +202,7 @@ impl UserEventsExporter {
                     .record
                     .timestamp
                     .or_else(|| log_data.record.observed_timestamp)
-                    .unwrap_or_else(SystemTime::now); // observerd_timestamp is always present as per otel specs.
+                    .unwrap_or_else(SystemTime::now); // observed_timestamp is always present as per otel specs.
                 cs_a_count += 1; // for event_time
                 eb.add_struct("PartA", cs_a_count, 0);
                 {

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -201,7 +201,8 @@ impl UserEventsExporter {
                 let event_time: SystemTime = log_data
                     .record
                     .timestamp
-                    .unwrap_or(log_data.record.observed_timestamp);
+                    .or_else(|| log_data.record.observed_timestamp)
+                    .unwrap_or_else(SystemTime::now); // observerd_timestamp is always present as per otel specs.
                 cs_a_count += 1; // for event_time
                 eb.add_struct("PartA", cs_a_count, 0);
                 {

--- a/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
@@ -45,7 +45,7 @@ impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
 
     // This is a no-op no special cleanup is required before
     // shutdown.
-    fn shutdown(&mut self) -> LogResult<()> {
+    fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.4.0
+
+### Changed
+
+- Bump opentelemetry version to 0.23, opentelemetry_sdk version to 0.23,
+  opentelemetry-proto version to 0.6.
+
 ## v0.3.0
 
 ### Changed

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-user-events-metrics"
-version = "0.3.0"
+version = "0.4.0"
 description = "OpenTelemetry metrics exporter to user events"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
@@ -14,7 +14,7 @@ rust-version = "1.65"
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "rt-tokio"] }
 opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
-eventheader = { version = "= 0.3.4" }
+eventheader = { version = "= 0.4.0" }
 async-trait = "0.1"
 prost = "0.12"
 


### PR DESCRIPTION
## Changes

New releases for user_events exporters with latest otel-rust (v0.23.0) dependency.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
