### PR TITLE
Add cloud_run_job to MonitoredResource

### DIFF
--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Added
+
+- Added support for `MonitoredResource::CloudRunJob` [#100](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/100)
+
 ## v0.21.0
 
 ### Changed

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -546,6 +546,24 @@ impl From<LogContext> for InternalLogContext {
     fn from(cx: LogContext) -> Self {
         let mut labels = HashMap::default();
         let resource = match cx.resource {
+            MonitoredResource::CloudRunJob {
+                project_id,
+                job_name,
+                location,
+            } => {
+                labels.insert("project_id".to_string(), project_id);
+                if let Some(job_name) = job_name {
+                    labels.insert("job_name".to_string(), job_name);
+                }
+                if let Some(location) = location {
+                    labels.insert("location".to_string(), location);
+                }
+
+                proto::api::MonitoredResource {
+                    r#type: "cloud_run_job".to_owned(),
+                    labels,
+                }
+            }
             MonitoredResource::CloudRunRevision {
                 project_id,
                 service_name,
@@ -657,6 +675,11 @@ pub enum MonitoredResource {
         namespace: Option<String>,
         job: Option<String>,
         task_id: Option<String>,
+    },
+    CloudRunJob {
+        project_id: String,
+        job_name: Option<String>,
+        location: Option<String>,
     },
     CloudRunRevision {
         project_id: String,


### PR DESCRIPTION
Fixes #100 

## Changes

Adds `MonitoredResource::CloudRunJob` which adds the appropriate labels for the `cloud_run_job` monitored resource type.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
