### PR TITLE
chore: update Datadog to otel 0.26

### DIFF
--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -27,9 +27,9 @@ intern-std = []
 [dependencies]
 indexmap = "2.0"
 once_cell = "1.12"
-opentelemetry = { version = "0.24", features = ["trace"] }
-opentelemetry_sdk = { version = "0.24", features = ["trace"] }
-opentelemetry-http = { version = "0.13" }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["trace"] }
+opentelemetry-http = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 rmp = "0.8"
 url = "2.2"
@@ -48,7 +48,7 @@ async-trait = "0.1"
 base64 = "0.13"
 bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-opentelemetry_sdk = { version = "0.24", features = ["trace", "testing"] }
+opentelemetry_sdk = { workspace = true, features = ["trace", "testing"] }
 criterion = "0.5"
 rand = "0.8"
 hyper = "1"

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -1,7 +1,7 @@
 use opentelemetry::{
     global::{self, shutdown_tracer_provider},
     trace::{SamplingResult, Span, TraceContextExt, Tracer},
-    Key,
+    Key, KeyValue, Value,
 };
 use opentelemetry_datadog::{new_pipeline, ApiVersion, DatadogTraceStateBuilder};
 use opentelemetry_sdk::trace::{self, RandomIdGenerator, ShouldSample};
@@ -11,8 +11,14 @@ use std::time::Duration;
 fn bar() {
     let tracer = global::tracer("component-bar");
     let mut span = tracer.start("bar");
-    span.set_attribute(Key::new("span.type").string("sql"));
-    span.set_attribute(Key::new("sql.query").string("SELECT * FROM table"));
+    span.set_attribute(KeyValue::new(
+        Key::new("span.type"),
+        Value::String("sql".into()),
+    ));
+    span.set_attribute(KeyValue::new(
+        Key::new("sql.query"),
+        Value::String("SELECT * FROM table".into()),
+    ));
     thread::sleep(Duration::from_millis(6));
     span.end()
 }
@@ -62,10 +68,19 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
     tracer.in_span("foo", |cx| {
         let span = cx.span();
-        span.set_attribute(Key::new("span.type").string("web"));
-        span.set_attribute(Key::new("http.url").string("http://localhost:8080/foo"));
-        span.set_attribute(Key::new("http.method").string("GET"));
-        span.set_attribute(Key::new("http.status_code").i64(200));
+        span.set_attribute(KeyValue::new(
+            Key::new("span.type"),
+            Value::String("web".into()),
+        ));
+        span.set_attribute(KeyValue::new(
+            Key::new("http.url"),
+            Value::String("http://localhost:8080/foo".into()),
+        ));
+        span.set_attribute(KeyValue::new(
+            Key::new("http.method"),
+            Value::String("GET".into()),
+        ));
+        span.set_attribute(KeyValue::new(Key::new("http.status_code"), Value::I64(200)));
 
         thread::sleep(Duration::from_millis(6));
         bar();

--- a/opentelemetry-datadog/examples/datadog.rs
+++ b/opentelemetry-datadog/examples/datadog.rs
@@ -1,7 +1,7 @@
 use opentelemetry::{
     global::{self, shutdown_tracer_provider},
     trace::{Span, TraceContextExt, Tracer},
-    Key,
+    Key, KeyValue, Value,
 };
 use opentelemetry_datadog::{new_pipeline, ApiVersion};
 use std::thread;
@@ -10,8 +10,14 @@ use std::time::Duration;
 fn bar() {
     let tracer = global::tracer("component-bar");
     let mut span = tracer.start("bar");
-    span.set_attribute(Key::new("span.type").string("sql"));
-    span.set_attribute(Key::new("sql.query").string("SELECT * FROM table"));
+    span.set_attribute(KeyValue::new(
+        Key::new("span.type"),
+        Value::String("sql".into()),
+    ));
+    span.set_attribute(KeyValue::new(
+        Key::new("sql.query"),
+        Value::String("SELECT * FROM table".into()),
+    ));
     thread::sleep(Duration::from_millis(6));
     span.end()
 }
@@ -24,10 +30,19 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
     tracer.in_span("foo", |cx| {
         let span = cx.span();
-        span.set_attribute(Key::new("span.type").string("web"));
-        span.set_attribute(Key::new("http.url").string("http://localhost:8080/foo"));
-        span.set_attribute(Key::new("http.method").string("GET"));
-        span.set_attribute(Key::new("http.status_code").i64(200));
+        span.set_attribute(KeyValue::new(
+            Key::new("span.type"),
+            Value::String("web".into()),
+        ));
+        span.set_attribute(KeyValue::new(
+            Key::new("http.url"),
+            Value::String("http://localhost:8080/foo".into()),
+        ));
+        span.set_attribute(KeyValue::new(
+            Key::new("http.method"),
+            Value::String("GET".into()),
+        ));
+        span.set_attribute(KeyValue::new(Key::new("http.status_code"), Value::I64(200)));
 
         thread::sleep(Duration::from_millis(6));
         bar();


### PR DESCRIPTION
Fixes #118

## Changes

- updated Datadog to use OTel 0.26
- changed version management of OTel dependencies to workspace

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
