### PR TITLE
feat: [opentelemetry-etw-logs] Remove todo macro

### DIFF
--- a/opentelemetry-etw-logs/src/logs/converters.rs
+++ b/opentelemetry-etw-logs/src/logs/converters.rs
@@ -21,7 +21,7 @@ fn serialize_anyvalue(value: &AnyValue, depth: usize) -> Value {
         AnyValue::Double(value) => json!(value),
         AnyValue::String(value) => json!(value.as_str()),
         AnyValue::Boolean(value) => json!(value),
-        AnyValue::Bytes(_value) => todo!("No support for AnyValue::Bytes yet."),
+        AnyValue::Bytes(_value) => json!("No support for AnyValue::Bytes yet."),
         AnyValue::ListAny(value) => {
             if depth > 0 {
                 // Do not allow nested lists.
@@ -110,14 +110,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_convert_bytes_panics() {
         let vec = vec![
             AnyValue::Bytes(Box::new(vec![97u8, 98u8, 99u8])),
             AnyValue::Bytes(Box::default()),
         ];
         let result = AnyValue::ListAny(Box::new(vec)).as_json_value();
-        assert_eq!(result, json!(["abc", ""]));
+        assert_eq!(result, json!(["No support for AnyValue::Bytes yet.", "No support for AnyValue::Bytes yet."]));
     }
 
     #[test]


### PR DESCRIPTION
## Changes
- Remove `todo!` macro as it would panic if a user provided byte array as attribute value
- Use `json!` macro to serialize the string `No support for AnyValue::Bytes yet.`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
