### PR TITLE
Fix typo in service name

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -291,7 +291,7 @@ impl DatadogPipelineBuilder {
         let provider = provider_builder.build();
         let tracer = opentelemetry::trace::TracerProvider::tracer_builder(
             &provider,
-            "opentelemyietry-datadog",
+            "opentelemetry-datadog",
         )
         .with_version(env!("CARGO_PKG_VERSION"))
         .with_schema_url(semcov::SCHEMA_URL)
@@ -311,7 +311,7 @@ impl DatadogPipelineBuilder {
         let provider = provider_builder.build();
         let tracer = opentelemetry::trace::TracerProvider::tracer_builder(
             &provider,
-            "opentelemyietry-datadog",
+            "opentelemetry-datadog",
         )
         .with_version(env!("CARGO_PKG_VERSION"))
         .with_schema_url(semcov::SCHEMA_URL)


### PR DESCRIPTION
Fixes: <img width="521" alt="image" src="https://github.com/open-telemetry/opentelemetry-rust-contrib/assets/35444188/ceb07341-fe7b-4851-a982-f5ede93ba481">

## Changes

Fix a typo in the operation name, now `opentelemetry` is spelled correctly

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
