### PR TITLE
chore(aws): update OpenTelemetry dependencies to 0.29.0

### DIFF
--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.17.0
+
 ### Changed
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29.0
   - Breaking change in the way XrayIdGenerator is configured:

--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+### Changed
+- Bump opentelemetry and opentelemetry_sdk versions to 0.29.0
+  - Updated imports for `TraceError` which moved from `opentelemetry::trace::TraceError` to `opentelemetry_sdk::trace::TraceError`
+  - Fixed issue with moved value in error handling for `TraceStateError`
+  - Updated XrayIdGenerator doctest to use the new API for configuring the IdGenerator
+
 ## v0.16.0
 
 - Bump msrv to 1.75.0

--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -4,9 +4,18 @@
 
 ### Changed
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29.0
-  - Updated imports for `TraceError` which moved from `opentelemetry::trace::TraceError` to `opentelemetry_sdk::trace::TraceError`
-  - Fixed issue with moved value in error handling for `TraceStateError`
-  - Updated XrayIdGenerator doctest to use the new API for configuring the IdGenerator
+  - Breaking change in the way XrayIdGenerator is configured:
+    ```rust
+    // Before
+    SdkTracerProvider::builder()
+        .with_config(trace::config().with_id_generator(XrayIdGenerator::default()))
+        .build();
+    
+    // After
+    SdkTracerProvider::builder()
+        .with_id_generator(XrayIdGenerator::default())
+        .build();
+    ```
 
 ## v0.16.0
 

--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -5,19 +5,19 @@
 ## v0.17.0
 
 ### Changed
-- Bump opentelemetry and opentelemetry_sdk versions to 0.29.0
-  - Breaking change in the way XrayIdGenerator is configured:
-    ```rust
-    // Before
-    SdkTracerProvider::builder()
-        .with_config(trace::config().with_id_generator(XrayIdGenerator::default()))
-        .build();
-    
-    // After
-    SdkTracerProvider::builder()
-        .with_id_generator(XrayIdGenerator::default())
-        .build();
-    ```
+- Update the opentelemetry and opentelemetry_sdk dependencies to always use the latest versions specified in `opentelemetry-rust-contrib`
+- Breaking change in the way XrayIdGenerator is configured:
+  ```rust
+  // Before
+  SdkTracerProvider::builder()
+      .with_config(trace::config().with_id_generator(XrayIdGenerator::default()))
+      .build();
+  
+  // After
+  SdkTracerProvider::builder()
+      .with_id_generator(XrayIdGenerator::default())
+      .build();
+  ```
 
 ## v0.16.0
 

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -25,17 +25,17 @@ detector-aws-lambda = ["dep:opentelemetry-semantic-conventions"]
 internal-logs = ["tracing"]
 
 [dependencies]
-opentelemetry = { version = "0.29" }
-opentelemetry_sdk = { version = "0.29", optional = true }
-opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = [
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true, features = [
     "semconv_experimental",
 ] }
 tracing = {version = "0.1", optional = true}
 
 [dev-dependencies]
-opentelemetry_sdk = { version = "0.29", features = ["testing"] }
-opentelemetry-http = { version = "0.29" }
-opentelemetry-stdout = { version = "0.29", features = ["trace"] }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+opentelemetry-http = { workspace = true }
+opentelemetry-stdout = { workspace = true, features = ["trace"] }
 hyper = { version = "1.4.1" }
 tokio = { version = "1.0", features = ["macros", "rt"] }
 sealed_test = "1.1"

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-aws"
-version = "0.16.0"
+version = "0.17.0"
 description = "AWS exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws"

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -25,17 +25,17 @@ detector-aws-lambda = ["dep:opentelemetry-semantic-conventions"]
 internal-logs = ["tracing"]
 
 [dependencies]
