### PR TITLE
feat: etw_log_processor()

### DIFF
--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added validation to provider name
 - Added optional feature `serde_json` to serialize List and Maps.
+- Added `etw_log_processor()` method that returns an `impl LogProcessor`.
 
 ## v0.8.0
 

--- a/opentelemetry-etw-logs/src/logs/mod.rs
+++ b/opentelemetry-etw-logs/src/logs/mod.rs
@@ -4,4 +4,5 @@ mod exporter;
 mod reentrant_logprocessor;
 mod with_etw_exporter;
 
+pub use reentrant_logprocessor::etw_log_processor;
 pub use with_etw_exporter::ETWLoggerProviderBuilderExt;

--- a/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-etw-logs/src/logs/reentrant_logprocessor.rs
@@ -40,6 +40,13 @@ impl ReentrantLogProcessor {
     }
 }
 
+/// Creates an opaque LogProcessor that can be used with the OpenTelemetry SDK.
+pub fn etw_log_processor(
+    provider_name: &str,
+) -> impl opentelemetry_sdk::logs::LogProcessor + use<> {
+    ReentrantLogProcessor::new(provider_name)
+}
+
 impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
     fn emit(&self, data: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
         let log_tuple = &[(data as &SdkLogRecord, instrumentation)];

--- a/opentelemetry-etw-logs/src/logs/with_etw_exporter.rs
+++ b/opentelemetry-etw-logs/src/logs/with_etw_exporter.rs
@@ -1,4 +1,4 @@
-use crate::logs::reentrant_logprocessor::{validate_provider_name, ReentrantLogProcessor};
+use crate::logs::reentrant_logprocessor::{etw_log_processor, validate_provider_name};
 use opentelemetry::otel_warn;
 use opentelemetry_sdk::logs::LoggerProviderBuilder;
 
@@ -14,7 +14,7 @@ impl ETWLoggerProviderBuilderExt for LoggerProviderBuilder {
             otel_warn!(name: "ETW.Exporter.CreationFailed", reason = &error);
             self
         } else {
-            let reentrant_processor = ReentrantLogProcessor::new(provider_name);
+            let reentrant_processor = etw_log_processor(provider_name);
             self.with_log_processor(reentrant_processor)
         }
     }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Adding `etw_log_processor()` method that returns an `impl LogProcessor`. Useful for advanced scenarios that requires access to the underlaying `LogProcessor`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
