### PR TITLE
chore: Upgrade actix-web-opentelemetry to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ resolver = "2"
 debug = 1
 
 [workspace.dependencies]
-opentelemetry = "0.28"
-opentelemetry-appender-tracing = "0.28"
-opentelemetry-http = "0.28"
-opentelemetry-proto = { version = "0.28", default-features = false }
-opentelemetry_sdk = { version = "0.28", default-features = false }
-opentelemetry-stdout = "0.28"
-opentelemetry-semantic-conventions = { version = "0.28", features = [
+opentelemetry = "0.29"
+opentelemetry-appender-tracing = "0.29"
+opentelemetry-http = "0.29"
+opentelemetry-proto = { version = "0.29", default-features = false }
+opentelemetry_sdk = { version = "0.29", default-features = false }
+opentelemetry-stdout = "0.29"
+opentelemetry-semantic-conventions = { version = "0.29", features = [
     "semconv_experimental",
 ] }
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "actix-web-opentelemetry",
     "opentelemetry-aws",
     "opentelemetry-contrib",
     "opentelemetry-datadog",

--- a/actix-web-opentelemetry/CHANGELOG.md
+++ b/actix-web-opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.22.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.22.0..v0.21.0)
+
+### Changed
+
+* Update opentelemetry packages to 0.29 (#210)
+
 ## [v0.21.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.21.0..v0.20.1)
 
 ### changed

--- a/actix-web-opentelemetry/Cargo.toml
+++ b/actix-web-opentelemetry/Cargo.toml
@@ -66,3 +66,6 @@ opentelemetry-stdout = { workspace = true, features = ["trace", "metrics"] }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/actix-web-opentelemetry/Cargo.toml
+++ b/actix-web-opentelemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "actix-web-opentelemetry"
 version = "0.22.0"
-description = "OpenTelemetry integration for Actix Web apps"
+description = "Deprecated: 0.22.0 is the last release for this crate. Use opentelemetry-instrumentation-actix-web instead"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/actix-web-opentelemetry"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/actix-web-opentelemetry"
 readme = "README.md"
@@ -35,9 +35,7 @@ awc = { version = "3.0", optional = true, default-features = false, features = [
 futures-util = { version = "0.3", default-features = false, features = [
   "alloc",
 ] }
-opentelemetry = { workspace = true, features = [
-  "trace",
-] }
+opentelemetry = { workspace = true, features = ["trace"] }
 opentelemetry-prometheus = { version = "0.29", optional = true }
 opentelemetry-semantic-conventions = { workspace = true, features = [
   "semconv_experimental",

--- a/actix-web-opentelemetry/Cargo.toml
+++ b/actix-web-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-opentelemetry"
-version = "0.21.0"
+version = "0.22.0"
 description = "OpenTelemetry integration for Actix Web apps"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/actix-web-opentelemetry"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/actix-web-opentelemetry"
@@ -35,14 +35,14 @@ awc = { version = "3.0", optional = true, default-features = false, features = [
 futures-util = { version = "0.3", default-features = false, features = [
   "alloc",
 ] }
-opentelemetry = { version = "0.28", default-features = false, features = [
+opentelemetry = { workspace = true, features = [
   "trace",
 ] }
-opentelemetry-prometheus = { version = "0.28", optional = true }
-opentelemetry-semantic-conventions = { version = "0.28", features = [
+opentelemetry-prometheus = { version = "0.29", optional = true }
+opentelemetry-semantic-conventions = { workspace = true, features = [
   "semconv_experimental",
 ] }
-opentelemetry_sdk = { version = "0.28", optional = true, features = [
+opentelemetry_sdk = { workspace = true, optional = true, features = [
   "metrics",
   "rt-tokio-current-thread",
 ] }
@@ -57,13 +57,13 @@ actix-web-opentelemetry = { path = ".", features = [
   "sync-middleware",
   "awc",
 ] }
-opentelemetry_sdk = { version = "0.28", features = [
+opentelemetry_sdk = { workspace = true, features = [
   "spec_unstable_metrics_views",
   "metrics",
   "rt-tokio-current-thread",
 ] }
-opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
-opentelemetry-stdout = { version = "0.28", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-stdout = { workspace = true, features = ["trace", "metrics"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/actix-web-opentelemetry/src/client.rs
+++ b/actix-web-opentelemetry/src/client.rs
@@ -23,9 +23,12 @@ use opentelemetry::{
     trace::{SpanKind, Status, TraceContextExt, Tracer},
     Context, KeyValue,
 };
-use opentelemetry_semantic_conventions::trace::{
-    HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, MESSAGING_MESSAGE_BODY_SIZE, SERVER_ADDRESS,
-    SERVER_PORT, URL_FULL, USER_AGENT_ORIGINAL,
+use opentelemetry_semantic_conventions::{
+    attribute::MESSAGING_MESSAGE_BODY_SIZE,
+    trace::{
+        HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, SERVER_ADDRESS, SERVER_PORT, URL_FULL,
+        USER_AGENT_ORIGINAL,
+    },
 };
 use serde::Serialize;
 use std::mem;

--- a/actix-web-opentelemetry/src/middleware/metrics.rs
+++ b/actix-web-opentelemetry/src/middleware/metrics.rs
@@ -212,7 +212,7 @@ where
             service,
             metrics: self.metrics.clone(),
             route_formatter: self.route_formatter.clone(),
-            metric_attrs_from_req: self.metric_attrs_from_req.clone(),
+            metric_attrs_from_req: self.metric_attrs_from_req,
         };
 
         future::ok(service)

--- a/actix-web-opentelemetry/src/middleware/metrics.rs
+++ b/actix-web-opentelemetry/src/middleware/metrics.rs
@@ -77,12 +77,14 @@ impl Metrics {
     }
 }
 
+type MetricsAttrsFromReqFn = fn(&dev::ServiceRequest, Cow<'static, str>) -> Vec<KeyValue>;
+
 /// Builder for [RequestMetrics]
 #[derive(Clone, Debug, Default)]
 pub struct RequestMetricsBuilder {
     route_formatter: Option<Arc<dyn RouteFormatter + Send + Sync + 'static>>,
     meter: Option<Meter>,
-    metric_attrs_from_req: Option<fn(&dev::ServiceRequest, Cow<'static, str>) -> Vec<KeyValue>>,
+    metric_attrs_from_req: Option<MetricsAttrsFromReqFn>,
 }
 
 impl RequestMetricsBuilder {

--- a/actix-web-opentelemetry/src/util.rs
+++ b/actix-web-opentelemetry/src/util.rs
@@ -4,10 +4,13 @@ use actix_web::{
     http::{Method, Version},
 };
 use opentelemetry::{KeyValue, Value};
-use opentelemetry_semantic_conventions::trace::{
-    CLIENT_ADDRESS, NETWORK_PEER_ADDRESS, MESSAGING_MESSAGE_BODY_SIZE, HTTP_REQUEST_METHOD, HTTP_ROUTE,
-    NETWORK_PROTOCOL_VERSION, SERVER_ADDRESS, SERVER_PORT, URL_PATH, URL_QUERY, URL_SCHEME,
-    USER_AGENT_ORIGINAL,
+use opentelemetry_semantic_conventions::{
+    attribute::MESSAGING_MESSAGE_BODY_SIZE,
+    trace::{
+        CLIENT_ADDRESS, HTTP_REQUEST_METHOD, HTTP_ROUTE, NETWORK_PEER_ADDRESS,
+        NETWORK_PROTOCOL_VERSION, SERVER_ADDRESS, SERVER_PORT, URL_PATH, URL_QUERY, URL_SCHEME,
+        USER_AGENT_ORIGINAL,
+    },
 };
 
 #[cfg(feature = "awc")]

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -23,16 +23,12 @@ api = []
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-jaeger_json_exporter = ["opentelemetry_sdk", "serde_json", "futures-core", "futures-util"]
+jaeger_json_exporter = ["opentelemetry_sdk", "serde_json"]
 rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
-rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
 
 [dependencies]
-async-std = { version = "1.10", optional = true }
 base64 = { version = "0.22", optional = true }
-futures-core = { version = "0.3", optional = true }
-futures-util = { version = "0.3", optional = true, default-features = false }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 serde_json = { version = "1", optional = true }


### PR DESCRIPTION
## Changes

Hi! Moving this PR to this repo. I notice that your current PR to upgrade to 0.29 is still in progress. I can fix the conflicts in this PR after that one is merged in. If you were planning on upgrading this crate yourself, you can feel free to close this PR.

Initial PR: https://github.com/OutThereLabs/actix-web-opentelemetry/pull/192

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
