### PR TITLE
Use unstable sort to group traces in DD exporter.

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -397,7 +397,7 @@ fn group_into_traces(spans: &mut [SpanData]) -> Vec<&[SpanData]> {
         return vec![];
     }
 
-    spans.sort_by_key(|x| x.span_context.trace_id().to_bytes());
+    spans.sort_unstable_by_key(|x| x.span_context.trace_id().to_bytes());
 
     let mut traces: Vec<&[SpanData]> = Vec::with_capacity(spans.len());
 


### PR DESCRIPTION
Stable sort is not required for grouping, while unstable gives slightly better performance according to `opentelemetry-datadog/benches/datadog_exporter.rs`

## Changes

Changed sort implementation to perform grouping by trace_id to use unstable sort (not preserving order of already sorted items). It has slightly better performance that stable sort while not violating [contract](https://github.com/DataDog/datadog-agent/blob/c076ea9a1ffbde4c76d35343dbc32aecbbf99cb9/pkg/trace/api/version.go#L30) of DD api.

Before:
<details>
<summary>before</summary>

```
Benchmarking export 128 traces with 4 spans: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
export 128 traces with 4 spans
                        time:   [1.1379 ms 1.1489 ms 1.1605 ms]
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

export 256 traces with 4 spans
                        time:   [2.3451 ms 2.3663 ms 2.3889 ms]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

export 512 traces with 4 spans
                        time:   [4.9149 ms 4.9865 ms 5.0610 ms]

export 512 traces with 2 spans
                        time:   [2.3401 ms 2.3634 ms 2.3889 ms]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking export 512 traces with 1 spans: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
export 512 traces with 1 spans
                        time:   [1.1479 ms 1.1569 ms 1.1678 ms]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```
</details>

<details>
<summary>after</summary>

```
Benchmarking export 128 traces with 4 spans: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.6s, enable flat sampling, or reduce sample count to 60.
export 128 traces with 4 spans
                        time:   [1.0981 ms 1.1063 ms 1.1166 ms]
                        change: [-1.3629% -0.2693% +0.8717%] (p = 0.63 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

export 256 traces with 4 spans
                        time:   [2.2418 ms 2.2610 ms 2.2832 ms]
                        change: [-5.6447% -4.4503% -3.1954%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

export 512 traces with 4 spans
                        time:   [4.6663 ms 4.7158 ms 4.7690 ms]
                        change: [-7.1722% -5.4285% -3.6779%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

export 512 traces with 2 spans
                        time:   [2.2707 ms 2.3037 ms 2.3402 ms]
                        change: [-4.1921% -2.5230% -0.6872%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

Benchmarking export 512 traces with 1 spans: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.6s, enable flat sampling, or reduce sample count to 60.
export 512 traces with 1 spans
                        time:   [1.1267 ms 1.1463 ms 1.1705 ms]
                        change: [-3.2121% -2.0460% -0.8733%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe
```
</details>
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
