### PR TITLE
feat: detect process.runtime.name and process.runtime.version

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Added
+
+- Add "process.runtime.name/process.runtime.version/process.runtime.description" attributes into the `ProcessResourceDetector`.
+
 ## v0.8.0
 
 ### Changed

--- a/opentelemetry-resource-detectors/build.rs
+++ b/opentelemetry-resource-detectors/build.rs
@@ -11,6 +11,8 @@ fn main() {
         return;
     };
 
+    println!("cargo:rustc-env=RUSTC_VERSION_DESCRIPTION={}", stdout);
+
     // rustc -V: rustc 1.76.0 (07dca489a 2024-02-04)
     // version is 1.76.0
     if let Some(version) = stdout.split_whitespace().nth(1) {

--- a/opentelemetry-resource-detectors/build.rs
+++ b/opentelemetry-resource-detectors/build.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let Ok(output) = Command::new("rustc").arg("-V").output() else {
+        return;
+    };
+
+    let Ok(stdout) = String::from_utf8(output.stdout) else {
+        return;
+    };
+
+    // rustc -V: rustc 1.76.0 (07dca489a 2024-02-04)
+    // version is 1.76.0
+    if let Some(version) = stdout.split_whitespace().nth(1) {
+        println!("cargo:rustc-env=RUSTC_VERSION={}", version);
+    }
+}

--- a/opentelemetry-resource-detectors/src/process.rs
+++ b/opentelemetry-resource-detectors/src/process.rs
@@ -15,6 +15,9 @@ use std::process::id;
 /// - process command line arguments(`process.command_args`), the full command arguments of this
 ///   application.
 /// - OS assigned process id(`process.pid`).
+/// - process runtime version(`process.runtime.version`).
+/// - process runtime name(`process.runtime.name`).
+/// - process runtime description(`process.runtime.description`).
 pub struct ProcessResourceDetector;
 
 impl ResourceDetector for ProcessResourceDetector {
@@ -39,12 +42,14 @@ impl ResourceDetector for ProcessResourceDetector {
                         opentelemetry_semantic_conventions::attribute::PROCESS_RUNTIME_NAME,
                         "rustc",
                     )),
+                    // Set from build.rs
                     option_env!("RUSTC_VERSION").map(|rustc_version| {
                         KeyValue::new(
                             opentelemetry_semantic_conventions::attribute::PROCESS_RUNTIME_VERSION,
                             rustc_version,
                         )
                     }),
+                    // Set from build.rs
                     option_env!("RUSTC_VERSION_DESCRIPTION").map(|rustc_version_desc| {
                         KeyValue::new(
                             opentelemetry_semantic_conventions::attribute::PROCESS_RUNTIME_DESCRIPTION,

--- a/opentelemetry-resource-detectors/src/process.rs
+++ b/opentelemetry-resource-detectors/src/process.rs
@@ -45,6 +45,12 @@ impl ResourceDetector for ProcessResourceDetector {
                             rustc_version,
                         )
                     }),
+                    option_env!("RUSTC_VERSION_DESCRIPTION").map(|rustc_version_desc| {
+                        KeyValue::new(
+                            opentelemetry_semantic_conventions::attribute::PROCESS_RUNTIME_DESCRIPTION,
+                            rustc_version_desc,
+                        )
+                    }),
                 ]
                 .into_iter()
                 .flatten(),
@@ -57,12 +63,13 @@ impl ResourceDetector for ProcessResourceDetector {
 mod tests {
     use super::ProcessResourceDetector;
     use opentelemetry_sdk::resource::ResourceDetector;
+    use opentelemetry_semantic_conventions::resource::PROCESS_RUNTIME_DESCRIPTION;
 
     #[cfg(target_os = "linux")]
     #[test]
     fn test_processor_resource_detector() {
         let resource = ProcessResourceDetector.detect();
-        assert_eq!(resource.len(), 4); // we cannot assert on the values because it changes along with runtime.
+        assert_eq!(resource.len(), 5); // we cannot assert on the values because it changes along with runtime.
     }
 
     #[test]
@@ -78,11 +85,14 @@ mod tests {
             Some("rustc".into())
         );
 
-        if option_env!("RUSTC_VERSION").is_some() {
-            assert_eq!(
-                resource.get(&PROCESS_RUNTIME_VERSION.into()),
-                Some(env!("RUSTC_VERSION").into())
-            );
-        }
+        assert_eq!(
+            resource.get(&PROCESS_RUNTIME_VERSION.into()),
+            Some(env!("RUSTC_VERSION").into())
+        );
+
+        assert_eq!(
+            resource.get(&PROCESS_RUNTIME_DESCRIPTION.into()),
+            Some(env!("RUSTC_VERSION_DESCRIPTION").into())
+        );
     }
 }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Added `process.runtime.name`/`process.runtime.version`/`process.runtime.description`. I'm not sure if these two fields are necessary — feel free to close the PR if they aren't.

<br class="Apple-interchange-newline">[process.runtime.name](https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
