### PR TITLE
chore: deprecate ZPages

### DIFF
--- a/opentelemetry-zpages/CHANGELOG.md
+++ b/opentelemetry-zpages/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## vNext
+## v0.14.0 (DEPRECATED)
 
 - Bump `async-channel` version to 2.3
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-zpages"
-version = "0.13.0"
-description = "ZPages implementation for OpenTelemetry"
+version = "0.14.0+deprecated"
+description = "[DEPRECATED] ZPages implementation for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-zpages"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-zpages"
 readme = "README.md"

--- a/opentelemetry-zpages/README.md
+++ b/opentelemetry-zpages/README.md
@@ -1,5 +1,8 @@
 # OpenTelemetry ZPages
 
+> [!WARNING]  
+> **This crate is deprecated and no longer maintained.**
+
 ![OpenTelemetry — An observability framework for cloud-native software.][splash]
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/master/assets/logo-text.png

--- a/opentelemetry-zpages/src/lib.rs
+++ b/opentelemetry-zpages/src/lib.rs
@@ -1,5 +1,7 @@
 //! ZPages implementation for Opentelemetry
 //!
+//! **This crate is deprecated and no longer maintained.**
+//!
 //! # Overview
 //! zPages are an in-process alternative to external exporters. When included,
 //! they collect and aggregate tracing and metrics information in the

--- a/opentelemetry-zpages/src/trace/mod.rs
+++ b/opentelemetry-zpages/src/trace/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod span_queue;
 /// # }
 ///
 /// ```
+#[deprecated(note = "This crate is deprecated and no longer maintained.")]
 pub fn tracez<R: Runtime>(
     sample_size: usize,
     runtime: R,

--- a/opentelemetry-zpages/src/trace/span_processor.rs
+++ b/opentelemetry-zpages/src/trace/span_processor.rs
@@ -19,6 +19,7 @@ use std::fmt::Formatter;
 ///
 /// ZPagesSpanProcessor employs a `SpanAggregator` running as another task to aggregate the spans
 /// using the name of spans.
+#[deprecated(note = "This crate is deprecated and no longer maintained.")]
 pub struct ZPagesSpanProcessor {
     tx: Sender<TracezMessage>,
 }


### PR DESCRIPTION
Fixes #4

## Changes

- I added the `deprecated` suffix to the crate version similar to `serde_yaml`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
