### PR TITLE
[REVIEW TO PROCESS] Add Counted Macro

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -27,6 +27,7 @@ jaeger_json_exporter = ["opentelemetry_sdk", "serde_json", "futures-core", "futu
 rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
+macros = ["opentelemetry-macros"]
 
 [dependencies]
 async-std = { version = "1.10", optional = true }
@@ -40,6 +41,10 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
+lazy_static = "1.5.0"
+opentelemetry-macros = {path = "../opentelemetry-macros", optional = true}
+
+
 
 [dev-dependencies]
 base64 = "0.13"

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -41,7 +41,6 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
-lazy_static = "1.5.0"
 opentelemetry-macros = {path = "../opentelemetry-macros", optional = true}
 
 

--- a/opentelemetry-contrib/src/lib.rs
+++ b/opentelemetry-contrib/src/lib.rs
@@ -30,4 +30,11 @@
 )]
 #![cfg_attr(test, deny(warnings))]
 
+#[cfg(feature = "macros")]
+pub extern crate lazy_static;
+#[cfg(feature = "macros")]
+pub extern crate opentelemetry;
+#[cfg(feature = "macros")]
+pub extern crate opentelemetry_macros;
+
 pub mod trace;

--- a/opentelemetry-contrib/src/lib.rs
+++ b/opentelemetry-contrib/src/lib.rs
@@ -30,8 +30,7 @@
 )]
 #![cfg_attr(test, deny(warnings))]
 
-#[cfg(feature = "macros")]
-pub extern crate lazy_static;
+
 #[cfg(feature = "macros")]
 pub extern crate opentelemetry;
 #[cfg(feature = "macros")]

--- a/opentelemetry-contrib/src/lib.rs
+++ b/opentelemetry-contrib/src/lib.rs
@@ -30,7 +30,6 @@
 )]
 #![cfg_attr(test, deny(warnings))]
 
-
 #[cfg(feature = "macros")]
 pub extern crate opentelemetry;
 #[cfg(feature = "macros")]

--- a/opentelemetry-macros/CODEOWNERS
+++ b/opentelemetry-macros/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+*  @open-telemetry/rust-approvers

--- a/opentelemetry-macros/Cargo.toml
+++ b/opentelemetry-macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "opentelemetry-macros"
+version = "0.3.0"
+edition = "2021"
+description = "A collection of community supported macros for OpenTelemetry"
+homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-macros"
+repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-macros"
+readme = "README.md"
+keywords = ["opentelemetry", "resource", "detector"]
+license = "Apache-2.0"
+rust-version = "1.65"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "2.0.72", features = ["full"]}
+
+[lib]
+proc-macro = true
+
+[[test]]
+name = "unitary_tests"
+path = "tests/unitary/mod.rs"
+
+
+

--- a/opentelemetry-macros/LICENSE
+++ b/opentelemetry-macros/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/opentelemetry-macros/src/lib.rs
+++ b/opentelemetry-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 
-use syn::{ItemFn, parse_macro_input};
+use syn::{parse_macro_input, ItemFn};
 
 use crate::metrics::counted::CountedBuilder;
 
@@ -16,11 +16,7 @@ pub fn counted(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     match builder.build() {
-        Ok(value) => {
-            value
-        }
-        Err(err) => {
-            TokenStream::from(err.to_compile_error())
-        }
+        Ok(value) => value,
+        Err(err) => TokenStream::from(err.to_compile_error()),
     }
 }

--- a/opentelemetry-macros/src/lib.rs
+++ b/opentelemetry-macros/src/lib.rs
@@ -1,0 +1,26 @@
+use proc_macro::TokenStream;
+
+use syn::{ItemFn, parse_macro_input};
+
+use crate::metrics::counted::CountedBuilder;
+
+mod metrics;
+
+#[proc_macro_attribute]
+pub fn counted(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut builder = match CountedBuilder::try_from(attr, parse_macro_input!(item as ItemFn)) {
+        Ok(value) => value,
+        Err(err) => {
+            return err;
+        }
+    };
+
+    match builder.build() {
+        Ok(value) => {
+            value
+        }
+        Err(err) => {
+            TokenStream::from(err.to_compile_error())
+        }
+    }
+}

--- a/opentelemetry-macros/src/metrics.rs
+++ b/opentelemetry-macros/src/metrics.rs
@@ -1,0 +1,1 @@
+pub mod counted;

