### PR TITLE
chore: update stackdriver's OpenTelemetry to 0.29

### DIFF
--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for `MonitoredResource::CloudFunction`, `MonitoredResource::AppEngine`,
   `MonitoredResource::ComputeEngine`, and `MonitoredResource::KubernetesEngine`
 - Update to opentelemetry v0.29.0, opentelemetry_sdk v0.29.0, opentelemetry-semantic-conventions v0.29.0
+- Drop `futures-core` from dependencies
 
 ## v0.25.0
 

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added support for `MonitoredResource::CloudFunction`, `MonitoredResource::AppEngine`,
   `MonitoredResource::ComputeEngine`, and `MonitoredResource::KubernetesEngine`
+- Update to opentelemetry v0.29.0, opentelemetry_sdk v0.29.0, opentelemetry-semantic-conventions v0.29.0
 
 ## v0.25.0
 

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -13,11 +13,9 @@ rust-version = "1.75.0"
 gcp_auth = { version = "0.12", optional = true }
 hex = "0.4"
 http = "1"
-opentelemetry = {version = "0.28"}
-opentelemetry_sdk = { version = "0.28", features = ["trace"] }
-opentelemetry-semantic-conventions = { version = "0.28", features = [
-    "semconv_experimental",
-]}
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["trace"] }
+opentelemetry-semantic-conventions = { workspace = true }
 prost = "0.13"
 prost-types = "0.13"
 thiserror = "2.0"
@@ -44,7 +42,7 @@ tokio = "1"
 tonic-build = "0.12"
 walkdir = "2.3.2"
 futures-util = { version = "0.3", default-features = false }
-opentelemetry = { version = "0.28", features = ["testing"] }
+opentelemetry = { workspace = true, features = ["testing"] }
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -23,7 +23,6 @@ tonic = { version = "0.12", default-features = false, features = ["channel", "co
 tracing = { version = "0.1", optional = true }
 
 # Futures
-futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-channel = { version = "0.3", default-features = false, features = ["std"] }
 


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Updates to open-telemetry 0.29

Notes:
The mpsc channel is backed by `Arc`s thus no additional interior mutability is needed.
I dropped the error wrapping in the internal-log only otel_error! macro usage. The macro now places the expr in multiple places; thus, it cannot move a value anymore. The name has enough information about the error kind. The display impl of the TraceError and Error variants did not add any additional context. Also, this is for internal debugging only.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