-opentelemetry = { version = "0.28" }
-opentelemetry_sdk = { version = "0.28", optional = true }
-opentelemetry-semantic-conventions = { version = "0.28", optional = true, features = [
+opentelemetry = { version = "0.29" }
+opentelemetry_sdk = { version = "0.29", optional = true }
+opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = [
     "semconv_experimental",
 ] }
 tracing = {version = "0.1", optional = true}
 
 [dev-dependencies]
-opentelemetry_sdk = { version = "0.28", features = ["testing"] }
-opentelemetry-http = { version = "0.28" }
-opentelemetry-stdout = { version = "0.28", features = ["trace"] }
+opentelemetry_sdk = { version = "0.29", features = ["testing"] }
+opentelemetry-http = { version = "0.29" }
+opentelemetry-stdout = { version = "0.29", features = ["trace"] }
 hyper = { version = "1.4.1" }
 tokio = { version = "1.0", features = ["macros", "rt"] }
 sealed_test = "1.1"

--- a/opentelemetry-aws/src/trace/id_generator.rs
+++ b/opentelemetry-aws/src/trace/id_generator.rs
@@ -24,10 +24,10 @@ use std::time::{Duration, UNIX_EPOCH};
 ///
 /// ```
 /// use opentelemetry::trace::{TraceId};
-/// use opentelemetry_sdk::trace::{self, IdGenerator, SdkTracerProvider};
+/// use opentelemetry_sdk::trace::{IdGenerator, SdkTracerProvider};
 /// use opentelemetry_aws::trace::XrayIdGenerator;
 /// let _provider:SdkTracerProvider = SdkTracerProvider::builder()
-///      .with_config(trace::config().with_id_generator(XrayIdGenerator::default()))
+///      .with_id_generator(XrayIdGenerator::default())
 ///      .build();
 /// ```
 ///

--- a/opentelemetry-aws/src/trace/xray_propagator.rs
+++ b/opentelemetry-aws/src/trace/xray_propagator.rs
@@ -41,9 +41,10 @@
 use opentelemetry::{
     otel_error,
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
-    trace::{SpanContext, SpanId, TraceContextExt, TraceError, TraceFlags, TraceId, TraceState},
+    trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
     Context,
 };
+use opentelemetry_sdk::trace::TraceError;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::sync::OnceLock;
@@ -144,7 +145,8 @@ pub fn span_context_from_str(value: &str) -> Option<SpanContext> {
             ))
         }
         Err(trace_state_err) => {
-            otel_error!(name: "SpanContextFromStr", error = format!("{:?}", TraceError::Other(Box::new(trace_state_err))));
+            let error = TraceError::Other(Box::new(trace_state_err));
+            otel_error!(name: "SpanContextFromStr", error = format!("{:?}", error));
             None //todo: assign an error type instead of using None
         }
     }

--- a/opentelemetry-aws/src/trace/xray_propagator.rs
+++ b/opentelemetry-aws/src/trace/xray_propagator.rs
@@ -44,7 +44,6 @@ use opentelemetry::{
     trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
     Context,
 };
-use opentelemetry_sdk::trace::TraceError;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::sync::OnceLock;
@@ -145,8 +144,7 @@ pub fn span_context_from_str(value: &str) -> Option<SpanContext> {
             ))
         }
         Err(trace_state_err) => {
-            let error = TraceError::Other(Box::new(trace_state_err));
-            otel_error!(name: "SpanContextFromStr", error = format!("{:?}", error));
+            otel_error!(name: "SpanContextFromStr", error = format!("{:?}", trace_state_err));
             None //todo: assign an error type instead of using None
         }
     }


### PR DESCRIPTION
Fixes # (no specific issue)
Design discussion issue (if applicable) # (not applicable)

## Changes

Updates the OpenTelemetry AWS crate to use the latest 0.29.0 version of OpenTelemetry.

Changes include:
- Updated imports for `TraceError` which moved from `opentelemetry::trace::TraceError` to `opentelemetry_sdk::trace::TraceError`
- Fixed issue with moved value in error handling for `TraceStateError`
- Updated XrayIdGenerator doctest to use the new API for configuring the IdGenerator

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)