### PR TITLE
Exclude crates failing to build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
 ]
 exclude = [
     "opentelemetry-dynatrace",
+    "opentelemetry-datadog",
+    "opentelemetry-stackdriver",
+    "opentelemetry-zpages"
 ]
 resolver = "2"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,8 +7,12 @@ cargo test --all --all-features "$@" -- --test-threads=1
 
 cargo test --manifest-path=opentelemetry-aws/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-contrib/Cargo.toml --all-features
-cargo test --manifest-path=opentelemetry-datadog/Cargo.toml --all-features
-cargo test --manifest-path=opentelemetry-stackdriver/Cargo.toml --all-features
+
+#TODO enable below once datadog exporter is building fine
+#cargo test --manifest-path=opentelemetry-datadog/Cargo.toml --all-features 
+
+#TODO enable below once stackdriver exporter is building fine
+#cargo test --manifest-path=opentelemetry-stackdriver/Cargo.toml --all-features
 
 cargo test --manifest-path=opentelemetry-user-events-logs/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-user-events-metrics/Cargo.toml --all-features


### PR DESCRIPTION
Excluding crates failing to build in the current pipeline. This may be due to the rust toolchain upgrade, or the dependency upgrades. These can be incrementally brought back once they are fixed.
Refer #64 for some of the errors tried fixing, but there are somewhat more.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
