### PR TITLE
Fix CI lint errors from new stable toolchain v1.83

### DIFF
--- a/opentelemetry-contrib/benches/new_span.rs
+++ b/opentelemetry-contrib/benches/new_span.rs
@@ -13,7 +13,7 @@ use opentelemetry_contrib::trace::{
 };
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::{Config, Sampler, TracerProvider},
+    trace::{Sampler, TracerProvider},
 };
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};

--- a/opentelemetry-contrib/benches/new_span.rs
+++ b/opentelemetry-contrib/benches/new_span.rs
@@ -152,7 +152,7 @@ impl Display for Environment {
 
 fn parent_sampled_tracer(inner_sampler: Sampler) -> (TracerProvider, BoxedTracer) {
     let provider = TracerProvider::builder()
-        .with_config(Config::default().with_sampler(Sampler::ParentBased(Box::new(inner_sampler))))
+        .with_sampler(Sampler::ParentBased(Box::new(inner_sampler)))
         .with_simple_exporter(NoopExporter)
         .build();
     let tracer = provider.tracer(module_path!());

--- a/opentelemetry-contrib/src/trace/context.rs
+++ b/opentelemetry-contrib/src/trace/context.rs
@@ -91,7 +91,6 @@ pub fn new_span_if_recording(
 /// ```
 /// use opentelemetry::trace::{SpanBuilder, TraceContextExt as _};
 /// use opentelemetry_contrib::trace::{new_span_if_parent_sampled, Contextualized, TracerSource};
-
 /// enum Message{Command};
 /// let (tx, rx) = std::sync::mpsc::channel();
 ///

--- a/opentelemetry-contrib/src/trace/tracer_source.rs
+++ b/opentelemetry-contrib/src/trace/tracer_source.rs
@@ -47,7 +47,7 @@ impl<'a> TracerSource<'a> {
     }
 }
 
-impl<'a> Debug for Variant<'a> {
+impl Debug for Variant<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use Variant::*;
         match self {

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -56,6 +56,7 @@ impl ShouldSample for AgentBasedSampler {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    #[allow(deprecated)]
     let tracer = new_pipeline()
         .with_service_name("agent-sampling-demo")
         .with_api_version(ApiVersion::Version05)

--- a/opentelemetry-datadog/src/exporter/intern.rs
+++ b/opentelemetry-datadog/src/exporter/intern.rs
@@ -18,7 +18,7 @@ pub(crate) enum InternValue<'a> {
     OpenTelemetryValue(&'a Value),
 }
 
-impl<'a> Hash for InternValue<'a> {
+impl Hash for InternValue<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match &self {
             InternValue::RegularString(s) => s.hash(state),
@@ -44,7 +44,7 @@ impl<'a> Hash for InternValue<'a> {
     }
 }
 
-impl<'a> Eq for InternValue<'a> {}
+impl Eq for InternValue<'_> {}
 
 const BOOLEAN_TRUE: &str = "true";
 const BOOLEAN_FALSE: &str = "false";
@@ -84,7 +84,7 @@ impl WriteAsLiteral for StringValue {
     }
 }
 
-impl<'a> InternValue<'a> {
+impl InternValue<'_> {
     pub(crate) fn write_as_str<W: RmpWrite>(
         &self,
         payload: &mut W,

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -287,7 +287,7 @@ impl DatadogPipelineBuilder {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
         let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
-        provider_builder = provider_builder.with_config(config);
+        provider_builder = provider_builder.with_resource(config.resource.into_owned());
         let provider = provider_builder.build();
         let scope = InstrumentationScope::builder("opentelemetry-datadog")
             .with_version(env!("CARGO_PKG_VERSION"))
@@ -305,7 +305,7 @@ impl DatadogPipelineBuilder {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
         let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
-        provider_builder = provider_builder.with_config(config);
+        provider_builder = provider_builder.with_resource(config.resource.into_owned());
         let provider = provider_builder.build();
         let scope = InstrumentationScope::builder("opentelemetry-datadog")
             .with_version(env!("CARGO_PKG_VERSION"))

--- a/opentelemetry-datadog/src/exporter/model/unified_tags.rs
+++ b/opentelemetry-datadog/src/exporter/model/unified_tags.rs
@@ -1,5 +1,4 @@
 /// Unified tags - See: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
-
 pub struct UnifiedTags {
     pub service: UnifiedTagField,
     pub env: UnifiedTagField,


### PR DESCRIPTION
See related issue: open-telemetry/opentelemetry-rust#2370

## Changes

Fixed the following lint errors:

```sh
error: use of deprecated method `opentelemetry_sdk::trace::Builder::with_config`: Config is becoming a private type. Use Builder::with_{config_name}(resource) instead. ex: Builder::with_resource(resource)
```

```sh
error: the following explicit lifetimes could be elided: 'a
```

```sh
error: empty line after doc comment
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
