### PR TITLE
userevent logs - nit fix

### DIFF
--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -310,11 +310,6 @@ impl UserEventsExporter {
             });
             Ok(())
         } else {
-            otel_debug!(
-                name: "UserEvents.EventSetNotEnabled",
-                level = level.as_int()
-            );
-
             // Return success when the event is not enabled
             // as this is not an error condition.
             Ok(())

--- a/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
@@ -26,6 +26,8 @@ impl<T: LogExporter> ReentrantLogProcessor<T> {
 impl<T: LogExporter> opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor<T> {
     fn emit(&self, record: &mut SdkLogRecord, scope: &InstrumentationScope) {
         let log_tuple = &[(record as &SdkLogRecord, scope)];
+        // TODO: Using futures_executor::block_on can make the code non reentrant safe
+        // if that crate starts emitting logs that are bridged to OTel.
         let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
     }
 

--- a/stress/src/user_events.rs
+++ b/stress/src/user_events.rs
@@ -24,6 +24,12 @@
 // Threads: 5 - Average Throughput: TODO
 // Threads: 10 - Average Throughput: 1.7 M iterations/sec
 // Threads: 16 - Average Throughput: TODO
+//
+// Stress Test Results (user_events disabled)
+// Threads: 1 - Average Throughput: TODO
+// Threads: 5 - Average Throughput: TODO
+// Threads: 10 - Average Throughput: 1.1 B iterations/sec
+// Threads: 16 - Average Throughput: TODO
 
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::SdkLoggerProvider;


### PR DESCRIPTION
Remove emitting logs of its own to avoid rentrancy. The exporter is paired with a processor that expects exporter is safe from reentrancy. Exporter should not do any internal logs that can break this contract.