### PR TITLE
ci: add check for workspace lints config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,3 +144,19 @@ jobs:
           tool: cargo-machete
       - name: cargo machete
         run: cargo machete
+  cargo-workspace-lints:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-workspace-lints
+      - name: cargo workspace-lints
+        run: cargo workspace-lints


### PR DESCRIPTION
## Changes

- this checks, if each workspace member has the workspace lints config set, otherwise `clippy --workspace` will ignore it

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
