### PR TITLE
fix: [ETW exporter] Bump tracelogging crate to 1.2.4

### DIFF
--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added validation to provider name
 - Added optional feature `serde_json` to serialize List and Maps.
+- Bump tracelogging crate to 1.2.4
 
 ## v0.8.0
 

--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["opentelemetry", "log", "trace", "etw"]
 license = "Apache-2.0"
 
 [dependencies]
-tracelogging_dynamic = "1.2.1"
+tracelogging_dynamic = "1.2.4"
 opentelemetry = { workspace = true, features = ["logs"] }
 opentelemetry_sdk = { workspace = true, features = ["logs"] }
 tracing = { version = "0.1", optional = true }

--- a/opentelemetry-etw-logs/build.rs
+++ b/opentelemetry-etw-logs/build.rs
@@ -1,7 +1,0 @@
-use std::env;
-
-fn main() {
-    if env::var("CARGO_CFG_WINDOWS").is_ok() {
-        println!("cargo:rustc-link-lib=advapi32");
-    }
-}

--- a/opentelemetry-etw-metrics/CHANGELOG.md
+++ b/opentelemetry-etw-metrics/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump tracelogging crate to 1.2.4
+
 ## v0.8.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.29

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -15,7 +15,7 @@ opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
 prost = "0.13"
-tracelogging = "1.2.1"
+tracelogging = "1.2.4"
 tracing = { version = "0.1", optional = true }
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
## Changes

And so, get rid of build.rs, added to fix the build for Rust 1.87.0

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
