### PR TITLE
Add back MSRV CI job and adjust MSRVs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,25 +50,28 @@ jobs:
         args: --all -- --check
     - name: Lint
       run: ./scripts/lint.sh
-# TODO: re-add this test
-#  msrv:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v4
-#      with:
-#        submodules: true
-#    - uses: actions-rs/toolchain@v1
-#      with:
-#        profile: minimal
-#        toolchain: 1.65.0
-#        override: true
-#    - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
-#      run: ./scripts/patch_dependencies.sh
-#    - name: Run tests
-#      run: cargo --version &&
-#        cargo test --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,testing &&
-#        cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --features rt-tokio &&
-#        cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
+  msrv:
+    strategy:
+      matrix:
+        rust: ["1.70.0", "1.71.1"]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - name: Patch dependencies versions
+        run: bash ./scripts/patch_dependencies.sh
+      - name: Check MSRV for all crates
+        run: bash ./scripts/msrv.sh ${{ matrix.rust }}
   cargo-deny:
     runs-on: ubuntu-latest
     continue-on-error: true # Prevent sudden announcement of a new advisory from failing ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
   msrv:
     strategy:
       matrix:
-        rust: ["1.70.0", "1.71.1"]
+        rust: ["1.71.1"]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenTelemetry-based utilities that don't fit the primary scope of the
 [OpenTelemetry Rust](https://github.com/open-telemetry/opentelemetry-rust)
 project.
 
-*Compiler support: [requires `rustc` 1.65+][msrv]*
+*Compiler support: [requires `rustc` 1.70+][msrv]*
 
 [msrv]: #supported-rust-versions
 

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["development-tools::debugging", "development-tools::profiling"]
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
 readme = "README.md"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 keywords = ["opentelemetry", "log", "trace", "etw"]
 license = "Apache-2.0"
 

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/
 readme = "README.md"
 keywords = ["opentelemetry", "resource", "detector"]
 license = "Apache-2.0"
-rust-version = "1.65"
+rust-version = "1.70.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/proto"]
-rust-version = "1.65"
+rust-version = "1.71.1"
 
 [dependencies]
 async-trait = "0.1.48"

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs"
 readme = "README.md"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 keywords = ["opentelemetry", "log", "trace", "user_events"]
 license = "Apache-2.0"
 

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/scripts/msrv.sh
+++ b/scripts/msrv.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Mostly copied from https://github.com/open-telemetry/opentelemetry-rust/blob/main/scripts/msrv.sh
+
+set -eu
+
+# function to check if specified toolchain is installed
+check_rust_toolchain_installed() {
+  local version=$1
+  if ! rustup toolchain list | grep -q "$version"; then
+    echo "Rust toolchain $version is not installed. Please install it using 'rustup toolchain install $version'."
+    exit 1
+  fi
+}
+
+# Check if a version is specified as parameter
+if [ $# -eq 0 ]; then
+  echo "No Rust version specified. Usage: $0 <rust-version>"
+  exit 1
+fi
+
+RUST_VERSION=$1
+
+# Determine the directory containing the script
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+
+# Path to the configuration file
+CONFIG_FILE="$SCRIPT_DIR/msrv_config.json"
+
+# check if specified toolchain is installed
+check_rust_toolchain_installed "$RUST_VERSION"
+
+# Extract the exact installed rust version string
+installed_version=$(rustup toolchain list | grep "$RUST_VERSION" | awk '{print $1}')
+
+# Read the configuration file and get the packages for the specified version
+if [ -f "$CONFIG_FILE" ]; then
+  packages=$(jq -r --arg version "$RUST_VERSION" '.[$version] | .[]' "$CONFIG_FILE" | tr '\n' ' ')
+  if [ -z "$packages" ]; then
+    echo "No packages found for Rust version $RUST_VERSION in the configuration file."
+    exit 1
+  fi
+else
+  echo "Configuration file $CONFIG_FILE not found."
+  exit 1
+fi
+
+# Check MSRV for the packages
+for package in $packages; do
+  package=$(echo "$package" | tr -d '\r\n') # Remove any newline and carriage return characters
+  echo "Verifying MSRV version $installed_version for $package"
+  rustup run "$installed_version" cargo msrv verify --path "$package" --output-format json
+done

--- a/scripts/msrv.sh
+++ b/scripts/msrv.sh
@@ -49,4 +49,5 @@ for package in $packages; do
   package=$(echo "$package" | tr -d '\r\n') # Remove any newline and carriage return characters
   echo "Verifying MSRV version $installed_version for $package"
   rustup run "$installed_version" cargo msrv verify --path "$package" --output-format json
+  echo "" # just for nicer separation between packages
 done

--- a/scripts/msrv_config.json
+++ b/scripts/msrv_config.json
@@ -1,0 +1,16 @@
+{
+  "1.70.0": [
+    "opentelemetry-aws",
+    "opentelemetry-contrib",
+    "opentelemetry-datadog",
+    "opentelemetry-etw-logs",
+    "opentelemetry-resource-detectors",
+    "opentelemetry-user-events-logs"
+  ],
+  "1.71.1": [
+    "opentelemetry-etw-metrics",
+    "opentelemetry-stackdriver",
+    "opentelemetry-user-events-metrics",
+    "opentelemetry-zpages"
+  ]
+}

--- a/scripts/msrv_config.json
+++ b/scripts/msrv_config.json
@@ -1,15 +1,18 @@
 {
-  "1.70.0": [
+  "//": [
+    "setting the version to 1.71.1 for all packages is temporary,",
+    "because cargo-msrv doesn't work with Rust <1.71",
+    "and the next OTel version will raise MSRV to 1.75.0 anyway"
+  ],
+  "1.71.1": [
     "opentelemetry-aws",
     "opentelemetry-contrib",
     "opentelemetry-datadog",
     "opentelemetry-etw-logs",
-    "opentelemetry-resource-detectors",
-    "opentelemetry-user-events-logs"
-  ],
-  "1.71.1": [
     "opentelemetry-etw-metrics",
+    "opentelemetry-resource-detectors",
     "opentelemetry-stackdriver",
+    "opentelemetry-user-events-logs",
     "opentelemetry-user-events-metrics",
     "opentelemetry-zpages"
   ]

--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -6,3 +6,4 @@ function patch_version() {
   cargo update -p $1:$latest_version --precise $2
 }
 
+patch_version home 0.5.5

--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -6,4 +6,5 @@ function patch_version() {
   cargo update -p $1:$latest_version --precise $2
 }
 
-patch_version home 0.5.5
+patch_version home 0.5.5 # for opentelemetry-stackdriver
+patch_version url 2.4.1 # for opentelemetry-datadog


### PR DESCRIPTION
## Changes

- Most of the MSRVs were not adjusted with the recent update to OTel 0.27 version (fixed that)
- Also added back the MSRV CI job and migrated to a very similar approach like `opentelemetry-rust`, just using `cargo-msrv` instead to verify it
- I had to set `1.71.1` in the CI job for all the packages, because `cargo-msrv` doesn't work with Rust <1.71 (also added a comment in the config file), but that doesn't matter much since the next OTel version will raise the MSRV to 1.75 anyway
- Also had to patch two dependencies otherwise it wouldn't work for that specific version

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
