### PR TITLE
feat: add `aws.log.group.names` attribute to `LambdaResourceDetector`

### DIFF
--- a/opentelemetry-aws/src/detector/lambda.rs
+++ b/opentelemetry-aws/src/detector/lambda.rs
@@ -1,4 +1,4 @@
-use opentelemetry::KeyValue;
+use opentelemetry::{Array, KeyValue, StringValue, Value};
 use opentelemetry_sdk::resource::ResourceDetector;
 use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions as semconv;
@@ -46,7 +46,7 @@ impl ResourceDetector for LambdaResourceDetector {
             KeyValue::new(semconv::resource::FAAS_MAX_MEMORY, function_memory_limit),
             KeyValue::new(
                 semconv::resource::AWS_LOG_GROUP_NAMES,
-                vec![log_group_name].into(),
+                Value::Array(Array::from(vec![StringValue::from(log_group_name)])),
             ),
         ];
 
@@ -87,7 +87,9 @@ mod tests {
             KeyValue::new(semconv::resource::FAAS_MAX_MEMORY, 128 * 1024 * 1024),
             KeyValue::new(
                 semconv::resource::AWS_LOG_GROUP_NAMES,
-                vec!["/aws/lambda/my-lambda-function"].into(),
+                Value::Array(Array::from(vec![StringValue::from(
+                    "/aws/lambda/my-lambda-function".to_string(),
+                )])),
             ),
         ]);
 

--- a/opentelemetry-aws/src/detector/lambda.rs
+++ b/opentelemetry-aws/src/detector/lambda.rs
@@ -12,6 +12,7 @@ const AWS_REGION_ENV_VAR: &str = "AWS_REGION";
 const AWS_LAMBDA_FUNCTION_VERSION_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_VERSION";
 const AWS_LAMBDA_LOG_STREAM_NAME_ENV_VAR: &str = "AWS_LAMBDA_LOG_STREAM_NAME";
 const AWS_LAMBDA_MEMORY_LIMIT_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE";
+const AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR: &str = "AWS_LAMBDA_LOG_GROUP_NAME";
 
 /// Resource detector that collects resource information from AWS Lambda environment.
 pub struct LambdaResourceDetector;
@@ -31,6 +32,7 @@ impl ResourceDetector for LambdaResourceDetector {
         // Instance attributes corresponds to the log stream name for AWS Lambda;
         // See the FaaS resource specification for more details.
         let instance = env::var(AWS_LAMBDA_LOG_STREAM_NAME_ENV_VAR).unwrap_or_default();
+        let log_group_name = env::var(AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR).unwrap_or_default();
 
         let attributes = [
             KeyValue::new(semconv::resource::CLOUD_PROVIDER, "aws"),
@@ -39,6 +41,10 @@ impl ResourceDetector for LambdaResourceDetector {
             KeyValue::new(semconv::resource::FAAS_NAME, lambda_name),
             KeyValue::new(semconv::resource::FAAS_VERSION, function_version),
             KeyValue::new(semconv::resource::FAAS_MAX_MEMORY, function_memory_limit),
+            KeyValue::new(
+                semconv::resource::AWS_LOG_GROUP_NAMES,
+                vec![log_group_name].into(),
+            ),
         ];
 
         Resource::new(attributes)
@@ -61,6 +67,10 @@ mod tests {
             "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc",
         );
         set_var(AWS_LAMBDA_MEMORY_LIMIT_ENV_VAR, "128");
+        set_var(
+            AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR,
+            "/aws/lambda/my-lambda-function",
+        );
 
         let expected = Resource::new([
             KeyValue::new(semconv::resource::CLOUD_PROVIDER, "aws"),
@@ -72,6 +82,10 @@ mod tests {
             KeyValue::new(semconv::resource::FAAS_NAME, "my-lambda-function"),
             KeyValue::new(semconv::resource::FAAS_VERSION, "$LATEST"),
             KeyValue::new(semconv::resource::FAAS_MAX_MEMORY, "128"),
+            KeyValue::new(
+                semconv::resource::AWS_LOG_GROUP_NAMES,
+                vec!["/aws/lambda/my-lambda-function"].into(),
+            ),
         ]);
 
         let detector = LambdaResourceDetector {};
@@ -84,6 +98,7 @@ mod tests {
         remove_var(AWS_LAMBDA_FUNCTION_VERSION_ENV_VAR);
         remove_var(AWS_LAMBDA_LOG_STREAM_NAME_ENV_VAR);
         remove_var(AWS_LAMBDA_MEMORY_LIMIT_ENV_VAR);
+        remove_var(AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR);
     }
 
     #[sealed_test]


### PR DESCRIPTION
Add `aws.log.group.names` resource attribute to `LambdaResourceDetector` using the `AWS_LAMBDA_LOG_GROUP_NAME` environment variable that is [always available in Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime).

This follows the OpenTelemetry semantic convention for [AWS Logs attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/aws/#amazon-logs-attributes).

The semantic convention specifies that `aws.log.group.names` should be an array of strings to support cases like multi-container applications, though in AWS Lambda we'll only ever have a single log group.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
