### PR TITLE
Add Multipass Setup for user_events metrics testing on Ubuntu 24.04 VM

### DIFF
--- a/opentelemetry-user-events-metrics/local-setup/README.md
+++ b/opentelemetry-user-events-metrics/local-setup/README.md
@@ -5,7 +5,7 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
 ## Prerequisites
 
 1. **Virtualization Support**: Ensure that your machine supports virtualization. Virtualization options vary by operating system:
-   - **Windows**: Requires Hyper-V, available on Windows 10 and above.
+   - **Windows**: Requires Hyper-V, available on Windows 10 Pro or Enterprise and above.
    - **macOS**: Requires Apple Silicon (M1, M2) or Intel hardware with virtualization enabled in BIOS.
    - **Linux**: Ensure KVM or VirtualBox is available and enabled in your distribution. Run `lsmod | grep kvm` to verify if KVM is installed.
 

--- a/opentelemetry-user-events-metrics/local-setup/README.md
+++ b/opentelemetry-user-events-metrics/local-setup/README.md
@@ -25,14 +25,14 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
     Launched: my-test-vm
     ```
 
-    This will some time to create and configure the VM. Validate that the VM is created and running:
+    This will take some time to create and configure the VM. Validate that the VM is created and running:
     ```bash
     PS> multipass list
     Name                    State             IPv4             Image
     my-test-vm              Running           172.27.162.116   Ubuntu 24.04 LTS    
     ```
 
-2. **Login into the VM:** You should get the ubuntu bash shell. 
+2. **Login into the VM:** You should get the ubuntu bash shell after login:
     ```bash
     PS> multipass shell my-test-vm
     ..
@@ -45,12 +45,12 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
     CONFIG_USER_EVENTS=y
     ```
 
-3. **Run perf tool:** Start running the perf tool to capture the user-events:
+3. **Run perf tool:** Invoke the perf tool to capture the user-events. Keep it running:
     ```bash
     ubuntu@my-test-vm:~$ sudo perf  record -e user_events:otlp_metrics
     ```
 
-3. **Run user_events example** Open another shell, and build and run the opentelemetry-user-events-metrics exporter example:
+4. **Run user_events example** Open another shell, and build and run the opentelemetry-user-events-metrics exporter example:
     ```bash
     PS> multipass shell my-test-vm
     ubuntu@my-test-vm:~$ cd opentelemetry-rust-contrib/opentelemetry-user-events-metrics/ && cargo build --example basic-metrics --all-features
@@ -58,27 +58,27 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
     Tracepoint registered successfully.
     ```
 
-4. Terminate perf capture (Ctrl+C). It should show something like
+5. Terminate perf capture (Ctrl+C) after some time. It should show something like
     ```bash
     [ perf record: Woken up 1 times to write data ]
     [ perf record: Captured and wrote 0.175 MB perf.data (5 samples) ]
     ```
-5. Convert perf data to json:
+6. Convert perf data to json:
     ```bash
     ubuntu@my-test-vm:~$ sudo chmod uog+r ./perf.data
     ubuntu@my-test-vm:~$ perf-decode ./perf.data > perf.json
     ```
-6. Ensure that `perf.json` contains something like:
+7. Ensure that `perf.json` contains something like:
     ```bash
     "./perf.data": [ { "n": "user_events:otlp_metrics", "protocol": 0, "version": "v0.19.00", "buffer": [ ... ], "meta": { "time": 816.790831600, "cpu": 0, "pid": 4957, "tid": 4958 } } ]
     ```
-7. Convert perf json to OpenTelemetry format:
+8. Convert perf json to OpenTelemetry format:
     ```bash
     ubuntu@my-test-vm:~$ source userevents-env/bin/activate
     (userevents-env) ubuntu@my-test-vm:~$ python3 decrypt_python.py perf.json
     ```
 
-6. The output will look something like this:
+9. The output will look something like this:
 <details>
 <summary>Click to expand output</summary>
 
@@ -253,4 +253,15 @@ resource_metrics {
     }
   }
 }
+```
+
+10. **Cleanup the VM:** Once tests are done, if required the VM can be stopped and/or deleted with below steps:
+```bash
+PS> multipass stop my-test-vm
+```
+
+And to delete:
+```bash
+PS> multipass delete my-test-vm
+PS> multipass purge
 ```

