### PR TITLE
Bump thiserror to v2

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump thiserror to 2.0
+
 ## v0.15.0
 
 ### Changed

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -35,7 +35,7 @@ rmp = "0.8"
 url = "2.2"
 reqwest = { version = "0.12", default-features = false, optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
-thiserror = "1.0"
+thiserror = "2.0"
 http = "1"
 futures-core = "0.3"
 ryu = "1"

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Remove `server` feature from tonic dependency
+- Bump thiserror to 2.0
 
 ## v0.24.0
 

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -19,7 +19,7 @@ opentelemetry_sdk = { workspace = true, features = ["trace"] }
 opentelemetry-semantic-conventions = { workspace = true}
 prost = "0.13"
 prost-types = "0.13"
-thiserror = "1.0.30"
+thiserror = "2.0"
 tonic = { version = "0.12", default-features = false, features = ["channel", "codegen", "gzip", "prost", "tls"] }
 once_cell = { version = "1.19", optional = true }
 tracing = { version = "0.1", optional = true }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

- no relevant breaking changes in `thiserror` v2

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
