### PR TITLE
Improve efficiency of ETW metrics exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-    "opentelemetry-*",
-    "examples/*",
-]
+members = ["opentelemetry-*", "examples/*"]
 resolver = "2"
 
 [profile.bench]
@@ -18,4 +15,7 @@ opentelemetry-http = "0.27"
 opentelemetry-proto = { version = "0.27", default-features = false }
 opentelemetry_sdk = { version = "0.27", default-features = false }
 opentelemetry-stdout = "0.27"
-opentelemetry-semantic-conventions = { version = "0.27", features = ["semconv_experimental"] }
+opentelemetry-semantic-conventions = { version = "0.27", features = [
+    "semconv_experimental",
+] }
+criterion = "0.5"

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -17,7 +17,8 @@ opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
 async-trait = "0.1"
 prost = "0.13"
 tracelogging = "1.2.1"
-tracing = {version = "0.1", optional = true}
+tracing = { version = "0.1", optional = true }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
@@ -28,3 +29,11 @@ default = ["internal-logs"]
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]
+
+[[bench]]
+name = "etw"
+harness = false
+
+[[bench]]
+name = "exporter"
+harness = false

--- a/opentelemetry-etw-metrics/benches/etw.rs
+++ b/opentelemetry-etw-metrics/benches/etw.rs
@@ -1,3 +1,18 @@
+//! run with `$ cargo bench --bench etw -- --exact <test_name>` to run specific test for logs
+//! So to run test named "fibonacci" you would run `$ cargo bench --bench etw -- --exact fibonacci`
+//! To run all tests for logs you would run `$ cargo bench --bench etw`
+//!
+/*
+The benchmark results:
+criterion = "0.5.1"
+OS:
+Hardware:
+RAM:
+| Test                           | Average time|
+|--------------------------------|-------------|
+|                                |             |
+*/
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn fibonacci(n: u64) -> u64 {

--- a/opentelemetry-etw-metrics/benches/etw.rs
+++ b/opentelemetry-etw-metrics/benches/etw.rs
@@ -5,12 +5,12 @@
 /*
 The benchmark results:
 criterion = "0.5.1"
-OS:
-Hardware:
-RAM:
+OS: Windows 11 Enterprise N, 23H2, Build 22631.4460
+Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz   2.79 GHz, 16vCPUs
+RAM: 64.0 GB
 | Test                           | Average time|
 |--------------------------------|-------------|
-|                                |             |
+| write_event                    | 2.0649ns    |
 */
 
 use opentelemetry_etw_metrics::etw::write;

--- a/opentelemetry-etw-metrics/benches/etw.rs
+++ b/opentelemetry-etw-metrics/benches/etw.rs
@@ -13,18 +13,16 @@ RAM:
 |                                |             |
 */
 
+use opentelemetry_etw_metrics::etw::write;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn fibonacci(n: u64) -> u64 {
-    match n {
-        0 => 0,
-        1 => 1,
-        _ => fibonacci(n - 1) + fibonacci(n - 2),
-    }
+fn write_event() {
+    let buffer = "This is a test buffer".as_bytes();
+    write(buffer);
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("fib 20", |b| b.iter(|| fibonacci(20)));
+    c.bench_function("write_event", |b| b.iter(|| write_event()));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/opentelemetry-etw-metrics/benches/etw.rs
+++ b/opentelemetry-etw-metrics/benches/etw.rs
@@ -1,0 +1,16 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("fib 20", |b| b.iter(|| fibonacci(20)));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/opentelemetry-etw-metrics/benches/etw.rs
+++ b/opentelemetry-etw-metrics/benches/etw.rs
@@ -13,8 +13,8 @@ RAM: 64.0 GB
 | write_event                    | 2.0649ns    |
 */
 
-use opentelemetry_etw_metrics::etw::write;
 use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry_etw_metrics::etw::write;
 
 fn write_event() {
     let buffer = "This is a test buffer".as_bytes();

--- a/opentelemetry-etw-metrics/benches/exporter.rs
+++ b/opentelemetry-etw-metrics/benches/exporter.rs
@@ -13,17 +13,10 @@ RAM: 64.0 GB
 | exporter                       | 847.38µs    |
 */
 
-use opentelemetry::metrics::Gauge;
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-use opentelemetry::{InstrumentationScope, InstrumentationScopeBuilder};
 use opentelemetry_etw_metrics::MetricsExporter;
-use opentelemetry_sdk::metrics::reader::MetricReader;
-use opentelemetry_sdk::metrics::{ManualReader, PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::{
-    metrics::{
-        data::{ResourceMetrics, ScopeMetrics},
-        exporter::PushMetricExporter,
-    },
+    metrics::{reader::MetricReader, PeriodicReader, SdkMeterProvider},
     runtime, Resource,
 };
 

--- a/opentelemetry-etw-metrics/benches/exporter.rs
+++ b/opentelemetry-etw-metrics/benches/exporter.rs
@@ -5,12 +5,12 @@
 /*
 The benchmark results:
 criterion = "0.5.1"
-OS:
-Hardware:
-RAM:
+OS: Windows 11 Enterprise N, 23H2, Build 22631.4460
+Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz   2.79 GHz, 16vCPUs
+RAM: 64.0 GB
 | Test                           | Average time|
 |--------------------------------|-------------|
-|                                |             |
+| exporter                       | 1.2927ms    |
 */
 
 use opentelemetry_etw_metrics::MetricsExporter;

--- a/opentelemetry-etw-metrics/benches/exporter.rs
+++ b/opentelemetry-etw-metrics/benches/exporter.rs
@@ -1,0 +1,31 @@
+//! run with `$ cargo bench --bench exporter -- --exact <test_name>` to run specific test for logs
+//! So to run test named "fibonacci" you would run `$ cargo bench --bench exporter -- --exact fibonacci`
+//! To run all tests for logs you would run `$ cargo bench --bench exporter`
+//!
+/*
+The benchmark results:
+criterion = "0.5.1"
+OS:
+Hardware:
+RAM:
+| Test                           | Average time|
+|--------------------------------|-------------|
+|                                |             |
+*/
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("fib 20", |b| b.iter(|| fibonacci(20)));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/opentelemetry-etw-metrics/src/lib.rs
+++ b/opentelemetry-etw-metrics/src/lib.rs
@@ -1,4 +1,4 @@
-mod etw;
+pub mod etw;
 mod exporter;
 
 pub use exporter::MetricsExporter;


### PR DESCRIPTION
Fixes #104 
Design Decisions:
* Follow .Net and C++ implementations and use helper methods to serialize fragments of metric points into a coherent, exportable buffer
* Construct a new `ResourceMetrics` for each metric point and serialize each into an exportable buffer

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
