### PR TITLE
fix: timestamp and binary format export

### DIFF
--- a/opentelemetry-etw-logs/src/logs/exporter/common.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/common.rs
@@ -21,7 +21,7 @@ pub fn add_attribute_to_event(event: &mut tld::EventBuilder, key: &Key, value: &
             event.add_str8(key.as_str(), s.as_str(), tld::OutType::Default, 0);
         }
         AnyValue::Bytes(b) => {
-            event.add_binaryc(key.as_str(), b.as_slice(), tld::OutType::Default, 0);
+            event.add_binary(key.as_str(), b.as_slice(), tld::OutType::Default, 0);
         }
         #[cfg(feature = "serde_json")]
         AnyValue::ListAny(_) => {

--- a/opentelemetry-etw-logs/src/logs/exporter/part_a.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/part_a.rs
@@ -95,7 +95,7 @@ fn populate_time(
     let timestamp: DateTime<Utc> = event_time.into();
     event.add_str8(
         "time",
-        timestamp.to_rfc3339().as_str(),
+        timestamp.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true).as_str(),
         tld::OutType::Default,
         field_tag,
     );


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Fixing two exporting objects:
- `time` format
- binary data (we must use `add_binary` instead of `add_binaryc` to support old ETW format.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