--- a/opentelemetry-user-events-metrics/local-setup/README.md
+++ b/opentelemetry-user-events-metrics/local-setup/README.md
@@ -79,8 +79,6 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
     ```
 
 9. The output will look something like this:
-<details>
-<summary>Click to expand output</summary>
 
 ```plaintext
 resource_metrics {
@@ -148,109 +146,7 @@ resource_metrics {
         is_monotonic: true
       }
     }
-    metrics {
-      name: "up_down_counter_i64_test"
-      sum {
-        data_points {
-          start_time_unix_nano: 1731569594054471309
-          time_unix_nano: 1731569834056844774
-          as_int: 2400
-          attributes {
-            key: "mykey1"
-            value {
-              string_value: "myvalue1"
-            }
-          }
-          attributes {
-            key: "mykey2"
-            value {
-              string_value: "myvalue2"
-            }
-          }
-        }
-        aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
-      }
-    }
-    metrics {
-      name: "up_down_counter_f64_test"
-      sum {
-        data_points {
-          start_time_unix_nano: 1731569594054479809
-          time_unix_nano: 1731569834056854074
-          as_double: 2400
-          attributes {
-            key: "mykey1"
-            value {
-              string_value: "myvalue1"
-            }
-          }
-          attributes {
-            key: "mykey2"
-            value {
-              string_value: "myvalue2"
-            }
-          }
-        }
-        aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
-      }
-    }
-    metrics {
-      name: "histogram_f64_test"
-      description: "test_description"
-      histogram {
-        data_points {
-          start_time_unix_nano: 1731569774055377418
-          time_unix_nano: 1731569834056858674
-          count: 60
-          sum: 630
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 60
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          bucket_counts: 0
-          explicit_bounds: 0
-          explicit_bounds: 5
-          explicit_bounds: 10
-          explicit_bounds: 25
-          explicit_bounds: 50
-          explicit_bounds: 75
-          explicit_bounds: 100
-          explicit_bounds: 250
-          explicit_bounds: 500
-          explicit_bounds: 750
-          explicit_bounds: 1000
-          explicit_bounds: 2500
-          explicit_bounds: 5000
-          explicit_bounds: 7500
-          explicit_bounds: 10000
-          attributes {
-            key: "mykey1"
-            value {
-              string_value: "myvalue1"
-            }
-          }
-          attributes {
-            key: "mykey2"
-            value {
-              string_value: "myvalue2"
-            }
-          }
-          min: 10.5
-          max: 10.5
-        }
-        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
-      }
-    }
+    ...
   }
 }
 ```

--- a/opentelemetry-user-events-metrics/local-setup/README.md
+++ b/opentelemetry-user-events-metrics/local-setup/README.md
@@ -1,0 +1,261 @@
+# Local Setup for testing with user_events using multipass:
+
+This directory contains `cloud-init.yaml`, a configuration file to set up an Ubuntu 24.04 virtual machine environment with essential tools required for running and validating user_events example contained in this repository. The setup includes enabling `user_events` and installing the `perf` tool, along with utilities for decoding `user_events` data and processing `proto` data.
+
+## Prerequisites
+
+1. **Virtualization Support**: Ensure that your machine supports virtualization. Virtualization options vary by operating system:
+   - **Windows**: Requires Hyper-V, available on Windows 10 and above.
+   - **macOS**: Requires Apple Silicon (M1, M2) or Intel hardware with virtualization enabled in BIOS.
+   - **Linux**: Ensure KVM or VirtualBox is available and enabled in your distribution. Run `lsmod | grep kvm` to verify if KVM is installed.
+
+2. **Install Multipass**: Multipass is a tool for managing Ubuntu instances as lightweight virtual machines. Installation varies by OS, follow the instructions available in [official site](https://multipass.run/install).
+
+   After installation, verify by running:
+   ```bash
+   multipass --version
+   ```
+
+## Usage
+
+1. **Launch a VM with cloud-init.yaml:** 
+    Use the following command to start a VM with the specified configuration:
+    ```bash
+    PS> multipass launch --name my-test-vm --cloud-init cloud-init.yaml
+    Launched: my-test-vm
+    ```
+
+    You can also specify the memory and disk size while creating the VM:
+    ```bash
+    PS> multipass launch --name my-test-vm -m 10G -d 40G --cloud-init cloud-init.yaml
+    ```
+
+    This will same time to create and configure the VM. Validate that the VM is created and running:
+    ```bash
+    PS> multipass list
+    Name                    State             IPv4             Image
+    my-test-vm              Running           172.27.162.116   Ubuntu 24.04 LTS    
+    ```
+
+2. **Login into the VM:** You should get the ubuntu bash shell. 
+    ```bash
+    PS> multipass shell my-test-vm
+    ..
+    ubuntu@my-test-vm:~$
+    ```
+
+    Verify that the user_events in available and enabled:
+    ```bash
+    ubuntu@my-test-vm:~$ grep USER_EVENTS /boot/config-6.8.0-48-generic
+    CONFIG_USER_EVENTS=y
+    ```
+
+3. **Run perf tool:** Start running the perf tool to capture the user-events:
+    ```bash
+    ubuntu@my-test-vm:~$ sudo perf  record -e user_events:otlp_metrics
+    ```
+
+3. **Run user_events example** Open another shell, and build and run the opentelemetry-user-events-metrics exporter example:
+    ```bash
+    PS> multipass shell my-test-vm
+    ubuntu@my-test-vm:~$ cd opentelemetry-rust-contrib/opentelemetry-user-events-metrics/ && cargo build --example basic-metrics --all-features
+    ubuntu@my-test-vm:~$ $ sudo ~/opentelemetry-rust-contrib/target/debug/examples/basic-metrics
+    Tracepoint registered successfully.
+    ```
+
+4. Terminate perf capture (Ctrl+C). It should show something like
+    ```bash
+    [ perf record: Woken up 1 times to write data ]
+    [ perf record: Captured and wrote 0.175 MB perf.data (5 samples) ]
+    ```
+5. Convert perf data to json:
+    ```bash
+    ubuntu@my-test-vm:~$ sudo chmod uog+r ./perf.data
+    ubuntu@my-test-vm:~$ perf-decode ./perf.data > perf.json
+    ```
+6. Ensure that `perf.json` contains something like:
+    ```bash
+    "./perf.data": [ { "n": "user_events:otlp_metrics", "protocol": 0, "version": "v0.19.00", "buffer": [ ... ], "meta": { "time": 816.790831600, "cpu": 0, "pid": 4957, "tid": 4958 } } ]
+    ```
+7. Convert perf json to OpenTelemetry format:
+    ```bash
+    ubuntu@my-test-vm:~$ source userevents-env/bin/activate
+    (userevents-env) ubuntu@my-test-vm:~$ python3 decrypt_python.py perf.json
+    ```
+
+6. The output will look something like this:
+<details>
+<summary>Click to expand output</summary>
+
+```plaintext
+resource_metrics {
+  resource {
+    attributes {
+      key: "service.name"
+      value {
+        string_value: "metric-demo"
+      }
+    }
+  }
+  scope_metrics {
+    scope {
+      name: "user-event-test"
+    }
+    metrics {
+      name: "counter_f64_test"
+      description: "test_decription"
+      unit: "test_unit"
+      sum {
+        data_points {
+          start_time_unix_nano: 1731569774055345718
+          time_unix_nano: 1731569834056820774
+          as_double: 60
+          attributes {
+            key: "mykey1"
+            value {
+              string_value: "myvalue1"
+            }
+          }
+          attributes {
+            key: "mykey2"
+            value {
+              string_value: "myvalue2"
+            }
+          }
+        }
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        is_monotonic: true
+      }
+    }
+    metrics {
+      name: "counter_u64_test"
+      description: "test_decription"
+      unit: "test_unit"
+      sum {
+        data_points {
+          start_time_unix_nano: 1731569774055358318
+          time_unix_nano: 1731569834056835474
+          as_int: 60
+          attributes {
+            key: "mykey1"
+            value {
+              string_value: "myvalue1"
+            }
+          }
+          attributes {
+            key: "mykey2"
+            value {
+              string_value: "myvalue2"
+            }
+          }
+        }
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+        is_monotonic: true
+      }
+    }
+    metrics {
+      name: "up_down_counter_i64_test"
+      sum {
+        data_points {
+          start_time_unix_nano: 1731569594054471309
+          time_unix_nano: 1731569834056844774
+          as_int: 2400
+          attributes {
+            key: "mykey1"
+            value {
+              string_value: "myvalue1"
+            }
+          }
+          attributes {
+            key: "mykey2"
+            value {
+              string_value: "myvalue2"
+            }
+          }
+        }
+        aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+      }
+    }
+    metrics {
+      name: "up_down_counter_f64_test"
+      sum {
+        data_points {
+          start_time_unix_nano: 1731569594054479809
+          time_unix_nano: 1731569834056854074
+          as_double: 2400
+          attributes {
+            key: "mykey1"
+            value {
+              string_value: "myvalue1"
+            }
+          }
+          attributes {
+            key: "mykey2"
+            value {
+              string_value: "myvalue2"
+            }
+          }
+        }
+        aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+      }
+    }
+    metrics {
+      name: "histogram_f64_test"
+      description: "test_description"
+      histogram {
+        data_points {
+          start_time_unix_nano: 1731569774055377418
+          time_unix_nano: 1731569834056858674
+          count: 60
+          sum: 630
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 60
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          bucket_counts: 0
+          explicit_bounds: 0
+          explicit_bounds: 5
+          explicit_bounds: 10
+          explicit_bounds: 25
+          explicit_bounds: 50
+          explicit_bounds: 75
+          explicit_bounds: 100
+          explicit_bounds: 250
+          explicit_bounds: 500
+          explicit_bounds: 750
+          explicit_bounds: 1000
+          explicit_bounds: 2500
+          explicit_bounds: 5000
+          explicit_bounds: 7500
+          explicit_bounds: 10000
+          attributes {
+            key: "mykey1"
+            value {
+              string_value: "myvalue1"
+            }
+          }
+          attributes {
+            key: "mykey2"
+            value {
+              string_value: "myvalue2"
+            }
+          }
+          min: 10.5
+          max: 10.5
+        }
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+      }
+    }
+  }
+}
+```

--- a/opentelemetry-user-events-metrics/local-setup/README.md
+++ b/opentelemetry-user-events-metrics/local-setup/README.md
@@ -1,4 +1,4 @@
-# Local Setup for testing with user_events using multipass:
+# Local Setup for Testing `user_events` with *Multipass*:
 
 This directory contains `cloud-init.yaml`, a configuration file to set up an Ubuntu 24.04 virtual machine environment with essential tools required for running and validating user_events example contained in this repository. The setup includes enabling `user_events` and installing the `perf` tool, along with utilities for decoding `user_events` data and processing `proto` data.
 
@@ -13,7 +13,7 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
 
    After installation, verify by running:
    ```bash
