### PR TITLE
Enable Internal log in userevents and etw metrics

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -33,6 +33,7 @@
         "codecov",
         "deque",
         "Dirkjan",
+        "errno",
         "hasher",
         "isahc",
         "Isobel",
@@ -51,6 +52,7 @@
         "reqwest",
         "rustc",
         "Tescher",
+        "tracepoint",
         "Zhongyang",
         "zipkin"
     ],

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75.0"
 
 [dependencies]
 opentelemetry = { workspace = true, features = ["metrics"] }
-opentelemetry_sdk = { workspace = true, features = ["metrics", "rt-tokio"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
 async-trait = "0.1"
 prost = "0.13"
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = ["full"] }
 criterion = { workspace = true, features = ["html_reports"] }
 
 [features]
-internal-logs = ["tracing"]
+internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
 default = ["internal-logs"]
 
 [package.metadata.cargo-machete]

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75.0"
 
 [dependencies]
 opentelemetry = { workspace = true, features = ["metrics"] }
-opentelemetry_sdk = { workspace = true, features = ["metrics", "rt-tokio"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
 eventheader = { version = "= 0.4.0" }
 async-trait = "0.1"
@@ -21,9 +21,10 @@ tracing = {version = "0.1", optional = true}
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "std", "fmt"] }
 
 [features]
-internal-logs = ["tracing"]
+internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
 default = ["internal-logs"]
 
 [package.metadata.cargo-machete]

--- a/opentelemetry-user-events-metrics/examples/basic-metrics.rs
+++ b/opentelemetry-user-events-metrics/examples/basic-metrics.rs
@@ -5,6 +5,7 @@ use opentelemetry_sdk::{
     Resource,
 };
 use opentelemetry_user_events_metrics::MetricsExporter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use std::thread;
 use std::time::Duration;
 
@@ -23,6 +24,18 @@ fn init_metrics(exporter: MetricsExporter) -> SdkMeterProvider {
 #[tokio::main]
 #[allow(unused_must_use)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a new tracing::Fmt layer to print the logs to stdout. It has a
+    // default filter of `info` level and above, and `debug` and above for logs
+    // from OpenTelemetry crates. The filter levels can be customized as needed.
+    let filter_fmt = EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap());
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_thread_names(true)
+        .with_filter(filter_fmt);
+
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .init();
+
     let exporter = opentelemetry_user_events_metrics::MetricsExporter::new();
     let meter_provider = init_metrics(exporter);
 

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -116,8 +116,7 @@ impl PushMetricExporter for MetricsExporter {
             otel_warn!(name: "TracepointDisabled", message = "Tracepoint is disabled, skipping export");
             return Ok(());
         }
-
-        if self.trace_point.enabled() {
+        else {
             let mut errors = Vec::new();
 
             for scope_metric in &metrics.scope_metrics {
@@ -466,7 +465,7 @@ impl PushMetricExporter for MetricsExporter {
     }
 
     fn shutdown(&self) -> OTelSdkResult {
-        // TracepointState automatically unregisters when dropped
+        // TracepointState automatically deregisters when dropped
         // https://github.com/microsoft/LinuxTracepoints-Rust/blob/main/eventheader/src/native.rs#L618
         Ok(())
     }

--- a/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
+++ b/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
@@ -91,13 +91,11 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
     match result {
         Ok(value) => {
             if value == 0 {
-                // Temporary print as a measure for quick testing
-                // will be replaced with proper logging mechanism
                 otel_info!(name: "TracePointRegistered", reason = "Tracepoint registered successfully.");
             } else if value == 95 {
-                otel_error!(name: "TracePointRegisterError", reason = "Trace/debug file systems are not mounted.");
+                otel_error!(name: "TracePointRegisterError", reason = "Trace/debug file systems are not mounted. Metrics will not be exported.");
             } else if value == 13 {
-                otel_error!(name: "TracePointRegisterError", reason = "Insufficient permissions. You need read/write/execute permissions to user_events tracing directory.");
+                otel_error!(name: "TracePointRegisterError", reason = "Insufficient permissions. You need read/write/execute permissions to user_events tracing directory. Metrics will not be exported.");
             }
             value
         }
@@ -105,7 +103,7 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
         Err(err) => {
             otel_error!(
                 name: "TracePointRegisterError",
-                reason = "Tracepoint failed to register.",
+                reason = "Tracepoint failed to register. Metrics will not be exported.",
                 error = format!("{:?}", err)
             );
             -1


### PR DESCRIPTION
Enabled internal logs. This was disabled as workspace has disabled default-features in opentelemetry and sdk crates.
Nit fixes.
Modify examples to show how to view internal logs