### PR TITLE
refactor: opentelemetry_etw_logs: make some types pub(crate) explicitly

### DIFF
--- a/opentelemetry-etw-logs/src/logs/exporter/common.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/common.rs
@@ -6,7 +6,7 @@ use opentelemetry::{
 };
 use tracelogging_dynamic as tld;
 
-pub fn add_attribute_to_event(event: &mut tld::EventBuilder, key: &Key, value: &AnyValue) {
+pub(crate) fn add_attribute_to_event(event: &mut tld::EventBuilder, key: &Key, value: &AnyValue) {
     match value {
         AnyValue::Boolean(b) => {
             event.add_bool32(key.as_str(), *b as i32, tld::OutType::Default, 0);
@@ -48,7 +48,7 @@ pub fn add_attribute_to_event(event: &mut tld::EventBuilder, key: &Key, value: &
     }
 }
 
-pub const fn convert_severity_to_level(severity: Severity) -> tld::Level {
+pub(crate) const fn convert_severity_to_level(severity: Severity) -> tld::Level {
     match severity {
         Severity::Debug
         | Severity::Debug2
@@ -80,22 +80,22 @@ pub fn get_event_name(log_record: &opentelemetry_sdk::logs::SdkLogRecord) -> &st
 }
 
 #[cfg(test)]
-pub mod test_utils {
+pub(crate) mod test_utils {
     use opentelemetry::logs::Logger;
     use opentelemetry::logs::LoggerProvider;
     use opentelemetry_sdk::logs::SdkLoggerProvider;
 
     use super::super::ETWExporter;
 
-    pub fn new_etw_exporter() -> ETWExporter {
+    pub(crate) fn new_etw_exporter() -> ETWExporter {
         ETWExporter::new("test-provider-name")
     }
 
-    pub fn new_instrumentation_scope() -> opentelemetry::InstrumentationScope {
+    pub(crate) fn new_instrumentation_scope() -> opentelemetry::InstrumentationScope {
         opentelemetry::InstrumentationScope::default()
     }
 
-    pub fn new_sdk_log_record() -> opentelemetry_sdk::logs::SdkLogRecord {
+    pub(crate) fn new_sdk_log_record() -> opentelemetry_sdk::logs::SdkLogRecord {
         SdkLoggerProvider::builder()
             .build()
             .logger("test")

--- a/opentelemetry-etw-logs/src/logs/exporter/mod.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/mod.rs
@@ -7,9 +7,8 @@ use tracelogging_dynamic as tld;
 use opentelemetry::logs::Severity;
 use opentelemetry::Key;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use std::str;
 
-mod common;
+pub(crate) mod common;
 mod part_a;
 mod part_b;
 mod part_c;

--- a/opentelemetry-etw-logs/src/logs/exporter/part_a.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/part_a.rs
@@ -2,7 +2,7 @@ use opentelemetry_sdk::logs::TraceContext;
 use std::time::SystemTime;
 use tracelogging_dynamic as tld;
 
-pub fn populate_part_a(
+pub(crate) fn populate_part_a(
     event: &mut tld::EventBuilder,
     resource: &super::Resource,
     log_record: &opentelemetry_sdk::logs::SdkLogRecord,

--- a/opentelemetry-etw-logs/src/logs/exporter/part_b.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/part_b.rs
@@ -1,7 +1,7 @@
 use opentelemetry::{logs::Severity, Key};
 use tracelogging_dynamic as tld;
 
-pub fn populate_part_b(
+pub(crate) fn populate_part_b(
     event: &mut tld::EventBuilder,
     log_record: &opentelemetry_sdk::logs::SdkLogRecord,
     level: Severity,

--- a/opentelemetry-etw-logs/src/logs/exporter/part_c.rs
+++ b/opentelemetry-etw-logs/src/logs/exporter/part_c.rs
@@ -1,9 +1,9 @@
 use opentelemetry::logs::AnyValue;
 use tracelogging_dynamic as tld;
 
-pub const EVENT_ID: &str = "event_id";
+pub(crate) const EVENT_ID: &str = "event_id";
 
-pub fn populate_part_c(
+pub(crate) fn populate_part_c(
     event: &mut tld::EventBuilder,
     log_record: &opentelemetry_sdk::logs::SdkLogRecord,
     field_tag: u32,


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Make some inner types to be `pub(crate)` instead of `pub`. This prevents accidentally exposing APIs that are not meant to be public during refactoring.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
