### PR TITLE
Replace once_cell with OnceLock

### DIFF
--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -25,7 +25,6 @@ detector-aws-lambda = ["dep:opentelemetry-semantic-conventions"]
 internal-logs = ["tracing"]
 
 [dependencies]
-once_cell = "1.12"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -34,7 +34,6 @@ async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
 futures-core = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }
-once_cell = "1.17.1"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }

--- a/opentelemetry-contrib/src/trace/tracer_source.rs
+++ b/opentelemetry-contrib/src/trace/tracer_source.rs
@@ -1,7 +1,7 @@
 //! Abstracts away details for acquiring a `Tracer` by instrumented libraries.
-use once_cell::sync::OnceCell;
 use opentelemetry::global::BoxedTracer;
 use std::fmt::Debug;
+use std::sync::OnceLock;
 
 /// Holds either a borrowed `BoxedTracer` or a factory that can produce one when
 /// and if needed.
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub struct TracerSource<'a> {
     variant: Variant<'a>,
-    tracer: OnceCell<BoxedTracer>,
+    tracer: OnceLock<BoxedTracer>,
 }
 
 enum Variant<'a> {
@@ -24,7 +24,7 @@ impl<'a> TracerSource<'a> {
     pub fn borrowed(tracer: &'a BoxedTracer) -> Self {
         Self {
             variant: Variant::Borrowed(tracer),
-            tracer: OnceCell::new(),
+            tracer: OnceLock::new(),
         }
     }
 
@@ -33,7 +33,7 @@ impl<'a> TracerSource<'a> {
     pub fn lazy(factory: &'a dyn Fn() -> BoxedTracer) -> Self {
         Self {
             variant: Variant::Lazy(factory),
-            tracer: OnceCell::new(),
+            tracer: OnceLock::new(),
         }
     }
 

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -26,7 +26,6 @@ intern-std = []
 
 [dependencies]
 indexmap = "2.0"
-once_cell = "1.12"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["trace"] }
 opentelemetry-http = { workspace = true }

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -21,7 +21,6 @@ prost = "0.13"
 prost-types = "0.13"
 thiserror = "1.0.30"
 tonic = { version = "0.12", default-features = false, features = ["channel", "codegen", "gzip", "prost", "tls"] }
-once_cell = { version = "1.19", optional = true }
 tracing = { version = "0.1", optional = true }
 
 # Futures
@@ -34,7 +33,7 @@ default = ["gcp-authorizer", "tls-native-roots", "internal-logs"]
 gcp-authorizer = ["dep:gcp_auth"]
 tls-native-roots = ["tonic/tls-roots"]
 tls-webpki-roots = ["tonic/tls-webpki-roots"]
-propagator = ["once_cell"]
+propagator = []
 internal-logs = ["tracing"]
 
 [dev-dependencies]


### PR DESCRIPTION
## Changes

- Since the MSRV will become 1.70+ via #150 there is no need for `once_cell` anymore
- The implementation is identical to the OTel one
https://github.com/open-telemetry/opentelemetry-rust/blob/b53c19e2e6c4f8f18d2427c40556b2d0b574aa50/opentelemetry-sdk/src/propagation/trace_context.rs#L18-L23
-  I also renamed the header fields static to `TRACE_CONTEXT_HEADER_FIELDS` to keep identical through out the different packages (they are not public so no harm here)

Do you want me to add it to the changelog or not worth it? No user-facing changes 🙂  

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
