### PR TITLE
Fix stackdriver resources

### DIFF
--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -220,6 +220,7 @@ impl Builder {
 
         let count_clone = pending_count.clone();
         let resource = Arc::new(RwLock::new(None));
+        let ctx_resource = resource.clone();
         let future = async move {
             let trace_client = TraceServiceClient::new(trace_channel);
             let authorizer = &authenticator;
@@ -229,7 +230,7 @@ impl Builder {
                 let log_client = log_client.clone();
                 let pending_count = count_clone.clone();
                 let scopes = scopes.clone();
-                let resource = resource.clone();
+                let resource = ctx_resource.clone();
                 ExporterContext {
                     trace_client,
                     log_client,
@@ -248,7 +249,7 @@ impl Builder {
             pending_count,
             maximum_shutdown_duration: maximum_shutdown_duration
                 .unwrap_or_else(|| Duration::from_secs(5)),
-            resource: Arc::new(RwLock::new(None)),
+            resource,
         };
 
         Ok((exporter, future))

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -772,8 +772,7 @@ fn transform_links(links: &opentelemetry_sdk::trace::SpanLinks) -> Option<Links>
 // Map conventional OpenTelemetry keys to their GCP counterparts.
 //
 // https://cloud.google.com/trace/docs/trace-labels
-const KEY_MAP: [(&str, &str); 20] = [
-    (semconv::resource::SERVICE_NAME, GCP_SERVICE_NAME),
+const KEY_MAP: [(&str, &str); 19] = [
     (HTTP_PATH, GCP_HTTP_PATH),
     (semconv::attribute::HTTP_HOST, "/http/host"),
     ("http.request.header.host", "/http/host"),
@@ -843,7 +842,6 @@ fn status(value: opentelemetry::trace::Status) -> Option<Status> {
 }
 const TRACE_APPEND: &str = "https://www.googleapis.com/auth/trace.append";
 const LOGGING_WRITE: &str = "https://www.googleapis.com/auth/logging.write";
-const GCP_SERVICE_NAME: &str = "g.co/gae/app/module";
 const MAX_ATTRIBUTES_PER_SPAN: usize = 32;
 
 #[cfg(test)]
@@ -937,19 +935,13 @@ mod tests {
             actual.attribute_map.get("/http/status_code"),
             Some(&AttributeValue::from(Value::I64(200))),
         );
-        assert_eq!(
-            actual.attribute_map.get("g.co/gae/app/module"),
-            Some(&AttributeValue::from(Value::String(
-                "Test Service Name".into()
-            ))),
-        );
     }
 
     #[test]
     fn test_too_many() {
         let resources = Resource::new([KeyValue::new(
-            semcov::resource::SERVICE_NAME,
-            "Test Service Name",
+            semconv::attribute::USER_AGENT_ORIGINAL,
+            "Test Service Name UA",
         )]);
         let mut attributes = Vec::with_capacity(32);
         for i in 0..32 {
@@ -963,9 +955,9 @@ mod tests {
         assert_eq!(actual.attribute_map.len(), 32);
         assert_eq!(actual.dropped_attributes_count, 1);
         assert_eq!(
-            actual.attribute_map.get("g.co/gae/app/module"),
+            actual.attribute_map.get("/http/user_agent"),
             Some(&AttributeValue::from(Value::String(
-                "Test Service Name".into()
+                "Test Service Name UA".into()
             ))),
         );
     }

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -772,7 +772,7 @@ fn transform_links(links: &opentelemetry_sdk::trace::SpanLinks) -> Option<Links>
 // Map conventional OpenTelemetry keys to their GCP counterparts.
 //
 // https://cloud.google.com/trace/docs/trace-labels
-const KEY_MAP: [(&str, &str); 16] = [
+const KEY_MAP: [(&str, &str); 20] = [
     (semconv::resource::SERVICE_NAME, GCP_SERVICE_NAME),
     (HTTP_PATH, GCP_HTTP_PATH),
     (semconv::attribute::HTTP_HOST, "/http/host"),
@@ -786,9 +786,26 @@ const KEY_MAP: [(&str, &str); 16] = [
     (semconv::attribute::HTTP_USER_AGENT, "/http/user_agent"),
     (semconv::attribute::USER_AGENT_ORIGINAL, "/http/user_agent"),
     (semconv::attribute::HTTP_STATUS_CODE, "/http/status_code"),
+    // https://cloud.google.com/trace/docs/trace-labels#canonical-gke
     (
         semconv::attribute::HTTP_RESPONSE_STATUS_CODE,
         "/http/status_code",
+    ),
+    (
+        semconv::attribute::K8S_CLUSTER_NAME,
+        "g.co/r/k8s_container/cluster_name",
+    ),
+    (
+        semconv::attribute::K8S_NAMESPACE_NAME,
+        "g.co/r/k8s_container/namespace",
+    ),
+    (
+        semconv::attribute::K8S_POD_NAME,
+        "g.co/r/k8s_container/pod_name",
+    ),
+    (
+        semconv::attribute::K8S_CONTAINER_NAME,
+        "g.co/r/k8s_container/container_name",
     ),
     (semconv::trace::HTTP_ROUTE, "/http/route"),
     (HTTP_PATH, GCP_HTTP_PATH),


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes
While preparing for a new `opentelemtry-stackdriver` release and updating the dependencies it seems a bug was introduced.
The new API stores resource attributes directly in the exporter. By adding this two instances of `RwLock<Resource>` were introduced, making it impossible to set the resource (using `set_resource`) as the `ExporterContext` uses a different pointer.

This fixes the issue and also updates resource attribute key mappings to the latest version (added k8s mappings and removed outdated service.name mapping).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
