### PR TITLE
fix: ETW LogExporter to unregister on shutdown

### DIFF
--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - Added support for populating cloud `role` and `roleInstance` from Resource's `service.name` and `service.instance.id` attributes respectively.
 
+- Exporter now unregister the Etw provider on `shutdown()`.
+
 ## v0.7.0
 
 - Bump msrv to 1.75.0

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -24,8 +24,9 @@
 
 - Added support for populating cloud `role` and `roleInstance` from Resource's `service.name` and `service.instance.id` attributes respectively.
 
+- `_typeName` field uses "Log" instead of "Logs".
 - Exporter now unregisters the Etw provider on `shutdown()`.
-  [222](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/222)
+  [#222](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/222)
 
 ## v0.7.0
 

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Added support for populating cloud `role` and `roleInstance` from Resource's `service.name` and `service.instance.id` attributes respectively.
 
-- Exporter now unregister the Etw provider on `shutdown()`.
+- Exporter now unregisters the Etw provider on `shutdown()`.
 
 ## v0.7.0
 

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added support for populating cloud `role` and `roleInstance` from Resource's `service.name` and `service.instance.id` attributes respectively.
 
 - Exporter now unregisters the Etw provider on `shutdown()`.
+  [222](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/222)
 
 ## v0.7.0
 

--- a/opentelemetry-etw-logs/src/logs/exporter/mod.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/mod.rs
@@ -120,12 +120,11 @@ impl Debug for ETWExporter {
 
 impl opentelemetry_sdk::logs::LogExporter for ETWExporter {
     async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
-        let mut res = Ok(());
-        for (log_record, instrumentation) in batch.iter() {
-            // no, res is not overwritten as the batch will only have one item
-            res = self.export_log_data(log_record, instrumentation);
-        }
-        res
+        let (record, instrumentation) = batch
+            .iter()
+            .next()
+            .expect("batch is expected to have one and only one record");
+        self.export_log_data(record, instrumentation)
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]

--- a/opentelemetry-etw-logs/src/logs/exporter/mod.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/mod.rs
@@ -120,11 +120,13 @@ impl Debug for ETWExporter {
 
 impl opentelemetry_sdk::logs::LogExporter for ETWExporter {
     async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
-        let (record, instrumentation) = batch
-            .iter()
-            .next()
-            .expect("batch is expected to have one and only one record");
-        self.export_log_data(record, instrumentation)
+        if let Some((record, instrumentation)) = batch.iter().next() {
+            self.export_log_data(record, instrumentation)
+        } else {
+            Err(OTelSdkError::InternalFailure(
+                "Batch is expected to have one and only one record, but none was found".to_string(),
+            ))
+        }
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]

--- a/opentelemetry-etw-logs/src/logs/exporter/mod.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/mod.rs
@@ -119,17 +119,13 @@ impl Debug for ETWExporter {
 }
 
 impl opentelemetry_sdk::logs::LogExporter for ETWExporter {
-    #[allow(clippy::manual_async_fn)]
-    fn export(
-        &self,
-        batch: opentelemetry_sdk::logs::LogBatch<'_>,
-    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
-        async move {
-            for (log_record, instrumentation) in batch.iter() {
-                let _ = self.export_log_data(log_record, instrumentation);
-            }
-            Ok(())
+    async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
+        let mut res = Ok(());
+        for (log_record, instrumentation) in batch.iter() {
+            // no, res is not overwritten as the batch will only have one item
+            res = self.export_log_data(log_record, instrumentation);
         }
+        res
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]
@@ -144,6 +140,16 @@ impl opentelemetry_sdk::logs::LogExporter for ETWExporter {
         self.resource.cloud_role_instance = resource
             .get(&Key::from_static_str("service.instance.id"))
             .map(|v| v.to_string());
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        let res = self.provider.as_ref().unregister();
+        if res != 0 {
+            return Err(OTelSdkError::InternalFailure(format!(
+                "Failed to unregister provider. Win32 error: {res}"
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/opentelemetry-etw-logs/src/logs/exporter/part_b.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/part_b.rs
@@ -22,7 +22,7 @@ pub fn populate_part_b(
     event.add_struct("PartB", field_count, 0);
 
     // Fill fields of PartB struct
-    event.add_str8("_typeName", "Logs", tld::OutType::Default, 0);
+    event.add_str8("_typeName", "Log", tld::OutType::Default, 0);
 
     if let Some(body) = log_record.body() {
         super::common::add_attribute_to_event(event, &Key::new("body"), body);

--- a/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
@@ -27,6 +27,7 @@ impl ReentrantLogProcessor {
 impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
     fn emit(&self, data: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
         let log_tuple = &[(data as &SdkLogRecord, instrumentation)];
+        // TODO: How to log if export() returns Err? Maybe a metric? or eprintln?
         let _ = futures_executor::block_on(self.event_exporter.export(LogBatch::new(log_tuple)));
     }
 
@@ -36,10 +37,8 @@ impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
         Ok(())
     }
 
-    // This is a no-op no special cleanup is required before
-    // shutdown.
     fn shutdown(&self) -> OTelSdkResult {
-        Ok(())
+        self.event_exporter.shutdown()
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -360,13 +360,7 @@ impl Debug for UserEventsExporter {
 
 impl opentelemetry_sdk::logs::LogExporter for UserEventsExporter {
     async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
-        let mut iter = batch.iter();
-        if let Some((record, instrumentation)) = iter.next() {
-            if iter.next().is_some() {
-                return Err(OTelSdkError::InternalFailure(
-                    "Batch is expected to have one and only one record, but more than one was found. No item is exported.".to_string(),
-                ));
-            }
+        if let Some((record, instrumentation)) = batch.iter().next() {
             self.export_log_data(record, instrumentation)
         } else {
             Err(OTelSdkError::InternalFailure(


### PR DESCRIPTION
Now that 0.29 upstream is added, shutdown can be performed by unregistering the provider.
Nit cleanup on export() method.
Rename "Logs" to "Log" for partB name, consistent with user-events exporter.
