### PR TITLE
[user_events logs] Remove Arc reference from eventheader provider

### DIFF
--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -4,7 +4,6 @@ use eventheader_dynamic::EventBuilder;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::Arc;
 
 use opentelemetry::{logs::AnyValue, logs::Severity, Key};
 use std::{cell::RefCell, str, time::SystemTime};
@@ -49,7 +48,7 @@ impl ExporterConfig {
 
 /// UserEventsExporter is a log exporter that exports logs in EventHeader format to user_events tracepoint.
 pub struct UserEventsExporter {
-    provider: Arc<eventheader_dynamic::Provider>,
+    provider: eventheader_dynamic::Provider,
     exporter_config: ExporterConfig,
 }
 
@@ -70,7 +69,7 @@ impl UserEventsExporter {
             eventheader_dynamic::Provider::new(provider_name, &options);
         Self::register_keywords(&mut eventheader_provider, &exporter_config);
         UserEventsExporter {
-            provider: Arc::new(eventheader_provider),
+            provider: eventheader_provider,
             exporter_config,
         }
     }

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -11,16 +11,16 @@
 //!
 // Conf - AMD EPYC 7763 64-Core Processor 2.44 GHz, 64GB RAM, Cores:8 , Logical processors: 16
 // Stress Test Results (user_events disabled)
-// Threads: 1 - Average Throughput: 30,866,752 iterations/sec
-// Threads: 5 - Average Throughput: 32,662,641 iterations/sec
-// Threads: 10 - Average Throughput: 25,776,394 iterations/sec
-// Threads: 16 - Average Throughput: 16,915,860 iterations/sec
+// Threads: 1 - Average Throughput: 42,086,520 iterations/sec
+// Threads: 5 - Average Throughput: 35,767,375 iterations/sec
+// Threads: 10 - Average Throughput: 29,189,340 iterations/sec
+// Threads: 16 - Average Throughput: 19,579,138 iterations/sec
 
 // Stress Test Results (user_events enabled)
-// Threads: 1 - Average Throughput: 212,594 iterations/sec
-// Threads: 5 - Average Throughput: 372,695 iterations/sec
-// Threads: 10 - Average Throughput: 277,675 iterations/sec
-// Threads: 16 - Average Throughput: 268,940 iterations/sec
+// Threads: 1 - Average Throughput: 285,692 iterations/sec
+// Threads: 5 - Average Throughput: 392,906 iterations/sec
+// Threads: 10 - Average Throughput: 349,334 iterations/sec
+// Threads: 16 - Average Throughput: 297,232 iterations/sec
 
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::LoggerProvider;


### PR DESCRIPTION
## Changes

The `Arc` is not required for eventheader-provider, so removing it. This has significant perf improvements as updated in the results.

Before (refer: #142)
is_enabled:true:
1 thread: 30,866,752 iterations/sec
16 threads: 16,915,860 iterations/sec

After:
is_enabled:false
1 thread: 41,555,620 iterations/sec
16 threads: 20,119,895 iterations/sec

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
