### PR TITLE
Trim host-id whitespace on Linux

### DIFF
--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -52,6 +52,7 @@ fn host_id_detect() -> Option<String> {
     let dbus_machine_id_path = Path::new("/var/lib/dbus/machine-id");
     read_to_string(machine_id_path)
         .or_else(|_| read_to_string(dbus_machine_id_path))
+        .map(|id| id.trim().to_string())
         .ok()
 }
 


### PR DESCRIPTION
## Changes

On Linux `/etc/machine-id` has a newline, it's unusual to have newlines in a resource value like `host.id`, so this change trims the whitespace around the value.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [N/A] Unit tests added/updated (if applicable)
* [N/A] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [N/A] Changes in public API reviewed (if applicable)