--- a/opentelemetry-macros/src/metrics/counted.rs
+++ b/opentelemetry-macros/src/metrics/counted.rs
@@ -1,0 +1,169 @@
+use proc_macro::TokenStream;
+use std::sync::Mutex;
+
+use syn::{Block, ItemFn, LitStr};
+use syn::__private::ToTokens;
+use syn::meta::ParseNestedMeta;
+use syn::parse::Parser;
+
+pub const EXPORTER_CRATE: &'static str = "opentelemetry_contrib";
+
+pub struct CountedBuilder {
+    item_fn: Option<ItemFn>,
+    attrs: CountedAttributes,
+}
+
+impl CountedBuilder {
+    pub fn try_from(attr: TokenStream, item_fn: ItemFn) -> Result<CountedBuilder, TokenStream> {
+        let attrs = CountedAttributes::try_from(attr, &item_fn)?;
+        Ok(Self {
+            item_fn: Some(item_fn),
+            attrs,
+        })
+    }
+
+    fn check_metric_name_availability(&self) {
+        const DETECTED_METRIC_NAME_DUPLICATION: &'static str = "detected metric name duplication!";
+        const LOCK_ERROR_METRIC_NAME_CHECKER: &'static str = "unexpected error encountered trying to lock shared data structure for metric name availability checker!";
+
+        static METRIC_NAMES: std::sync::LazyLock<Mutex<Vec<String>>> =
+            std::sync::LazyLock::new(|| Mutex::new(Vec::new()));
+
+        let attrs = &self.attrs;
+        match METRIC_NAMES.lock() {
+            Ok(mut names) => {
+                if names.contains(&attrs.name.as_str().to_string()) {
+                    panic!("{}", DETECTED_METRIC_NAME_DUPLICATION);
+                }
+                names.push(attrs.name.clone())
+            }
+            Err(_) => {
+                panic!("{}", LOCK_ERROR_METRIC_NAME_CHECKER);
+            }
+        }
+    }
+
+    fn build_code_block(&self) -> Result<Block, syn::Error> {
+        let label_size = &self.attrs.labels_size;
+        let labels = &self.attrs.labels;
+        let meter_provider = &self.attrs.meter_provider;
+        let name = &self.attrs.name;
+        let description = &self.attrs.description;
+
+        let result = syn::parse_str::<Block>(&format!(
+            r#"
+            {{
+             {EXPORTER_CRATE}::lazy_static::lazy_static! {{
+             static ref LABELS: [{EXPORTER_CRATE}::opentelemetry::KeyValue; {label_size}] = {{
+                [{labels}]
+                }};
+            static ref COUNTER: {EXPORTER_CRATE}::opentelemetry::metrics::Counter<u64> = {{
+                let meter = {EXPORTER_CRATE}::opentelemetry::global::meter("{meter_provider}");
+                meter.u64_counter("{name}").with_description("{description}").init()
+                }};
+            }}
+            COUNTER.add(1, &*LABELS);
+            }}
+    "#
+        ))?;
+
+        Ok(result)
+    }
+
+    pub fn build(&mut self) -> Result<TokenStream, syn::Error> {
+        self.check_metric_name_availability();
+        let mut code_block = self.build_code_block()?;
+
+        let mut item_fn = self.item_fn.take().unwrap();
+        code_block.stmts.extend_from_slice(&*item_fn.block.stmts);
+        item_fn.block.stmts = code_block.stmts;
+
+        Ok(TokenStream::from(item_fn.into_token_stream()))
+    }
+}
+
+pub struct CountedAttributes {
+    name: String,
+    description: String,
+    meter_provider: String,
+    labels: String,
+    labels_size: u8,
+}
+
+impl CountedAttributes {
+    pub fn try_from(attr: TokenStream, item_fn: &ItemFn) -> Result<Self, TokenStream> {
+        const DEFAULT_METER_PROVIDER_NAME: &'static str = "default_meter_provider";
+        const DEFAULT_DESCRIPTION: &'static str = "Empty description!";
+        const METER_PROVIDER_NAME_ATTR_NAME: &'static str = "meter_provider";
+        const NAME_ATTR_NAME: &'static str = "name";
+        const DESCRIPTION_ATTR_NAME: &'static str = "description";
+        const LABELS_ATTR_NAME: &'static str = "labels";
+        const ATTR_ERROR_MESSAGE: &'static str = "unsupported attribute for counted macro!";
+
+        let mut name = format!("fn_{}_count", item_fn.sig.ident.to_string());
+        let mut meter_provider = DEFAULT_METER_PROVIDER_NAME.to_string();
+        let mut description = DEFAULT_DESCRIPTION.to_string();
+        let mut labels = "".to_string();
+        let mut labels_size = 0;
+
+        let parser = syn::meta::parser(|meta| {
+            if meta.path.is_ident(NAME_ATTR_NAME) {
+                name = meta.value()?.parse::<LitStr>()?.value();
+            } else if meta.path.is_ident(METER_PROVIDER_NAME_ATTR_NAME) {
+                meter_provider = meta.value()?.parse::<LitStr>()?.value();
+            } else if meta.path.is_ident(DESCRIPTION_ATTR_NAME) {
+                description = meta.value()?.parse::<LitStr>()?.value();
+            } else if meta.path.is_ident(LABELS_ATTR_NAME) {
+                let (labels_res, labels_size_res) = Self::process_labels_attr(&meta)?;
+                labels = labels_res;
+                labels_size = labels_size_res;
+            } else {
+                return Err(meta.error(ATTR_ERROR_MESSAGE));
+            }
+            Ok(())
+        });
+
+        if let Err(err) = parser.parse(attr) {
+            return Err(TokenStream::from(err.to_compile_error()));
+        }
+
+        Ok(Self {
+            name,
+            description,
+            meter_provider,
+            labels,
+            labels_size,
+        })
+    }
+
+    fn process_labels_attr(meta: &ParseNestedMeta) -> Result<(String, u8), syn::Error> {
+        const LABELS_LENGTH_ERROR_MESSAGE: &'static str =
+            "invalid arguments provided in labels attribute! (must be provided list of key-value)";
+
+        let lebels_as_str = meta.value()?.parse::<LitStr>()?.value();
+        let labels_as_array: Vec<String> = lebels_as_str
+            .split(",")
+            .into_iter()
+            .map(|v| v.trim().to_string())
+            .collect();
+
+        if labels_as_array.len() % 2 != 0 {
+            panic!("{}", LABELS_LENGTH_ERROR_MESSAGE);
+        }
+
+        let labels_size = labels_as_array.len() as u8 / 2;
+        let mut labels = "".to_string();
+        for label_chunk in labels_as_array.chunks(2) {
+            if let [key, value] = label_chunk {
+                if !labels.is_empty() {
+                    labels.push_str(", ");
+                }
+                labels.push_str(&format!(
+                    r#"{EXPORTER_CRATE}::opentelemetry::KeyValue::new("{key}", "{value}")"#
+                ));
+            }
+        }
+
+        Ok((labels, labels_size))
+    }
+}

