### PR TITLE
leverage native async trait in JaegerJsonRuntime and GcpAuthorizer

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -23,14 +23,13 @@ api = []
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-jaeger_json_exporter = ["opentelemetry_sdk", "serde_json", "futures-core", "futures-util", "async-trait"]
+jaeger_json_exporter = ["opentelemetry_sdk", "serde_json", "futures-core", "futures-util"]
 rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
 
 [dependencies]
 async-std = { version = "1.10", optional = true }
-async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.22", optional = true }
 futures-core = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }

--- a/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
+++ b/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
@@ -4,6 +4,7 @@
 use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use opentelemetry::trace::SpanId;
+#[allow(unused_imports)]
 use opentelemetry_sdk::error::OTelSdkError;
 use opentelemetry_sdk::runtime::RuntimeChannel;
 use opentelemetry_sdk::{

--- a/opentelemetry-etw-metrics/src/etw/mod.rs
+++ b/opentelemetry-etw-metrics/src/etw/mod.rs
@@ -33,6 +33,7 @@ pub fn register() {
 }
 
 /// Write an event to the ETW provider.
+#[allow(clippy::repr_packed_without_abi)]
 pub fn write(buffer: &[u8]) -> u32 {
     tracelogging::write_event!(
         PROVIDER,

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 ///
 /// This resource detector returns the following information:
 ///
-/// - [`host.id from non-containerized systems`]: https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems
+/// - [`host.id from non-containerized systems`](https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems)
 /// - Host architecture (host.arch).
 pub struct HostResourceDetector {
     host_id_detect: fn() -> Option<String>,

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -10,7 +10,6 @@ exclude = ["/proto"]
 rust-version = "1.75.0"
 
 [dependencies]
-async-trait = "0.1.48"
 gcp_auth = { version = "0.12", optional = true }
 hex = "0.4"
 http = "1"

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -23,7 +23,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use async_trait::async_trait;
 use futures_core::future::BoxFuture;
 use futures_util::stream::StreamExt;
 use opentelemetry::{
@@ -442,7 +441,6 @@ impl GcpAuthorizer {
 }
 
 #[cfg(feature = "gcp-authorizer")]
-#[async_trait]
 impl Authorizer for GcpAuthorizer {
     type Error = Error;
 
@@ -470,16 +468,15 @@ impl Authorizer for GcpAuthorizer {
     }
 }
 
-#[async_trait]
 pub trait Authorizer: Sync + Send + 'static {
     type Error: std::error::Error + fmt::Debug + Send + Sync;
 
     fn project_id(&self) -> &str;
-    async fn authorize<T: Send + Sync>(
+    fn authorize<T: Send + Sync>(
         &self,
         request: &mut Request<T>,
         scopes: &[&str],
-    ) -> Result<(), Self::Error>;
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 impl From<Value> for AttributeValue {


### PR DESCRIPTION
## Changes

- there are still some more `async-trait` usages, but they have to wait till the next OTel SDK release

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
