### PR TITLE
Replace global::shutdown_tracer_provider with tracer_provider.shutdown()

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Bump thiserror to 2.0
+- [Breaking] Replace `opentelemetry::global::shutdown_tracer_provider()` with `tracer_provider.shutdown()` (original PR [opentelemetry-rust#2369](https://github.com/open-telemetry/opentelemetry-rust/pull/2369))
 
 ## v0.15.0
 

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    global::{self, shutdown_tracer_provider},
+    global,
     trace::{SamplingResult, Span, TraceContextExt, Tracer},
     Key, KeyValue, Value,
 };
@@ -57,7 +57,7 @@ impl ShouldSample for AgentBasedSampler {
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     #[allow(deprecated)]
-    let tracer = new_pipeline()
+    let (tracer, provider) = new_pipeline()
         .with_service_name("agent-sampling-demo")
         .with_api_version(ApiVersion::Version05)
         .with_trace_config(
@@ -88,7 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         thread::sleep(Duration::from_millis(6));
     });
 
-    shutdown_tracer_provider();
+    provider.shutdown()?;
 
     Ok(())
 }

--- a/opentelemetry-datadog/examples/datadog.rs
+++ b/opentelemetry-datadog/examples/datadog.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    global::{self, shutdown_tracer_provider},
+    global,
     trace::{Span, TraceContextExt, Tracer},
     Key, KeyValue, Value,
 };
@@ -23,7 +23,7 @@ fn bar() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let tracer = new_pipeline()
+    let (tracer, provider) = new_pipeline()
         .with_service_name("trace-demo")
         .with_api_version(ApiVersion::Version05)
         .install_simple()?;
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         thread::sleep(Duration::from_millis(6));
     });
 
-    shutdown_tracer_provider();
+    provider.shutdown()?;
 
     Ok(())
 }

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -283,7 +283,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Install the Datadog trace exporter pipeline using a simple span processor.
-    pub fn install_simple(mut self) -> Result<Tracer, TraceError> {
+    pub fn install_simple(mut self) -> Result<(Tracer, TracerProvider), TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
         let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
@@ -295,13 +295,16 @@ impl DatadogPipelineBuilder {
             .with_attributes(None)
             .build();
         let tracer = provider.tracer_with_scope(scope);
-        let _ = global::set_tracer_provider(provider);
-        Ok(tracer)
+        let _ = global::set_tracer_provider(provider.clone());
+        Ok((tracer, provider))
     }
 
     /// Install the Datadog trace exporter pipeline using a batch span processor with the specified
     /// runtime.
-    pub fn install_batch<R: RuntimeChannel>(mut self, runtime: R) -> Result<Tracer, TraceError> {
+    pub fn install_batch<R: RuntimeChannel>(
+        mut self,
+        runtime: R,
+    ) -> Result<(Tracer, TracerProvider), TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
         let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
@@ -313,8 +316,8 @@ impl DatadogPipelineBuilder {
             .with_attributes(None)
             .build();
         let tracer = provider.tracer_with_scope(scope);
-        let _ = global::set_tracer_provider(provider);
-        Ok(tracer)
+        let _ = global::set_tracer_provider(provider.clone());
+        Ok((tracer, provider))
     }
 
     /// Assign the service name under which to group traces

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -83,7 +83,6 @@
 //! use opentelemetry::{KeyValue, trace::Tracer};
 //! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry_sdk::export::trace::ExportResult;
-//! use opentelemetry::global::shutdown_tracer_provider;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
 //! use opentelemetry_http::{HttpClient, HttpError};
 //! use async_trait::async_trait;
@@ -115,7 +114,8 @@
 //! }
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {
-//!     let tracer = new_pipeline()
+//!     #[allow(deprecated)]
+//!     let (tracer, provider) = new_pipeline()
 //!         .with_service_name("my_app")
 //!         .with_api_version(ApiVersion::Version05)
 //!         .with_agent_endpoint("http://localhost:8126")
@@ -130,7 +130,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     shutdown_tracer_provider(); // sending remaining spans before exit
+//!     provider.shutdown()?; // sending remaining spans before exit
 //!
 //!     Ok(())
 //! }


### PR DESCRIPTION
## Changes

- Relates to open-telemetry/opentelemetry-rust#2369
- I implemented it identical to the Zipkin Exporter

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
