### PR TITLE
Remove server feature from tonic in opentelemetry-stackdriver

### DIFF
--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Remove `server` feature from tonic dependency
+
 ## v0.24.0
 
 ### Changed

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -20,7 +20,7 @@ opentelemetry-semantic-conventions = { workspace = true}
 prost = "0.13"
 prost-types = "0.13"
 thiserror = "1.0.30"
-tonic = { version = "0.12", features = ["gzip", "tls", "transport"] }
+tonic = { version = "0.12", default-features = false, features = ["channel", "codegen", "gzip", "prost", "tls"] }
 once_cell = { version = "1.19", optional = true }
 tracing = { version = "0.1", optional = true }
 


### PR DESCRIPTION
Fixes #147

## Changes

opentelemetry-stackdriver does not need the server implementation from tonic, which brings in axum etc. This change brings in all features other than that, which are needed for the client implementation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
