### PR TITLE
Remove global set_tracer_provider from trace pipelines

### DIFF
--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -4,7 +4,7 @@ use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use opentelemetry::{
     global,
     propagation::TextMapPropagator,
-    trace::{SpanKind, TraceContextExt, Tracer},
+    trace::{SpanKind, TraceContextExt, TraceError, Tracer},
     Context, KeyValue,
 };
 use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
@@ -12,21 +12,20 @@ use opentelemetry_http::{Bytes, HeaderExtractor, HeaderInjector};
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
 use opentelemetry_stdout::SpanExporter;
 
-fn init_tracer() {
+fn init_traces() -> Result<TracerProvider, TraceError> {
     global::set_text_map_propagator(TraceContextPropagator::new());
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = TracerProvider::builder()
+    Ok(TracerProvider::builder()
         .with_simple_exporter(SpanExporter::default())
-        .build();
-
-    global::set_tracer_provider(provider);
+        .build())
 }
 
 #[tokio::main]
-async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    init_tracer();
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let tracer_provider = init_traces()?;
+    global::set_tracer_provider(tracer_provider.clone());
 
     let client = Client::builder(TokioExecutor::new()).build_http();
     let tracer = global::tracer("example/client");
@@ -67,6 +66,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
             KeyValue::new("child_sampled", response_span.span_context().is_sampled()),
         ],
     );
