### PR TITLE
Update log_enabled feature name in etw logs

### DIFF
--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -32,8 +32,9 @@ microbench = "0.5"
 logs_level_enabled = [
     "opentelemetry/spec_unstable_logs_enabled",
     "opentelemetry_sdk/spec_unstable_logs_enabled",
+    "opentelemetry-appender-tracing/spec_unstable_logs_enabled"
 ]
-default = ["logs_level_enabled"]
+default = ["spec_unstable_logs_enabled"]
 
 [[example]]
 name = "basic"


### PR DESCRIPTION
Fixes #
Update the spec_unstable_logs_enabled cargo feature and enable default 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
