### PR TITLE
opentelemetry-zpages publish fix - remove unsupported `experimental` category slug

### DIFF
--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -9,7 +9,6 @@ categories = [
     "development-tools::debugging",
     "development-tools::profiling",
     "asynchronous",
-    "experimental",
 ]
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Changes

opentelemetry-zpages publishin fails with error:
```
   Uploading opentelemetry-zpages v0.9.0 (/home/labhas/obs/ot/lalit/rust/opentelemetry-rust-contrib/opentelemetry-zpages)
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): The following category slugs are not currently supported on crates.io: experimental

  See https://crates.io/category_slugs for a list of supported slugs.`
```
Removing unsupported experimental category flag in this PR.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
