### PR TITLE
opentelemetry 0.27

### DIFF
--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump opentelemetry and opentelemetry_sdk versions to 0.27
+
 ## v0.5.0
 
 ### Changed

--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-etw-logs"
 description = "OpenTelemetry logs exporter to ETW (Event Tracing for Windows)"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
@@ -13,13 +13,13 @@ license = "Apache-2.0"
 [dependencies]
 tracelogging = "1.2.1"
 tracelogging_dynamic = "1.2.1"
-opentelemetry = { workspace = true, features = ["logs"] }
-opentelemetry_sdk = { workspace = true, features = ["logs"] }
+opentelemetry = { version = "0.27", features = ["logs"] }
+opentelemetry_sdk = { version = "0.27", features = ["logs"] }
 async-trait = { version = "0.1" }
 serde_json = "1.0.113"
 
 [dev-dependencies]
-opentelemetry-appender-tracing = { workspace = true }
+opentelemetry-appender-tracing = { version = "0.27" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = [
@@ -29,11 +29,11 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 microbench = "0.5"
 
 [features]
-logs_level_enabled = [
-    "opentelemetry/logs_level_enabled",
-    "opentelemetry_sdk/logs_level_enabled",
+spec_unstable_logs_enabled  = [
+    "opentelemetry/spec_unstable_logs_enabled",
+    "opentelemetry_sdk/spec_unstable_logs_enabled",
 ]
-default = ["logs_level_enabled"]
+default = ["spec_unstable_logs_enabled"]
 
 [[example]]
 name = "basic"

--- a/opentelemetry-etw-logs/src/logs/converters.rs
+++ b/opentelemetry-etw-logs/src/logs/converters.rs
@@ -17,6 +17,11 @@ impl IntoJson for AnyValue {
             AnyValue::Bytes(_value) => todo!("No support for AnyValue::Bytes yet."),
             AnyValue::ListAny(value) => value.as_json_value(),
             AnyValue::Map(value) => value.as_json_value(),
+            &&_ => {
+                // If we reach this line is because we are upgrading opentelemetry to a version that contains a new type.
+                // We must add support for the new type.
+                todo!("Add support for new types");
+            }
         }
     }
 }

--- a/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
@@ -1,10 +1,10 @@
 use std::fmt::Debug;
 
-use opentelemetry::logs::LogResult;
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::logs::LogRecord;
+use opentelemetry_sdk::logs::LogResult;
 
-#[cfg(feature = "logs_level_enabled")]
+#[cfg(feature = "spec_unstable_logs_enabled")]
 use opentelemetry_sdk::export::logs::LogExporter;
 
 use crate::logs::exporter::ExporterConfig;
@@ -33,7 +33,7 @@ impl ReentrantLogProcessor {
 }
 
 impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
-    fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationLibrary) {
+    fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationScope) {
         _ = self.event_exporter.export_log_data(data, instrumentation);
     }
 
@@ -49,7 +49,7 @@ impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
         Ok(())
     }
 
-    #[cfg(feature = "logs_level_enabled")]
+    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn event_enabled(
         &self,
         level: opentelemetry::logs::Severity,


### PR DESCRIPTION
## Changes

Update `opentelemetry_etw_logs` to use `opentelemetry` and `opentelemetry_sdk` versions `0.27`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
