### PR TITLE
Prepare for relate (most) contrib crates.

### DIFF
--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-aws"
-version = "0.10.0"
+version = "0.11.0"
 description = "AWS exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws"

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-contrib"
-version = "0.14.0"
+version = "0.15.0"
 description = "Rust contrib repo for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-contrib"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-contrib"

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-datadog"
-version = "0.10.0"
+version = "0.11.0"
 description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-resource-detectors"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A collection of community supported resource detectors for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-resource-detectors"

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-zpages"
-version = "0.7.0"
+version = "0.8.0"
 description = "ZPages implementation for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-zpages"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-zpages"
@@ -9,6 +9,7 @@ categories = [
     "development-tools::debugging",
     "development-tools::profiling",
     "asynchronous",
+    "experimental",
 ]
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,10 +16,10 @@ if rustup component add clippy; then
 
   cargo_feature opentelemetry-aws "default"
 
-# TODO: Can re-enable once back in the workspace.
-#  cargo_feature opentelemetry-datadog "reqwest-blocking-client"
-#  cargo_feature opentelemetry-datadog "reqwest-client"
-#  cargo_feature opentelemetry-datadog "surf-client"
+  cargo_feature opentelemetry-datadog "reqwest-blocking-client,intern-std"
+  cargo_feature opentelemetry-datadog "reqwest-client,intern-std"
+# TODO: Clippy doesn't seem to like surf client.
+#  cargo_feature opentelemetry-datadog "surf-client,intern-std"
 
   cargo_feature opentelemetry-contrib "default"
   cargo_feature opentelemetry-contrib "api"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,11 +8,8 @@ cargo test --all --all-features "$@" -- --test-threads=1
 cargo test --manifest-path=opentelemetry-aws/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-contrib/Cargo.toml --all-features
 
-#TODO enable below once datadog exporter is building fine
-#cargo test --manifest-path=opentelemetry-datadog/Cargo.toml --all-features 
-
-#TODO enable below once stackdriver exporter is building fine
-#cargo test --manifest-path=opentelemetry-stackdriver/Cargo.toml --all-features
+cargo test --manifest-path=opentelemetry-datadog/Cargo.toml --all-features
+cargo test --manifest-path=opentelemetry-stackdriver/Cargo.toml --all-features
 
 cargo test --manifest-path=opentelemetry-user-events-logs/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-user-events-metrics/Cargo.toml --all-features


### PR DESCRIPTION
- opentelemetry-aws
- opentelemetry-contrib
- opentelemetry-datadog
- opentelemetry-resource-detectors
- opentelemetry-zpages

Re-enable testing for opentelemetry-datadog, except surf-client

Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