+
+    tracer_provider.shutdown()?;
 
     Ok(())
 }

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- [Breaking] `JaegerJsonExporter::install_batch()` now returns `Tracer` and `TracerProvider`.
+- [Breaking] `JaegerJsonExporter::install_batch()` now returns `TracerProvider`.
   Additionally, global tracer provider now needs to be set by the user by calling `global::set_tracer_provider(tracer_provider.clone())` (original PR [opentelemetry-rust#1812](https://github.com/open-telemetry/opentelemetry-rust/pull/1812))
 
 ## v0.19.0

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- [Breaking] `JaegerJsonExporter::install_batch()` now returns `Tracer` and `TracerProvider`.
+  Additionally, global tracer provider now needs to be set by the user by calling `global::set_tracer_provider(tracer_provider.clone())` (original PR [opentelemetry-rust#1812](https://github.com/open-telemetry/opentelemetry-rust/pull/1812))
+
 ## v0.19.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.27

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -23,7 +23,7 @@ api = []
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-jaeger_json_exporter = ["opentelemetry_sdk", "serde_json", "futures-core", "futures-util", "async-trait", "opentelemetry-semantic-conventions"]
+jaeger_json_exporter = ["opentelemetry_sdk", "serde_json", "futures-core", "futures-util", "async-trait"]
 rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
@@ -36,7 +36,6 @@ futures-core = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-opentelemetry-semantic-conventions = { workspace = true, optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
 

--- a/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
+++ b/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
@@ -49,7 +49,7 @@ impl<R: JaegerJsonRuntime> JaegerJsonExporter<R> {
     }
 
     /// Install the exporter using the internal provided runtime
-    pub fn install_batch(self) -> Tracer {
+    pub fn install_batch(self) -> (Tracer, TracerProvider) {
         let runtime = self.runtime.clone();
         let provider_builder = TracerProvider::builder().with_batch_exporter(self, runtime);
         let provider = provider_builder.build();
@@ -58,9 +58,8 @@ impl<R: JaegerJsonRuntime> JaegerJsonExporter<R> {
             .with_schema_url(SCHEMA_URL)
             .build();
         let tracer = provider.tracer_with_scope(scope);
-        let _ = opentelemetry::global::set_tracer_provider(provider);
 
-        tracer
+        (tracer, provider)
     }
 }
 

--- a/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
+++ b/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
@@ -11,14 +11,11 @@ use opentelemetry::trace::SpanId;
     feature = "rt-tokio-current-thread"
 ))]
 use opentelemetry::trace::TraceError;
-use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
     runtime::RuntimeChannel,
-    trace::{Tracer, TracerProvider},
+    trace::TracerProvider,
 };
-use opentelemetry_semantic_conventions::SCHEMA_URL;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -49,17 +46,11 @@ impl<R: JaegerJsonRuntime> JaegerJsonExporter<R> {
     }
 
     /// Install the exporter using the internal provided runtime
-    pub fn install_batch(self) -> (Tracer, TracerProvider) {
+    pub fn install_batch(self) -> TracerProvider {
         let runtime = self.runtime.clone();
-        let provider_builder = TracerProvider::builder().with_batch_exporter(self, runtime);
-        let provider = provider_builder.build();
-        let scope = InstrumentationScope::builder("opentelemetry")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .with_schema_url(SCHEMA_URL)
-            .build();
-        let tracer = provider.tracer_with_scope(scope);
-
-        (tracer, provider)
+        TracerProvider::builder()
+            .with_batch_exporter(self, runtime)
+            .build()
     }
 }
 

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Bump thiserror to 2.0
 - [Breaking] Replace `opentelemetry::global::shutdown_tracer_provider()` with `tracer_provider.shutdown()` (original PR [opentelemetry-rust#2369](https://github.com/open-telemetry/opentelemetry-rust/pull/2369))
+- [Breaking] `DatadogPipelineBuilder::install_simple()` and `DatadogPipelineBuilder::install_batch()` now return `Tracer` and `TracerProvider`.
+  Additionally, global tracer provider now needs to be set by the user by calling `global::set_tracer_provider(tracer_provider.clone())` (original PR [opentelemetry-rust#1812](https://github.com/open-telemetry/opentelemetry-rust/pull/1812))
 
 ## v0.15.0
 

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump thiserror to 2.0
 - [Breaking] Replace `opentelemetry::global::shutdown_tracer_provider()` with `tracer_provider.shutdown()` (original PR [opentelemetry-rust#2369](https://github.com/open-telemetry/opentelemetry-rust/pull/2369))
-- [Breaking] `DatadogPipelineBuilder::install_simple()` and `DatadogPipelineBuilder::install_batch()` now return `Tracer` and `TracerProvider`.
+- [Breaking] `DatadogPipelineBuilder::install_simple()` and `DatadogPipelineBuilder::install_batch()` now return `TracerProvider`.
   Additionally, global tracer provider now needs to be set by the user by calling `global::set_tracer_provider(tracer_provider.clone())` (original PR [opentelemetry-rust#1812](https://github.com/open-telemetry/opentelemetry-rust/pull/1812))
 
 ## v0.15.0

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         )
         .install_simple()?;
     global::set_tracer_provider(provider.clone());
-    let scope = InstrumentationScope::builder("opentelemetry-datadog")
+    let scope = InstrumentationScope::builder("opentelemetry-datadog-demo")
         .with_version(env!("CARGO_PKG_VERSION"))
         .with_schema_url(semcov::SCHEMA_URL)
         .with_attributes(None)

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -66,6 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
                 .with_id_generator(RandomIdGenerator::default()),
         )
         .install_simple()?;
+    global::set_tracer_provider(provider.clone());
 
     tracer.in_span("foo", |cx| {
         let span = cx.span();

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -1,10 +1,11 @@
 use opentelemetry::{
     global,
-    trace::{SamplingResult, Span, TraceContextExt, Tracer},
-    Key, KeyValue, Value,
+    trace::{SamplingResult, Span, TraceContextExt, Tracer, TracerProvider},
+    InstrumentationScope, Key, KeyValue, Value,
 };
 use opentelemetry_datadog::{new_pipeline, ApiVersion, DatadogTraceStateBuilder};
 use opentelemetry_sdk::trace::{self, RandomIdGenerator, ShouldSample};
+use opentelemetry_semantic_conventions as semcov;
 use std::thread;
 use std::time::Duration;
 
@@ -57,7 +58,7 @@ impl ShouldSample for AgentBasedSampler {
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     #[allow(deprecated)]
-    let (tracer, provider) = new_pipeline()
+    let provider = new_pipeline()
         .with_service_name("agent-sampling-demo")
         .with_api_version(ApiVersion::Version05)
         .with_trace_config(
@@ -67,6 +68,12 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         )
         .install_simple()?;
     global::set_tracer_provider(provider.clone());
+    let scope = InstrumentationScope::builder("opentelemetry-datadog")
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_schema_url(semcov::SCHEMA_URL)
+        .with_attributes(None)
+        .build();
+    let tracer = provider.tracer_with_scope(scope);
 
     tracer.in_span("foo", |cx| {
         let span = cx.span();

--- a/opentelemetry-datadog/examples/datadog.rs
+++ b/opentelemetry-datadog/examples/datadog.rs
@@ -1,9 +1,10 @@
 use opentelemetry::{
     global,
-    trace::{Span, TraceContextExt, Tracer},
-    Key, KeyValue, Value,
+    trace::{Span, TraceContextExt, Tracer, TracerProvider},
+    InstrumentationScope, Key, KeyValue, Value,
 };
 use opentelemetry_datadog::{new_pipeline, ApiVersion};
+use opentelemetry_semantic_conventions as semcov;
 use std::thread;
 use std::time::Duration;
 
@@ -23,11 +24,17 @@ fn bar() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (tracer, provider) = new_pipeline()
+    let provider = new_pipeline()
         .with_service_name("trace-demo")
         .with_api_version(ApiVersion::Version05)
         .install_simple()?;
     global::set_tracer_provider(provider.clone());
+    let scope = InstrumentationScope::builder("opentelemetry-datadog")
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_schema_url(semcov::SCHEMA_URL)
+        .with_attributes(None)
+        .build();
+    let tracer = provider.tracer_with_scope(scope);
 
     tracer.in_span("foo", |cx| {
         let span = cx.span();

--- a/opentelemetry-datadog/examples/datadog.rs
+++ b/opentelemetry-datadog/examples/datadog.rs
@@ -27,6 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .with_service_name("trace-demo")
         .with_api_version(ApiVersion::Version05)
         .install_simple()?;
+    global::set_tracer_provider(provider.clone());
 
     tracer.in_span("foo", |cx| {
         let span = cx.span();

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -4,19 +4,17 @@ mod model;
 pub use model::ApiVersion;
 pub use model::Error;
 pub use model::FieldMappingFn;
-use opentelemetry::InstrumentationScope;
 
 use crate::exporter::model::FieldMapping;
 use futures_core::future::BoxFuture;
 use http::{Method, Request, Uri};
-use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{trace::TraceError, KeyValue};
 use opentelemetry_http::{HttpClient, ResponseExt};
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
     resource::{ResourceDetector, SdkProvidedResourceDetector},
     runtime::RuntimeChannel,
-    trace::{Config, Tracer, TracerProvider},
+    trace::{Config, TracerProvider},
     Resource,
 };
 use opentelemetry_semantic_conventions as semcov;
@@ -283,20 +281,13 @@ impl DatadogPipelineBuilder {
     }
 
     /// Install the Datadog trace exporter pipeline using a simple span processor.
-    pub fn install_simple(mut self) -> Result<(Tracer, TracerProvider), TraceError> {
+    pub fn install_simple(mut self) -> Result<TracerProvider, TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
-        let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
-        provider_builder = provider_builder.with_resource(config.resource.into_owned());
-        let provider = provider_builder.build();
-        let scope = InstrumentationScope::builder("opentelemetry-datadog")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .with_schema_url(semcov::SCHEMA_URL)
-            .with_attributes(None)
-            .build();
-        let tracer = provider.tracer_with_scope(scope);
-
-        Ok((tracer, provider))
+        Ok(TracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .with_resource(config.resource.into_owned())
+            .build())
     }
 
     /// Install the Datadog trace exporter pipeline using a batch span processor with the specified
@@ -304,20 +295,13 @@ impl DatadogPipelineBuilder {
     pub fn install_batch<R: RuntimeChannel>(
         mut self,
         runtime: R,
-    ) -> Result<(Tracer, TracerProvider), TraceError> {
+    ) -> Result<TracerProvider, TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
-        let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
-        provider_builder = provider_builder.with_resource(config.resource.into_owned());
-        let provider = provider_builder.build();
-        let scope = InstrumentationScope::builder("opentelemetry-datadog")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .with_schema_url(semcov::SCHEMA_URL)
-            .with_attributes(None)
-            .build();
-        let tracer = provider.tracer_with_scope(scope);
-
-        Ok((tracer, provider))
+        Ok(TracerProvider::builder()
+            .with_batch_exporter(exporter, runtime)
+            .with_resource(config.resource.into_owned())
+            .build())
     }
 
     /// Assign the service name under which to group traces

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -10,7 +10,7 @@ use crate::exporter::model::FieldMapping;
 use futures_core::future::BoxFuture;
 use http::{Method, Request, Uri};
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::{global, trace::TraceError, KeyValue};
+use opentelemetry::{trace::TraceError, KeyValue};
 use opentelemetry_http::{HttpClient, ResponseExt};
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
@@ -295,7 +295,7 @@ impl DatadogPipelineBuilder {
             .with_attributes(None)
             .build();
         let tracer = provider.tracer_with_scope(scope);
-        let _ = global::set_tracer_provider(provider.clone());
+
         Ok((tracer, provider))
     }
 
@@ -316,7 +316,7 @@ impl DatadogPipelineBuilder {
             .with_attributes(None)
             .build();
         let tracer = provider.tracer_with_scope(scope);
-        let _ = global::set_tracer_provider(provider.clone());
+
         Ok((tracer, provider))
     }
 

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -48,7 +48,7 @@ static DD_MEASURED_KEY: &str = "_dd.measured";
 /// use opentelemetry_datadog::{ApiVersion, new_pipeline};
 ///
 /// fn main() -> Result<(), opentelemetry::trace::TraceError> {
-///     let (tracer, provider) = new_pipeline()
+///     let provider = new_pipeline()
 ///         .with_service_name("my_app")
 ///         .with_api_version(ApiVersion::Version05)
 ///         // the custom mapping below will change the all spans' name to datadog spans
@@ -56,6 +56,7 @@ static DD_MEASURED_KEY: &str = "_dd.measured";
 ///         .with_agent_endpoint("http://localhost:8126")
 ///         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 ///     global::set_tracer_provider(provider.clone());
+///     let tracer = global::tracer("opentelemetry-datadog");
 ///
 ///     Ok(())
 /// }

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -56,7 +56,7 @@ static DD_MEASURED_KEY: &str = "_dd.measured";
 ///         .with_agent_endpoint("http://localhost:8126")
 ///         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 ///     global::set_tracer_provider(provider.clone());
-///     let tracer = global::tracer("opentelemetry-datadog");
+///     let tracer = global::tracer("opentelemetry-datadog-demo");
 ///
 ///     Ok(())
 /// }

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -44,19 +44,20 @@ static DD_MEASURED_KEY: &str = "_dd.measured";
 ///
 /// For example,
 /// ```no_run
+/// use opentelemetry::global;
 /// use opentelemetry_datadog::{ApiVersion, new_pipeline};
-/// fn main() -> Result<(), opentelemetry::trace::TraceError> {
-///    let tracer = new_pipeline()
-///            .with_service_name("my_app")
-///            .with_api_version(ApiVersion::Version05)
-///            // the custom mapping below will change the all spans' name to datadog spans
-///            .with_name_mapping(|span, model_config|{
-///                 "datadog spans"
-///             })
-///            .with_agent_endpoint("http://localhost:8126")
-///            .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 ///
-///    Ok(())
+/// fn main() -> Result<(), opentelemetry::trace::TraceError> {
+///     let (tracer, provider) = new_pipeline()
+///         .with_service_name("my_app")
+///         .with_api_version(ApiVersion::Version05)
+///         // the custom mapping below will change the all spans' name to datadog spans
+///         .with_name_mapping(|span, model_config|{"datadog spans"})
+///         .with_agent_endpoint("http://localhost:8126")
+///         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+///     global::set_tracer_provider(provider.clone());
+///
+///     Ok(())
 /// }
 /// ```
 pub type FieldMappingFn = dyn for<'a> Fn(&'a SpanData, &'a ModelConfig) -> &'a str + Send + Sync;

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! ```no_run
 //! # fn main() -> Result<(), opentelemetry::trace::TraceError> {
-//! let tracer = opentelemetry_datadog::new_pipeline()
+//! let (tracer, provider) = opentelemetry_datadog::new_pipeline()
 //!     .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //! # Ok(())
 //! # }
@@ -80,7 +80,7 @@
 //! [`DatadogPipelineBuilder`]: struct.DatadogPipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::{KeyValue, trace::Tracer};
+//! use opentelemetry::{global, KeyValue, trace::Tracer};
 //! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry_sdk::export::trace::ExportResult;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
@@ -125,6 +125,7 @@
 //!                 .with_id_generator(RandomIdGenerator::default())
 //!         )
 //!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+//!     global::set_tracer_provider(provider.clone());
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! ```no_run
 //! # fn main() -> Result<(), opentelemetry::trace::TraceError> {
-//! let (tracer, provider) = opentelemetry_datadog::new_pipeline()
+//! let provider = opentelemetry_datadog::new_pipeline()
 //!     .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //! # Ok(())
 //! # }
@@ -80,11 +80,12 @@
 //! [`DatadogPipelineBuilder`]: struct.DatadogPipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::{global, KeyValue, trace::Tracer};
+//! use opentelemetry::{global, KeyValue, trace::{Tracer, TracerProvider}, InstrumentationScope};
 //! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry_sdk::export::trace::ExportResult;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
 //! use opentelemetry_http::{HttpClient, HttpError};
+//! use opentelemetry_semantic_conventions as semcov;
 //! use async_trait::async_trait;
 //! use bytes::Bytes;
 //! use futures_util::io::AsyncReadExt as _;
@@ -115,7 +116,7 @@
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //!     #[allow(deprecated)]
-//!     let (tracer, provider) = new_pipeline()
+//!     let provider = new_pipeline()
 //!         .with_service_name("my_app")
 //!         .with_api_version(ApiVersion::Version05)
 //!         .with_agent_endpoint("http://localhost:8126")
@@ -126,6 +127,13 @@
 //!         )
 //!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //!     global::set_tracer_provider(provider.clone());
+//!
+//!     let scope = InstrumentationScope::builder("opentelemetry-datadog")
+//!         .with_version(env!("CARGO_PKG_VERSION"))
+//!         .with_schema_url(semcov::SCHEMA_URL)
+//!         .with_attributes(None)
+//!         .build();
+//!     let tracer = provider.tracer_with_scope(scope);
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...


### PR DESCRIPTION
## Changes

- Follow-up to https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/155/files/1f8b9f034b76adec7a69a30c3afc91b7f2d3e449#r1924545070
- Also adjusted all the examples I could find

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
