### PR TITLE
Upgrade hyper and otel dependencies

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+## v0.12.0
+
+### Changed
+
+- Bump opentelemetry and opentelemetry_sdk version to 0.24
+- Bump hyper to version 1
+
 ## v0.10.0
 
 ### Added
@@ -16,7 +23,6 @@
 
 - allow send all traces to `datadog-agent` with `agent-sampling` feature.
 - allow `datadog-agent` generate metrics from spans for [APM](https://docs.datadoghq.com/tracing/metrics/).
-
 
 ## v0.9.0
 

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-datadog"
-version = "0.11.0"
+version = "0.12.0"
 description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -5,10 +5,7 @@ description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 readme = "README.md"
-categories = [
-    "development-tools::debugging",
-    "development-tools::profiling",
-]
+categories = ["development-tools::debugging", "development-tools::profiling"]
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
@@ -30,17 +27,17 @@ intern-std = []
 [dependencies]
 indexmap = "2.0"
 once_cell = "1.12"
-opentelemetry = { version = "0.23", features = ["trace"] }
-opentelemetry_sdk = { version = "0.23", features = ["trace"] }
-opentelemetry-http = {version = "0.12" }
+opentelemetry = { version = "0.24", features = ["trace"] }
+opentelemetry_sdk = { version = "0.24", features = ["trace"] }
+opentelemetry-http = { version = "0.13" }
 opentelemetry-semantic-conventions = { workspace = true }
 rmp = "0.8"
 url = "2.2"
-reqwest = { version = "0.11", default-features = false, optional = true }
+reqwest = { version = "0.12", default-features = false, optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
 thiserror = "1.0"
 itertools = "0.11"
-http = "0.2"
+http = "1"
 futures-core = "0.3"
 ryu = "1"
 itoa = "1"
@@ -51,10 +48,13 @@ async-trait = "0.1"
 base64 = "0.13"
 bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-isahc = "1.4"
-opentelemetry_sdk = {version = "0.23", features = ["trace", "testing"] }
+opentelemetry_sdk = { version = "0.24", features = ["trace", "testing"] }
 criterion = "0.5"
 rand = "0.8"
+hyper = "1"
+hyper-util = { version = "0.1.6", features = ["client", "full"] }
+hyperlocal = "0.9.1"
+http-body-util = "0.1.2"
 
 [[bench]]
 name = "datadog_exporter"

--- a/opentelemetry-datadog/benches/datadog_exporter.rs
+++ b/opentelemetry-datadog/benches/datadog_exporter.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    time::{Duration, SystemTime},
-};
+use std::time::{Duration, SystemTime};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use http::Request;
@@ -14,7 +11,6 @@ use opentelemetry_http::HttpClient;
 use opentelemetry_sdk::{
     export::trace::{SpanData, SpanExporter},
     trace::{SpanEvents, SpanLinks},
-    Resource,
 };
 use rand::seq::SliceRandom;
 use rand::{rngs::ThreadRng, thread_rng, RngCore};
@@ -154,7 +150,6 @@ fn get_span(trace_id: u128, parent_span_id: u64, span_id: u64, rng: &mut ThreadR
     ];
     let events = SpanEvents::default();
     let links = SpanLinks::default();
-    let resource = Resource::new(vec![KeyValue::new("host.name", "test")]);
     let instrumentation_lib = InstrumentationLibrary::builder("component").build();
 
     SpanData {
@@ -169,7 +164,6 @@ fn get_span(trace_id: u128, parent_span_id: u64, span_id: u64, rng: &mut ThreadR
         events,
         links,
         status: Status::Ok,
-        resource: Cow::Owned(resource),
         instrumentation_lib,
     }
 }

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .with_service_name("agent-sampling-demo")
         .with_api_version(ApiVersion::Version05)
         .with_trace_config(
-            trace::config()
+            trace::Config::default()
                 .with_sampler(AgentBasedSampler)
                 .with_id_generator(RandomIdGenerator::default()),
         )

--- a/opentelemetry-etw-logs/src/logs/exporter.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter.rs
@@ -397,7 +397,7 @@ fn add_attribute_to_event(event: &mut tld::EventBuilder, key: &Key, value: &AnyV
         AnyValue::ListAny(l) => {
             event.add_str8(
                 key.as_str(),
-                &l.as_json_value().to_string(),
+                l.as_json_value().to_string(),
                 tld::OutType::Json,
                 0,
             );
@@ -405,7 +405,7 @@ fn add_attribute_to_event(event: &mut tld::EventBuilder, key: &Key, value: &AnyV
         AnyValue::Map(m) => {
             event.add_str8(
                 key.as_str(),
-                &m.as_json_value().to_string(),
+                m.as_json_value().to_string(),
                 tld::OutType::Json,
                 0,
             );

--- a/opentelemetry-resource-detectors/src/process.rs
+++ b/opentelemetry-resource-detectors/src/process.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 /// This resource detector returns the following information:
 ///
 /// - process command line arguments(`process.command_args`), the full command arguments of this
-/// application.
+///   application.
 /// - OS assigned process id(`process.pid`).
 pub struct ProcessResourceDetector;
 

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -4,6 +4,7 @@
 // When this PR is merged we should be able to remove this attribute:
 // https://github.com/danburkert/prost/pull/291
 #![allow(
+    clippy::doc_lazy_continuation,
     deprecated,
     rustdoc::bare_urls,
     rustdoc::broken_intra_doc_links,

--- a/opentelemetry-stackdriver/src/proto/api.rs
+++ b/opentelemetry-stackdriver/src/proto/api.rs
@@ -189,18 +189,18 @@ pub struct Http {
 ///     message) are classified into three categories:
 ///     - Fields referred by the path template. They are passed via the URL path.
 ///     - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
-///       are passed via the HTTP
+///     are passed via the HTTP
 ///       request body.
 ///     - All other fields are passed via the URL query parameters, and the
 ///       parameter name is the field path in the request message. A repeated
 ///       field can be represented as multiple query parameters under the same
 ///       name.
 ///   2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
-///      query parameter, all fields are passed via URL path and HTTP request
-///      body.
+///   query parameter, all fields
+///      are passed via URL path and HTTP request body.
 ///   3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
-///      request body, all fields are passed via URL path and URL query
-///      parameters.
+///   request body, all
+///      fields are passed via URL path and URL query parameters.
 ///
 /// ### Path template syntax
 ///

--- a/opentelemetry-stackdriver/src/proto/api.rs
+++ b/opentelemetry-stackdriver/src/proto/api.rs
@@ -189,18 +189,18 @@ pub struct Http {
 ///     message) are classified into three categories:
 ///     - Fields referred by the path template. They are passed via the URL path.
 ///     - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
-///     are passed via the HTTP
+///       are passed via the HTTP
 ///       request body.
 ///     - All other fields are passed via the URL query parameters, and the
 ///       parameter name is the field path in the request message. A repeated
 ///       field can be represented as multiple query parameters under the same
 ///       name.
 ///   2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
-///   query parameter, all fields
-///      are passed via URL path and HTTP request body.
+///      query parameter, all fields are passed via URL path and HTTP request
+///      body.
 ///   3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
-///   request body, all
-///      fields are passed via URL path and URL query parameters.
+///      request body, all fields are passed via URL path and URL query
+///      parameters.
 ///
 /// ### Path template syntax
 ///

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -119,7 +119,7 @@ impl UserEventsExporter {
                 eb.add_value(field_name, f, FieldFormat::Float, 0);
             }
             AnyValue::String(s) => {
-                eb.add_str(field_name, &s.to_string(), FieldFormat::Default, 0);
+                eb.add_str(field_name, s.to_string(), FieldFormat::Default, 0);
             }
             _ => (),
         }


### PR DESCRIPTION

## Changes
Upgrade otel and hyper dependencies, change HttpClient example to hyper over unix socket.

I removed writing the resource for every span, as the field was [removed from `SpanData`](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md?plain=1#L58).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
