### PR TITLE
[opentelemetry-user-events-logs] Avoid string allocation when exporting log record attributes

### DIFF
--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -157,18 +157,18 @@ impl UserEventsExporter {
 
     fn add_attribute_to_event(&self, eb: &mut EventBuilder, (key, value): (&Key, &AnyValue)) {
         let field_name = key.as_str();
-        match value.to_owned() {
+        match value {
             AnyValue::Boolean(b) => {
-                eb.add_value(field_name, b, FieldFormat::Boolean, 0);
+                eb.add_value(field_name, *b, FieldFormat::Boolean, 0);
             }
             AnyValue::Int(i) => {
-                eb.add_value(field_name, i, FieldFormat::SignedInt, 0);
+                eb.add_value(field_name, *i, FieldFormat::SignedInt, 0);
             }
             AnyValue::Double(f) => {
-                eb.add_value(field_name, f, FieldFormat::Float, 0);
+                eb.add_value(field_name, *f, FieldFormat::Float, 0);
             }
             AnyValue::String(s) => {
-                eb.add_str(field_name, s.to_string(), FieldFormat::Default, 0);
+                eb.add_str(field_name, s.as_str(), FieldFormat::Default, 0);
             }
             _ => (),
         }


### PR DESCRIPTION
## Changes
- Avoid string allocation when exporting log record attributes

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
