### PR TITLE
fix: Make usereventlogexporter re-entrant safe and handle shutdown

### DIFF
--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Make exporter reentrant-safe by removing logs that could be bridged back
   to itself.
 - Exporter now unregisters the `Provider` on `shutdown()`.
+  [221](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/221)
 
 ## v0.11.0
 

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added support for Populating Cloud RoleName, RoleInstance from Resource's
   "service.name" and "service.instance.id" attributes respectively.
+- Make exporter reentrant-safe by removing logs that could be bridged back
+  to itself.
 
 ## v0.11.0
 

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -6,6 +6,7 @@
   "service.name" and "service.instance.id" attributes respectively.
 - Make exporter reentrant-safe by removing logs that could be bridged back
   to itself.
+- Exporter now unregisters the Tracepoint on `shutdown()`.
 
 ## v0.11.0
 

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -6,7 +6,7 @@
   "service.name" and "service.instance.id" attributes respectively.
 - Make exporter reentrant-safe by removing logs that could be bridged back
   to itself.
-- Exporter now unregisters the Tracepoint on `shutdown()`.
+- Exporter now unregisters the `Provider` on `shutdown()`.
 
 ## v0.11.0
 

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Make exporter reentrant-safe by removing logs that could be bridged back
   to itself.
 - Exporter now unregisters the `Provider` on `shutdown()`.
-  [221](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/221)
+  [#221](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/221)
 
 ## v0.11.0
 

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -1,6 +1,6 @@
 use eventheader::{FieldFormat, Level, Opcode};
 use eventheader_dynamic::{EventBuilder, EventSet, Provider};
-use opentelemetry::{otel_debug, otel_info};
+use opentelemetry::otel_debug;
 use opentelemetry_sdk::Resource;
 use std::sync::Arc;
 use std::{fmt::Debug, sync::Mutex};

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -360,12 +360,11 @@ impl Debug for UserEventsExporter {
 
 impl opentelemetry_sdk::logs::LogExporter for UserEventsExporter {
     async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
-        let mut res = Ok(());
-        for (record, instrumentation) in batch.iter() {
-            // no, res is not overwritten as the batch will only have one item
-            res = self.export_log_data(record, instrumentation);
-        }
-        res
+        let (record, instrumentation) = batch
+            .iter()
+            .next()
+            .expect("batch is expected to have one and only one record");
+        self.export_log_data(record, instrumentation)
     }
 
     fn shutdown(&self) -> OTelSdkResult {

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -327,9 +327,9 @@ impl UserEventsExporter {
 
                 let result = eb.write(event_set, None, None);
                 if result > 0 {
-                    // Specially treat the case where there is no listener and size exceeding.
+                    // Specially treat the case where there is no listener or payload size exceeds the limit.
                     if result == 9 {
-                        Err(OTelSdkError::InternalFailure("Failed to write event to user_events tracepoint as there is no listener. This can occur when there was a listener when we started serializing event, but it was removed before the event was written".to_string()))
+                        Err(OTelSdkError::InternalFailure("Failed to write event to user_events tracepoint as there is no listener. This can occur if there was a listener when we started serializing the event, but it was removed before the event was written".to_string()))
                     } else if result == 34 {
                         Err(OTelSdkError::InternalFailure("Failed to write event to user_events tracepoint as total payload size exceeded 64KB limit".to_string()))
                     } else {

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -327,20 +327,18 @@ impl UserEventsExporter {
 
                 let result = eb.write(event_set, None, None);
                 if result > 0 {
-                    // Specially log the case where there is no listener and size exceeding.
+                    // Specially treat the case where there is no listener and size exceeding.
                     if result == 9 {
-                        otel_debug!(name: "UserEvents.EventWriteFailed", result = result, reason = "No listener. This can occur when there was a listener but it was removed before the event was written");
+                        Err(OTelSdkError::InternalFailure("Failed to write event to user_events tracepoint as there is no listener. This can occur when there was a listener when we started serializing event, but it was removed before the event was written".to_string()))
                     } else if result == 34 {
-                        // Info level for size exceeding.
-                        otel_info!(name: "UserEvents.EventWriteFailed", result = result, reason = "Total payload size exceeded 64KB limit");
+                        Err(OTelSdkError::InternalFailure("Failed to write event to user_events tracepoint as total payload size exceeded 64KB limit".to_string()))
                     } else {
-                        // For all other cases, log the error code.
-                        otel_debug!(name: "UserEvents.EventWriteFailed", result = result);
+                        // For all other cases, return failure and include the result code.
+                        Err(OTelSdkError::InternalFailure(format!(
+                            "Failed to write event to user_events tracepoint with result code: {}",
+                            result
+                        )))
                     }
-                    Err(OTelSdkError::InternalFailure(format!(
-                        "Failed to write event to user_events tracepoint with result code: {}",
-                        result
-                    )))
                 } else {
                     Ok(())
                 }
@@ -362,10 +360,12 @@ impl Debug for UserEventsExporter {
 
 impl opentelemetry_sdk::logs::LogExporter for UserEventsExporter {
     async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
+        let mut res = Ok(());
         for (record, instrumentation) in batch.iter() {
-            let _ = self.export_log_data(record, instrumentation);
+            // no, res is not overwritten as the batch will only have one item
+            res = self.export_log_data(record, instrumentation);
         }
-        Ok(())
+        res
     }
 
     fn shutdown(&self) -> OTelSdkResult {

--- a/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
@@ -40,9 +40,7 @@ impl<T: LogExporter> opentelemetry_sdk::logs::LogProcessor for ReentrantLogProce
 
     // Nothing to shutdown
     fn shutdown(&self) -> OTelSdkResult {
-        // TODO: Actually invoke shutdown on the exporter
-        // This cannot be done today as it requires mutable reference to exporter.
-        Ok(())
+        self.exporter.shutdown()
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]

--- a/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
@@ -29,6 +29,7 @@ impl<T: LogExporter> opentelemetry_sdk::logs::LogProcessor for ReentrantLogProce
         let log_tuple = &[(record as &SdkLogRecord, scope)];
         // TODO: Using futures_executor::block_on can make the code non reentrant safe
         // if that crate starts emitting logs that are bridged to OTel.
+        // TODO: How to log if export() returns Err? Maybe a metric?
         let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
     }
 


### PR DESCRIPTION
1. Handle shutdown to exporter
2. No more internal logs - This limits self observability, but can add some metric, or eprintln() in the future, if this turns out to be an issue.