-   multipass --version
+   PS> multipass --version
    ```
 
 ## Usage
@@ -21,16 +21,11 @@ This directory contains `cloud-init.yaml`, a configuration file to set up an Ubu
 1. **Launch a VM with cloud-init.yaml:** 
     Use the following command to start a VM with the specified configuration:
     ```bash
-    PS> multipass launch --name my-test-vm --cloud-init cloud-init.yaml
+    PS> multipass launch --name my-test-vm -m 6G -d 10G --cloud-init cloud-init.yaml
     Launched: my-test-vm
     ```
 
-    You can also specify the memory and disk size while creating the VM:
-    ```bash
-    PS> multipass launch --name my-test-vm -m 10G -d 40G --cloud-init cloud-init.yaml
-    ```
-
-    This will same time to create and configure the VM. Validate that the VM is created and running:
+    This will some time to create and configure the VM. Validate that the VM is created and running:
     ```bash
     PS> multipass list
     Name                    State             IPv4             Image

--- a/opentelemetry-user-events-metrics/local-setup/cloud-init.yaml
+++ b/opentelemetry-user-events-metrics/local-setup/cloud-init.yaml
@@ -1,0 +1,72 @@
+# cloud-init.yaml
+#cloud-config
+package_update: true
+packages:
+  - git
+  - wget
+  - build-essential
+  - cmake
+  - flex
+  - bison
+  - linux-tools-generic
+  - python3.12-venv
+
+runcmd:
+  - echo "Hello, Multipass!" > /home/ubuntu/hello.txt
+  - sudo apt-get update
+  - sudo apt-get install -y git wget build-essential cmake flex bison linux-tools-generic python3.12-venv
+  - sudo -u ubuntu bash -c "
+      cd /home/ubuntu &&
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
+      source /home/ubuntu/.cargo/env &&
+      git clone https://github.com/microsoft/LinuxTracepoints &&
+      cd LinuxTracepoints && mkdir build && cd build && cmake .. && make &&
+      sudo cp bin/perf-decode /usr/local/bin &&
+      cd /home/ubuntu && rm -rf LinuxTracepoints &&
+      git clone https://github.com/open-telemetry/opentelemetry-rust-contrib.git /home/ubuntu/opentelemetry-rust-contrib &&
+      python3 -m venv /home/ubuntu/userevents-env &&
+      source /home/ubuntu/userevents-env/bin/activate &&
+      pip install opentelemetry-proto
+    "
+  - |
+    cat << 'EOF' > /home/ubuntu/decrypt_python.py
+    import sys
+    import json
+    from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+
+    # Check if a filename is provided
+    if len(sys.argv) < 2:
+        print("Usage: python decrypt_metric.py <filename>")
+        sys.exit(1)
+
+    try:
+        # Read the JSON file
+        with open(sys.argv[1], 'r', encoding='utf-8-sig') as file:
+            data = json.load(file)
+
+            # Traverse through each item in the JSON data
+            for key in data:
+                for item in data[key]:
+                    result = ExportMetricsServiceRequest()
+                    # Convert the buffer list to bytes and parse it
+                    buffer_data = bytes(item['buffer'])
+                    result.ParseFromString(buffer_data)
+                    print(result)
+
+    except json.JSONDecodeError as e:
+        print(f"JSON decoding error: {e}")
+        print("Please ensure the JSON file is properly formatted.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+    EOF
+
+users:
+  - name: ubuntu
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    groups: sudo
+    home: /home/ubuntu
+    shell: /bin/bash
+    lock_passwd: false  # Ensure the password is not locked
+    plain_text_passwd: "ubuntu"  # Set a password for user 'ubuntu' (you can set this to any preferred password)
+
+ssh_pwauth: true  # Enable password authentication for SSH

--- a/opentelemetry-user-events-metrics/local-setup/cloud-init.yaml
+++ b/opentelemetry-user-events-metrics/local-setup/cloud-init.yaml
@@ -12,7 +12,6 @@ packages:
   - python3.12-venv
 
 runcmd:
-  - echo "Hello, Multipass!" > /home/ubuntu/hello.txt
   - sudo apt-get update
   - sudo apt-get install -y git wget build-essential cmake flex bison linux-tools-generic python3.12-venv
   - sudo -u ubuntu bash -c "


### PR DESCRIPTION
## Changes

Note: I found this setup helpful for testing my latest `user_events` metrics PR, so thought of adding it. Feel free to reject the PR if this doesn't seem helpful :)

Setting up the Linux kernel with user_events enabled can be challenging, especially since the latest WSL images do not *yet* support it. An easier alternative is to use an Ubuntu 24.04 (or greater) VM, which can be run on Hyper-V, VirtualBox, or other virtualization platforms.

This PR introduces a cloud-init.yaml configuration file for creating an Ubuntu VM using [multipass](https://multipass.run/), with user_events support and other required configurations for decoding `proto` packets. This setup is cross-platform, allowing developers to run it on Windows, macOS, or Linux, simplifying the environment setup process for consistent testing.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
