### PR TITLE
chore: Prepare release to pickup 0.29

### DIFF
--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -5,8 +5,10 @@
 ## v0.17.0
 
 ### Changed
-- Update the opentelemetry and opentelemetry_sdk dependencies to always use the latest versions specified in `opentelemetry-rust-contrib`
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.29.0
 - Breaking change in the way XrayIdGenerator is configured:
+  
   ```rust
   // Before
   SdkTracerProvider::builder()

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.21.0
+
 - Bump `base64` version to 0.22
 - `rt-async-std` feature removed, as it is removed from upstream `opentelemetry_sdk`
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-contrib"
-version = "0.20.0"
+version = "0.21.0"
 description = "Rust contrib repo for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-contrib"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-contrib"

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## vNext
 
-- `DatadogExporter.export()` doesn't require mutablity anymore
+## v0.17.0
+
+- `DatadogExporter.export()` doesn't require mutability anymore
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29
 - Bump opentelemetry-http and opentelemetry-semantic-conventions versions to 0.29
 

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-datadog"
-version = "0.16.0"
+version = "0.17.0"
 description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.8.0
+
 - Added the `with_etw_exporter` trait method to `LoggerProviderBuilder`.
   This is now the only way to add an ETW exporter. The following line
   will add an ETW exporter using the given provider name:

--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-etw-logs"
 description = "OpenTelemetry logs exporter to ETW (Event Tracing for Windows)"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"

--- a/opentelemetry-etw-metrics/CHANGELOG.md
+++ b/opentelemetry-etw-metrics/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.8.0
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29
 - Bump opentelemetry-proto version to 0.29
 

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-etw-metrics"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "OpenTelemetry metrics exporter to ETW (Event Tracing for Windows)"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-metrics"

--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.8.0
+
 ### Changed
 
 - Expose `K8sResourceDetector`, which populates `k8s.pod.name` and `k8s.namespace.name`

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-resource-detectors"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "A collection of community supported resource detectors for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-resource-detectors"

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.26.0
+
 - Update gRPC schemas
 
 ### Changed

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stackdriver"
-version = "0.25.0"
+version = "0.26.0"
 description = "A Rust opentelemetry exporter that uploads traces to Google Stackdriver trace."
 documentation = "https://docs.rs/opentelemetry-stackdriver/"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib"

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.12.0
+
 - Added support for Populating Cloud RoleName, RoleInstance from Resource's
   "service.name" and "service.instance.id" attributes respectively.
 - Make exporter reentrant-safe by removing logs that could be bridged back

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-user-events-logs"
 description = "OpenTelemetry Logs Exporter for Linux user_events"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs"

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.10.0
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29
 - Bump opentelemetry-proto version to 0.29
 

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-user-events-metrics"
-version = "0.9.0"
+version = "0.10.0"
 description = "OpenTelemetry metrics exporter to user events"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.1.0
+
 ### Added
 
 - Initial Alpha implementation

--- a/opentelemetry-user-events-trace/Cargo.toml
+++ b/opentelemetry-user-events-trace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-user-events-trace"
 description = "OpenTelemetry-Rust exporter to user_events"
-version = "0.10.0"
+version = "0.1.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-traces"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-traces"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 packages=(
-    "actix-web-opentelemetry",
+    "actix-web-opentelemetry"
     "opentelemetry-aws"
     "opentelemetry-contrib"
     "opentelemetry-datadog"
@@ -10,9 +10,8 @@ packages=(
     "opentelemetry-resource-detectors"
     "opentelemetry-stackdriver"
     "opentelemetry-user-events-logs"
-    "opentelemetry-user-events-metrics",
-    opentelemetry-user-events-trace
-
+    "opentelemetry-user-events-metrics"
+    "opentelemetry-user-events-trace"
     # Add more packages as needed, in the right order. A package should only be published after all it's dependencies have been published
 )
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+packages=(
+    "actix-web-opentelemetry",
+    "opentelemetry-aws"
+    "opentelemetry-contrib"
+    "opentelemetry-datadog"
+    "opentelemetry-etw-logs"
+    "opentelemetry-etw-metrics"    
+    "opentelemetry-resource-detectors"
+    "opentelemetry-stackdriver"
+    "opentelemetry-user-events-logs"
+    "opentelemetry-user-events-metrics",
+    opentelemetry-user-events-trace
+
+    # Add more packages as needed, in the right order. A package should only be published after all it's dependencies have been published
+)
+
+# Set the current directory to one level above the scripts directory
+current_dir=$(pwd)/..
+cd "$current_dir"  # Change to the current directory
+
+# Iterate over the list of packages
+for package in "${packages[@]}"; do
+    if [ -d "$package" ]; then
+        echo "=================================================="
+        echo "Processing package: $package"
+        cd "$package"  # Change to the directory of package
+
+        # Extract the name and version from Cargo.toml
+        name=$(grep -m1 '^name =' Cargo.toml | cut -d'"' -f2)
+        version=$(grep -m1 '^version =' Cargo.toml | cut -d'"' -f2)
+
+        if [[ -n "$name" && -n "$version" ]]; then
+            echo "Found package $name with version $version" in cargo.toml
+            
+            # Tag the version in git
+            tag="${name}-${version}"
+            tag_message="${name} ${version} release."
+            # uncomment the following lines after verifying all looks good.
+            # git tag -a "$tag" -m "\"$tag_message\""
+            # git push origin "$tag"
+            echo "git tag -a "$tag" -m "$tag_message""
+
+            # Run cargo publish
+            # uncomment the following line after verifying all looks good.
+            # cargo publish
+            echo "Published $name $version"
+        else
+            echo "Error: Unable to extract name or version from Cargo.toml in $package"
+        fi
+
+        cd "$current_dir"  # Return to the original directory
+        echo "Sleeping for 15 seconds before next package..."
+        sleep 15  # Sleep for 15 seconds to allow crates.io to index the previous package
+    else
+        echo "Skipping: $package is not a valid package directory."
+    fi
+done
+
+echo "Finished publishing all packages."


### PR DESCRIPTION
Some crates had version already updated, some didn't. This updates the missing ones.