### PR TITLE
Enable event_enabled flag for opentelemetry-user-events-logs example code

### DIFF
--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Renamed  `logs_level_enabled` flag to `spec_unstable_logs_enabled` to be consistent with core repo.
+
 ## v0.8.0
 
 ### Changed

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -26,5 +26,5 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 microbench = "0.5"
 
 [features]
-logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
+logs_level_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
 default = ["logs_level_enabled"]

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -26,5 +26,5 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 microbench = "0.5"
 
 [features]
-logs_level_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
-default = ["logs_level_enabled"]
+spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
+default = ["spec_unstable_logs_enabled"]

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -324,7 +324,7 @@ impl opentelemetry_sdk::export::logs::LogExporter for UserEventsExporter {
         Ok(())
     }
 
-    #[cfg(feature = "logs_level_enabled")]
+    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn event_enabled(&self, level: Severity, _target: &str, name: &str) -> bool {
         let (found, keyword) = if self.exporter_config.keywords_map.is_empty() {
             (true, self.exporter_config.default_keyword)

--- a/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use opentelemetry_sdk::logs::LogResult;
 
-#[cfg(feature = "logs_level_enabled")]
+#[cfg(feature = "spec_unstable_logs_enabled")]
 use opentelemetry_sdk::export::logs::LogExporter;
 
 use crate::logs::exporter::*;
@@ -46,7 +46,7 @@ impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
         Ok(())
     }
 
-    #[cfg(feature = "logs_level_enabled")]
+    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn event_enabled(
         &self,
         level: opentelemetry::logs::Severity,

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -37,7 +37,7 @@ if rustup component add clippy; then
 #  cargo_feature opentelemetry-stackdriver "tls-webpki-roots"
 
   cargo_feature opentelemetry-user-events-logs "default"
-  cargo_feature opentelemetry-user-events-logs "logs_level_enabled"
+  cargo_feature opentelemetry-user-events-logs "spec_unstable_logs_enabled"
 
   cargo_feature opentelemetry-user-events-metrics ""
 


### PR DESCRIPTION
## Changes

A small change to enable event_enabled for opentelemetry-user-events-logs example code

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
