### PR TITLE
prepare Datadog 0.14 release

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## vNext
 
+## v0.14.0
+
+### Changed
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.26
+- Bump opentelemetry-http and opentelemetry-semantic-conventions versions to 0.26
+- Remove unused itertools dependency
+
 ## v0.13.0
 
 ### Changed

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-datadog"
-version = "0.13.0"
+version = "0.14.0"
 description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"


### PR DESCRIPTION
## Changes

- prepare Datadog 0.14 release

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
