### PR TITLE
refactor: remove Prometheus related dependencies from actix instrumentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ debug = 1
 opentelemetry = "0.29"
 opentelemetry-appender-tracing = "0.29"
 opentelemetry-http = "0.29"
+opentelemetry-otlp = "0.29"
 opentelemetry-proto = { version = "0.29", default-features = false }
 opentelemetry_sdk = { version = "0.29", default-features = false }
 opentelemetry-stdout = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ debug = 1
 opentelemetry = "0.29"
 opentelemetry-appender-tracing = "0.29"
 opentelemetry-http = "0.29"
-opentelemetry-otlp = "0.29"
 opentelemetry-proto = { version = "0.29", default-features = false }
 opentelemetry_sdk = { version = "0.29", default-features = false }
 opentelemetry-stdout = "0.29"

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,5 @@
 [graph]
-exclude=[
-    "protobuf" # opentelemetry-instrumentation-actix-web depends on prometheus should try to remove it
-]
+exclude=[]
 
 [licenses]
 allow = [

--- a/opentelemetry-instrumentation-actix-web/CHANGELOG.md
+++ b/opentelemetry-instrumentation-actix-web/CHANGELOG.md
@@ -4,7 +4,31 @@
 
 ### Changed
 
+* Remove `opentelemetry-prometheus`, `opentelemetry_sdk`, `prometheus` and `tracing` dependencies
 * **Breaking** Rename crate to `opentelemetry-instrumentation-actix-web`
+* **Breaking** Remove `metrics-prometheus` feature and use `metric` feature instead
+* **Breaking** Remove Prometheus middleware `PrometheusMetricsHandler` and use OTLP exporter instead
+  ```rust
+  // Initialize OTLP exporter using HTTP binary protocol
+  let exporter = opentelemetry_otlp::MetricExporter::builder()
+      .with_http()
+      .with_protocol(Protocol::HttpBinary)
+      .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
+      .build()?;
+
+  // set up your meter provider with your exporter(s)
+  let provider = SdkMeterProvider::builder()
+      .with_periodic_exporter(exporter)
+      .with_resource(
+          // recommended attributes
+          Resource::builder_empty()
+              .with_attribute(KeyValue::new("service.name", "my_app"))
+              .with_attribute(KeyValue::new("service.instance.id", Uuid::new_v4().to_string()))
+              .build(),
+      )
+      .build();
+  global::set_meter_provider(provider.clone());
+  ```
 
 ## [v0.22.0](https://github.com/OutThereLabs/actix-web-opentelemetry/compare/v0.22.0..v0.21.0)
 

--- a/opentelemetry-instrumentation-actix-web/Cargo.toml
+++ b/opentelemetry-instrumentation-actix-web/Cargo.toml
@@ -6,20 +6,13 @@ homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/ma
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/actix-web-opentelemetry"
 readme = "README.md"
 categories = ["api-bindings"]
-keywords = ["actix", "actix-web", "opentelemetry", "prometheus"]
+keywords = ["actix", "actix-web", "opentelemetry"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
 
 [features]
 metrics = ["opentelemetry/metrics"]
-metrics-prometheus = [
-  "metrics",
-  "opentelemetry-prometheus",
-  "prometheus",
-  "dep:opentelemetry_sdk",
-  "dep:tracing",
-]
 sync-middleware = []
 
 [dependencies]
@@ -36,22 +29,15 @@ futures-util = { version = "0.3", default-features = false, features = [
   "alloc",
 ] }
 opentelemetry = { workspace = true, features = ["trace"] }
-opentelemetry-prometheus = { version = "0.29", optional = true }
 opentelemetry-semantic-conventions = { workspace = true, features = [
   "semconv_experimental",
 ] }
-opentelemetry_sdk = { workspace = true, optional = true, features = [
-  "metrics",
-  "rt-tokio-current-thread",
-] }
-prometheus = { version = "0.13", default-features = false, optional = true }
 serde = "1.0"
-tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4.0", features = ["macros"] }
 opentelemetry-instrumentation-actix-web = { path = ".", features = [
-  "metrics-prometheus",
+  "metrics",
   "sync-middleware",
   "awc",
 ] }
@@ -60,8 +46,9 @@ opentelemetry_sdk = { workspace = true, features = [
   "metrics",
   "rt-tokio-current-thread",
 ] }
-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
 opentelemetry-stdout = { workspace = true, features = ["trace", "metrics"] }
+uuid = { version = "1.16.0", features = ["v4"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-instrumentation-actix-web/Cargo.toml
+++ b/opentelemetry-instrumentation-actix-web/Cargo.toml
@@ -46,9 +46,7 @@ opentelemetry_sdk = { workspace = true, features = [
   "metrics",
   "rt-tokio-current-thread",
 ] }
-opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
 opentelemetry-stdout = { workspace = true, features = ["trace", "metrics"] }
-uuid = { version = "1.16.0", features = ["v4"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-instrumentation-actix-web/README.md
+++ b/opentelemetry-instrumentation-actix-web/README.md
@@ -52,5 +52,4 @@ $ firefox http://localhost:16686/
 
 - `awc` -- enable support for tracing the `awc` http client.
 - `metrics` -- enable support for opentelemetry metrics (only traces are enabled by default)
-- `metrics-prometheus` -- enable support for prometheus metrics (requires `metrics` feature)
 - `sync-middleware` -- enable tracing on actix-web middlewares that do synchronous work before returning a future. Adds a small amount of overhead to every request.

--- a/opentelemetry-instrumentation-actix-web/examples/client.rs
+++ b/opentelemetry-instrumentation-actix-web/examples/client.rs
@@ -3,6 +3,7 @@ use opentelemetry_instrumentation_actix_web::ClientExt;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
+use opentelemetry_stdout::SpanExporter;
 use std::error::Error;
 use std::io;
 
@@ -34,11 +35,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .build();
 
     let tracer = SdkTracerProvider::builder()
-        .with_batch_exporter(
-            opentelemetry_otlp::SpanExporter::builder()
-                .with_tonic()
-                .build()?,
-        )
+        .with_batch_exporter(SpanExporter::default())
         .with_resource(service_name_resource)
         .build();
 

--- a/opentelemetry-instrumentation-actix-web/examples/server.rs
+++ b/opentelemetry-instrumentation-actix-web/examples/server.rs
@@ -49,7 +49,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_resource(
                 Resource::builder_empty()
                     .with_attribute(KeyValue::new("service.name", "my_app"))
-                    .with_attribute(KeyValue::new("service.instance.id", Uuid::new_v4().to_string()))
+                    .with_attribute(KeyValue::new(
+                        "service.instance.id",
+                        Uuid::new_v4().to_string(),
+                    ))
                     .build(),
             )
             .with_view(

--- a/opentelemetry-instrumentation-actix-web/src/lib.rs
+++ b/opentelemetry-instrumentation-actix-web/src/lib.rs
@@ -60,9 +60,8 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!     // Install an OpenTelemetry trace pipeline.
-//!     // Swap for https://docs.rs/opentelemetry-jaeger or other compatible
-//!     // exporter to send trace information to your collector.
+//!     // Swap for `opentelemetry_otlp` or any other compatible
+//!     // exporter to send metrics to your collector.
 //!     let exporter = opentelemetry_stdout::SpanExporter::default();
 //!
 //!     // Configure your tracer provider with your exporter(s)
@@ -90,9 +89,7 @@
 //! use opentelemetry::{global, KeyValue};
 //! # #[cfg(feature = "metrics")]
 //! use opentelemetry_instrumentation_actix_web::{RequestMetrics, RequestTracing};
-//! use opentelemetry_otlp::{Protocol, WithExportConfig};
 //! use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
-//! use uuid::Uuid;
 //!
 //! async fn index() -> &'static str {
 //!     "Hello world!"
@@ -101,21 +98,16 @@
 //! # #[cfg(feature = "metrics")]
 //! #[actix_web::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     // Initialize OTLP exporter using HTTP binary protocol
-//!     let exporter = opentelemetry_otlp::MetricExporter::builder()
-//!         .with_http()
-//!         .with_protocol(Protocol::HttpBinary)
-//!         .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
-//!         .build()?;
+//!     // Swap for `opentelemetry_otlp` or any other compatible
+//!     // exporter to send metrics to your collector.
+//!     let exporter = opentelemetry_stdout::MetricExporter::default();
 //!
 //!     // set up your meter provider with your exporter(s)
 //!     let provider = SdkMeterProvider::builder()
 //!         .with_periodic_exporter(exporter)
 //!         .with_resource(
-//!             // recommended attributes
 //!             Resource::builder_empty()
 //!                 .with_attribute(KeyValue::new("service.name", "my_app"))
-//!                 .with_attribute(KeyValue::new("service.instance.id", Uuid::new_v4().to_string()))
 //!                 .build(),
 //!         )
 //!         .build();

--- a/opentelemetry-instrumentation-actix-web/src/middleware/metrics.rs
+++ b/opentelemetry-instrumentation-actix-web/src/middleware/metrics.rs
@@ -143,9 +143,7 @@ impl RequestMetricsBuilder {
 /// use actix_web::{http, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 /// use opentelemetry::{global, KeyValue};
 /// use opentelemetry_instrumentation_actix_web::{RequestMetrics, RequestTracing};
-/// use opentelemetry_otlp::{Protocol, WithExportConfig};
 /// use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
-/// use uuid::Uuid;
 ///
 /// async fn manual_hello() -> impl Responder {
 ///     HttpResponse::Ok().body("Hey there!")
@@ -153,12 +151,8 @@ impl RequestMetricsBuilder {
 ///
 /// #[actix_web::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Initialize OTLP exporter using HTTP binary protocol
-///     let exporter = opentelemetry_otlp::MetricExporter::builder()
-///         .with_http()
-///         .with_protocol(Protocol::HttpBinary)
-///         .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
-///         .build()?;
+///     // Initialize STDOUT exporter
+///     let exporter = opentelemetry_stdout::MetricExporter::default();
 ///
 ///     // set up your meter provider with your exporter(s)
 ///     let provider = SdkMeterProvider::builder()
@@ -167,7 +161,6 @@ impl RequestMetricsBuilder {
 ///             // recommended attributes
 ///             Resource::builder_empty()
 ///                 .with_attribute(KeyValue::new("service.name", "my_app"))
-///                 .with_attribute(KeyValue::new("service.instance.id", Uuid::new_v4().to_string()))
 ///                 .build(),
 ///         )
 ///         .build();

--- a/opentelemetry-instrumentation-actix-web/src/middleware/metrics.rs
+++ b/opentelemetry-instrumentation-actix-web/src/middleware/metrics.rs
@@ -135,38 +135,57 @@ impl RequestMetricsBuilder {
 
 /// Request metrics tracking
 ///
+/// For more information on how to configure Prometheus with [OTLP](https://prometheus.io/docs/guides/opentelemetry)
+///
 /// # Examples
 ///
 /// ```no_run
-/// use actix_web::{dev, http, web, App, HttpRequest, HttpServer};
-/// use opentelemetry::global;
-/// use opentelemetry_instrumentation_actix_web::{PrometheusMetricsHandler, RequestMetrics, RequestTracing};
-/// use opentelemetry_sdk::metrics::SdkMeterProvider;
+/// use actix_web::{http, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+/// use opentelemetry::{global, KeyValue};
+/// use opentelemetry_instrumentation_actix_web::{RequestMetrics, RequestTracing};
+/// use opentelemetry_otlp::{Protocol, WithExportConfig};
+/// use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
+/// use uuid::Uuid;
+///
+/// async fn manual_hello() -> impl Responder {
+///     HttpResponse::Ok().body("Hey there!")
+/// }
 ///
 /// #[actix_web::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Configure prometheus or your preferred metrics service
-///     let registry = prometheus::Registry::new();
-///     let exporter = opentelemetry_prometheus::exporter()
-///         .with_registry(registry.clone())
+///     // Initialize OTLP exporter using HTTP binary protocol
+///     let exporter = opentelemetry_otlp::MetricExporter::builder()
+///         .with_http()
+///         .with_protocol(Protocol::HttpBinary)
+///         .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
 ///         .build()?;
 ///
 ///     // set up your meter provider with your exporter(s)
 ///     let provider = SdkMeterProvider::builder()
-///         .with_reader(exporter)
+///         .with_periodic_exporter(exporter)
+///         .with_resource(
+///             // recommended attributes
+///             Resource::builder_empty()
+///                 .with_attribute(KeyValue::new("service.name", "my_app"))
+///                 .with_attribute(KeyValue::new("service.instance.id", Uuid::new_v4().to_string()))
+///                 .build(),
+///         )
 ///         .build();
-///     global::set_meter_provider(provider);
+///     global::set_meter_provider(provider.clone());
 ///
-///     // Run actix server, metrics are now available at http://localhost:8080/metrics
+///     // Run actix server, metrics will be exported periodically
 ///     HttpServer::new(move || {
 ///         App::new()
 ///             .wrap(RequestTracing::new())
 ///             .wrap(RequestMetrics::default())
-///             .route("/metrics", web::get().to(PrometheusMetricsHandler::new(registry.clone())))
+///             .route("/hey", web::get().to(manual_hello))
 ///         })
 ///         .bind("localhost:8080")?
 ///         .run()
 ///         .await?;
+///
+///     //Shutdown the meter provider. This will trigger an export of all metrics.
+///     provider.shutdown()?;
 ///
 ///     Ok(())
 /// }
@@ -298,60 +317,5 @@ where
                 res
             }
         }))
-    }
-}
-
-#[cfg(feature = "metrics-prometheus")]
-#[cfg_attr(docsrs, doc(cfg(feature = "metrics-prometheus")))]
-pub(crate) mod prometheus {
-    use actix_web::{dev, http::StatusCode};
-    use futures_util::future::{self, LocalBoxFuture};
-    use opentelemetry_sdk::metrics::MetricError;
-    use prometheus::{Encoder, Registry, TextEncoder};
-
-    /// Prometheus request metrics service
-    #[derive(Clone, Debug)]
-    pub struct PrometheusMetricsHandler {
-        prometheus_registry: Registry,
-    }
-
-    impl PrometheusMetricsHandler {
-        /// Build a route to serve Prometheus metrics
-        pub fn new(registry: Registry) -> Self {
-            Self {
-                prometheus_registry: registry,
-            }
-        }
-    }
-
-    impl PrometheusMetricsHandler {
-        fn metrics(&self) -> String {
-            let encoder = TextEncoder::new();
-            let metric_families = self.prometheus_registry.gather();
-            let mut buf = Vec::new();
-            if let Err(err) = encoder.encode(&metric_families[..], &mut buf) {
-                tracing::error!(
-                    name: "encode_failure",
-                    target: env!("CARGO_PKG_NAME"),
-                    name = "encode_failure",
-                    error = MetricError::Other(err.to_string()).to_string(),
-                    ""
-                );
-            }
-
-            String::from_utf8(buf).unwrap_or_default()
-        }
-    }
-
-    impl dev::Handler<actix_web::HttpRequest> for PrometheusMetricsHandler {
-        type Output = Result<actix_web::HttpResponse<String>, actix_web::error::Error>;
-        type Future = LocalBoxFuture<'static, Self::Output>;
-
-        fn call(&self, _req: actix_web::HttpRequest) -> Self::Future {
-            Box::pin(future::ok(actix_web::HttpResponse::with_body(
-                StatusCode::OK,
-                self.metrics(),
-            )))
-        }
     }
 }


### PR DESCRIPTION
## Changes

- removed Prometheus middleware in favour of leveraging OTLP with Prometheus
- I didn't plan on it, but now the crate only depends on `opentelemetry` + `opentelemetry-semantic-conventions` from the OTel family

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
