### PR TITLE
Revert "chore: fix Rust 1.87 lints (#264)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         # test only stable version of Rust on Windows and MacOS
         include:
           - rust: stable
-            os: windows-2025
+            os: windows-latest
           - rust: stable
             os: macos-latest
           - rust: stable
@@ -58,17 +58,17 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test (Windows)
-      if: ${{ matrix.os == 'windows-2025'}}
+      if: ${{ matrix.os == 'windows-latest'}}
       run: ./scripts/test.ps1
       shell: pwsh
     - name: Test (Unix)
-      if: ${{ matrix.os != 'windows-2025'}}
+      if: ${{ matrix.os != 'windows-latest'}}
       run: bash ./scripts/test.sh
   lint:
     strategy:
       matrix:
         # clippy must be run in every OS to lint platform-specific code 
-        os: [ubuntu-latest, windows-2025, macos-latest, ubuntu-22.04-arm]
+        os: [ubuntu-latest, windows-latest, macos-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -89,11 +89,11 @@ jobs:
     - name: Format
       run: cargo fmt --all -- --check
     - name: Lint (Windows)
-      if: ${{ matrix.os == 'windows-2025'}}
+      if: ${{ matrix.os == 'windows-latest'}}
       run: ./scripts/lint.ps1
       shell: pwsh
     - name: Lint (Unix)
-      if: ${{ matrix.os != 'windows-2025'}}
+      if: ${{ matrix.os != 'windows-latest'}}
       run: ./scripts/lint.sh
   msrv:
     strategy:
@@ -101,7 +101,7 @@ jobs:
         rust: ["1.75.0"]
         os: [
           ubuntu-latest,
-          # windows-2025 # Disabled due bug in `cargo-msrv` on Windows( https://github.com/foresterre/cargo-msrv/issues/1102 )
+          # windows-latest # Disabled due bug in `cargo-msrv` on Windows( https://github.com/foresterre/cargo-msrv/issues/1102 )
         ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
@@ -122,13 +122,13 @@ jobs:
         with:
           tool: cargo-msrv
       - name: Patch dependencies versions (Unix)
-        if: ${{ matrix.os != 'windows-2025'}}
+        if: ${{ matrix.os != 'windows-latest'}}
         run: bash ./scripts/patch_dependencies.sh
       - name: Check MSRV for all crates (Unix)
-        if: ${{ matrix.os != 'windows-2025'}}
+        if: ${{ matrix.os != 'windows-latest'}}
         run: bash ./scripts/msrv.sh ${{ matrix.rust }}
       - name: Check MSRV for all crates (Windows)
-        if: ${{ matrix.os == 'windows-2025'}}
+        if: ${{ matrix.os == 'windows-latest'}}
         run: ./scripts/msrv.ps1 ${{ matrix.rust }}
   cargo-deny:
     runs-on: ubuntu-latest

--- a/opentelemetry-etw-logs/build.rs
+++ b/opentelemetry-etw-logs/build.rs
@@ -1,7 +1,0 @@
-use std::env;
-
-fn main() {
-    if env::var("CARGO_CFG_WINDOWS").is_ok() {
-        println!("cargo:rustc-link-lib=advapi32");
-    }
-}

--- a/opentelemetry-instrumentation-actix-web/examples/client.rs
+++ b/opentelemetry-instrumentation-actix-web/examples/client.rs
@@ -13,16 +13,16 @@ async fn execute_request(client: awc::Client) -> io::Result<String> {
         .trace_request()
         .send()
         .await
-        .map_err(|err| io::Error::other(err.to_string()))?;
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
 
     let bytes = response
         .body()
         .await
-        .map_err(|err| io::Error::other(err.to_string()))?;
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
 
     std::str::from_utf8(&bytes)
         .map(|s| s.to_owned())
-        .map_err(io::Error::other)
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
 }
 
 #[actix_web::main]


### PR DESCRIPTION
Reason: Accidental Merge.

This reverts commit 85625025b6a1777c84d64a2f143dbd6aa65c6c3f.