### PR TITLE
Refresh generated code in opentelemetry-stackdriver

### DIFF
--- a/opentelemetry-stackdriver/src/proto/devtools/cloudtrace/v2.rs
+++ b/opentelemetry-stackdriver/src/proto/devtools/cloudtrace/v2.rs
@@ -518,8 +518,8 @@ pub mod trace_service_client {
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
@@ -543,7 +543,7 @@ pub mod trace_service_client {
                 >,
             >,
             <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             TraceServiceClient::new(InterceptedService::new(inner, interceptor))
         }

--- a/opentelemetry-stackdriver/src/proto/logging/v2.rs
+++ b/opentelemetry-stackdriver/src/proto/logging/v2.rs
@@ -654,8 +654,8 @@ pub mod logging_service_v2_client {
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
@@ -679,7 +679,7 @@ pub mod logging_service_v2_client {
                 >,
             >,
             <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             LoggingServiceV2Client::new(InterceptedService::new(inner, interceptor))
         }


### PR DESCRIPTION
`Send` and `Sync` in code generated by tonic 0.12.2 is fully qualified as `std::marker::Send` and `std::marker::Sync`.

## Changes

Refreshes generated code in opentelemetry-stackdriver to fix "generated_code_is_fresh" test.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