--- a/opentelemetry-macros/tests/unitary/metrics/counted.rs
+++ b/opentelemetry-macros/tests/unitary/metrics/counted.rs
@@ -1,0 +1,2 @@
+#[test]
+fn should_returns_error_token_stream() {}

--- a/opentelemetry-macros/tests/unitary/metrics/mod.rs
+++ b/opentelemetry-macros/tests/unitary/metrics/mod.rs
@@ -1,0 +1,1 @@
+pub mod counted;

--- a/opentelemetry-macros/tests/unitary/mod.rs
+++ b/opentelemetry-macros/tests/unitary/mod.rs
@@ -1,0 +1,1 @@
+pub mod metrics;


### PR DESCRIPTION
Moved and refined from pull request: https://github.com/open-telemetry/opentelemetry-rust/pull/1972

## Changes
I am developing a macros crate designed to streamline the generation of observability-related code across various types of metrics and logging functionalities. The initial focus of this crate is on implementing a basic counter, but our goal is to support a wide range of observability features

The crate leverages Rust's powerful attribute macros to simplify the configuration and integration process. By using these attribute macros, developers can avoid repetitive boilerplate code and configure observability tools with maximum flexibility. This approach ensures that the observability code remains concise, readable, and maintainable, allowing developers to focus more on their core application logic.

Key benefits of this macros crate include:

    Reduction of Boilerplate Code: By abstracting common patterns and setups into macros, we significantly reduce the amount of boilerplate code developers need to write and maintain.

    Consistency: The macros enforce consistent implementation of observability features across different parts of the codebase, reducing the likelihood of errors and inconsistencies.

    Flexibility: The attribute macros are designed to be highly configurable, allowing developers to customize the generated code to fit their specific needs without sacrificing simplicity.

Current output result of macro:

```
    #[counted(
        name = "redis_hits",
        meter_provider = "meter_provider",
        description = "redis cache hits",
        labels = "key, value"
    )]
    pub fn test() {
    }
```

```          
static LABELS: std::sync::OnceLock<[opentelemetry_contrib::opentelemetry::KeyValue; 1], > = std::sync::OnceLock::new();
        let labels_value = LABELS
            .get_or_init(|| {
                [opentelemetry_contrib::opentelemetry::KeyValue::new("key", "value")]
            });

static COUNTER: std::sync::OnceLock<opentelemetry_contrib::opentelemetry::metrics::Counter<u64>,> = std::sync::OnceLock::new();
         let counter_value = COUNTER
            .get_or_init(|| {
                let meter = opentelemetry_contrib::opentelemetry::global::meter(
                    "meter_provider",
                );
                meter
                    .u64_counter("redis_hits")
                    .with_description("redis cache hits")
                    .init()
            });
counter_value.add(1, labels_value);

```  

Design:
![counted_macro_design](https://github.com/user-attachments/assets/f3cdf3ef-ebff-4a56-a805-1d15a794a9ad)


Hi @cijothomas ,
Regarding the performance issue in the generation of KeyValue that you mentioned, the continuous creation is currently mitigated by using static variables. Another way to mitigate it could be an enabled attribute that prevents the generation of this code, but it would not be at runtime.

Any improvements you see that could be introduced or features to inaugurate this crate, which would contain the other possible macros, let me know and as soon as everything is ready, I will start with the documentation, testing, and other phases.

UPDATE:
Using enabled attribute to false:
```  
    #[counted(
        name = "redis_hits",
        meter_provider = "meter_provider",
        description = "redis cache hits",
        labels = "key, value",
        enabled = false
    )]
    pub fn test() {

    }

```  
Output:
```  
 pub fn test() {}
```  


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
