### PR TITLE
Add stress test for user-events logs exporter

### DIFF
--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -22,9 +22,9 @@ num-format = "0.4.4"
 sysinfo = { version = "0.32", optional = true }
 eventheader_dynamic = "0.4.0"
 
-opentelemetry-appender-tracing = { workspace = true }
-opentelemetry_sdk = { workspace = true, features = ["logs"] }
-opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs"}
+opentelemetry-appender-tracing = { workspace = true, features= ["spec_unstable_logs_enabled"] }
+opentelemetry_sdk = { workspace = true, features = ["logs", "spec_unstable_logs_enabled"] }
+opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs", features = ["spec_unstable_logs_enabled"]}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -26,7 +26,6 @@ opentelemetry-appender-tracing = { workspace = true, features= ["spec_unstable_l
 opentelemetry_sdk = { workspace = true, features = ["logs", "spec_unstable_logs_enabled"] }
 opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs", features = ["spec_unstable_logs_enabled"]}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 
 [features]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[[bin]] # Bin to run the metrics stress tests for Logs UserEvent Exporter
+[[bin]]
 name = "eventheader"
 path = "src/eventheader.rs"
+doc = false
+
+[[bin]]
+name = "user_events"
+path = "src/user_events.rs"
 doc = false
 
 [dependencies]
@@ -16,6 +21,13 @@ num_cpus = "1.15.0"
 num-format = "0.4.4"
 sysinfo = { version = "0.32", optional = true }
 eventheader_dynamic = "0.4.0"
+
+opentelemetry-appender-tracing = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["logs"] }
+opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs"}
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-core = "0.1.31"
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 
 [features]
 stats = ["sysinfo"]

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -1,12 +1,12 @@
 //! Run this stress test using `$ sudo -E ~/.cargo/bin/cargo run --bin user_events --release -- <num-of-threads>`.
 //!
 //! IMPORTANT:
-//! To test with `user_events` enabled, perform the following step before running the test:
-//!   - Add `1` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
-//!     `echo 1 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
-//! To test with `user_events` disabled, perform the following step:
-//!   - Add `0` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
-//!     `echo 0 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
+//!     To test with `user_events` enabled, perform the following step before running the test:
+//!     - Add `1` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
+//!         `echo 1 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
+//!     To test with `user_events` disabled, perform the following step:
+//!     - Add `0` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
+//!         `echo 0 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
 //!
 //!
 // Conf - AMD EPYC 7763 64-Core Processor 2.44 GHz, 64GB RAM, Cores:8 , Logical processors: 16

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -62,7 +62,7 @@ fn main() {
     // Use the provided stress test framework
     println!("Starting stress test for UserEventsExporter...");
     throughput::test_throughput(|| {
-        log_event_task(); // Log the error event in each iteration
+        log_event_task();
     });
     println!("Stress test completed.");
 }

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -1,0 +1,57 @@
+//! Run this stress test using `$ sudo -E ~/.cargo/bin/cargo run --bin user_events --release -- <num-of-threads>`.
+//!
+//! IMPORTANT:
+//! To test with `user_events` enabled, perform the following step before running the test:
+//!   - Add `1` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
+//!     `echo 1 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
+//! To test with `user_events` disabled, perform the following step:
+//!   - Add `0` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
+//!     `echo 0 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
+//!
+//! NOTE: Running as `sudo -E` ensures the environment variables for Rust and Cargo are retained,
+//! and you have sufficient permissions to access `/sys/kernel/debug/tracing` and utilize `user_events`.
+
+use opentelemetry_appender_tracing::layer;
+use opentelemetry_sdk::logs::LoggerProvider;
+use opentelemetry_user_events_logs::{ExporterConfig, ReentrantLogProcessor, UserEventsExporter};
+use std::collections::HashMap;
+use tracing::error;
+use tracing_subscriber::prelude::*;
+mod throughput;
+
+// Function to initialize the logger
+fn init_logger() -> LoggerProvider {
+    let exporter_config = ExporterConfig {
+        default_keyword: 1,
+        keywords_map: HashMap::new(),
+    };
+    let exporter = UserEventsExporter::new("test", None, exporter_config);
+    let reentrant_processor = ReentrantLogProcessor::new(exporter);
+    LoggerProvider::builder()
+        .with_log_processor(reentrant_processor)
+        .build()
+}
+
+// Function that performs the logging task
+fn log_event_task() {
+    error!(
+        name = "my-event-name",
+        event_id = 20,
+        user_name = "otel user",
+        user_email = "otel@opentelemetry.io"
+    );
+}
+
+fn main() {
+    // Initialize the logger
+    let logger_provider = init_logger();
+    let layer = layer::OpenTelemetryTracingBridge::new(&logger_provider);
+    tracing_subscriber::registry().with(layer).init();
+
+    // Use the provided stress test framework
+    println!("Starting stress test for UserEventsExporter...");
+    throughput::test_throughput(|| {
+        log_event_task(); // Log the error event in each iteration
+    });
+    println!("Stress test completed.");
+}

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -15,7 +15,7 @@ use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::LoggerProvider;
 use opentelemetry_user_events_logs::{ExporterConfig, ReentrantLogProcessor, UserEventsExporter};
 use std::collections::HashMap;
-use tracing::error;
+use tracing::info;
 use tracing_subscriber::prelude::*;
 mod throughput;
 
@@ -25,7 +25,7 @@ fn init_logger() -> LoggerProvider {
         default_keyword: 1,
         keywords_map: HashMap::new(),
     };
-    let exporter = UserEventsExporter::new("test", None, exporter_config);
+    let exporter = UserEventsExporter::new("testprovider", None, exporter_config);
     let reentrant_processor = ReentrantLogProcessor::new(exporter);
     LoggerProvider::builder()
         .with_log_processor(reentrant_processor)
@@ -34,7 +34,7 @@ fn init_logger() -> LoggerProvider {
 
 // Function that performs the logging task
 fn log_event_task() {
-    error!(
+    info!(
         name = "my-event-name",
         event_id = 20,
         user_name = "otel user",

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -8,8 +8,19 @@
 //!   - Add `0` to `/sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`:
 //!     `echo 0 > /sys/kernel/debug/tracing/events/user_events/testprovider_L4K1Gtestprovider/enable`
 //!
-//! NOTE: Running as `sudo -E` ensures the environment variables for Rust and Cargo are retained,
-//! and you have sufficient permissions to access `/sys/kernel/debug/tracing` and utilize `user_events`.
+//!
+// Conf - AMD EPYC 7763 64-Core Processor 2.44 GHz, 64GB RAM, Cores:8 , Logical processors: 16
+// Stress Test Results (user_events disabled)
+// Threads: 1 - Average Throughput: 30,866,752 iterations/sec
+// Threads: 5 - Average Throughput: 32,662,641 iterations/sec
+// Threads: 10 - Average Throughput: 25,776,394 iterations/sec
+// Threads: 16 - Average Throughput: 16,915,860 iterations/sec
+
+// Stress Test Results (user_events enabled)
+// Threads: 1 - Average Throughput: 212,594 iterations/sec
+// Threads: 5 - Average Throughput: 372,695 iterations/sec
+// Threads: 10 - Average Throughput: 277,675 iterations/sec
+// Threads: 16 - Average Throughput: 268,940 iterations/sec
 
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::LoggerProvider;


### PR DESCRIPTION
## Changes

Adding test for user-events exporter, with steps to take results by enabling and disabling user-events. Also, added the initial results I got in my devenv. This mayn't be accurate. The next steps are to evaluate the results, and see potential improvements required. 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
