### PR TITLE
chore: upperbound lz4_flex dependency to fix MSRV check

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -17,7 +17,7 @@ native-tls = "0.2"
 thiserror = "2.0"
 chrono = "0.4"
 url = "2.2"
-lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
+lz4_flex = { version = ">=0.11.0, <0.11.4", features = ["safe-encode"], default-features = false }
 
 [features]
 self_signed_certs = [] # Empty by default for security


### PR DESCRIPTION
## Changes

- this is a temporary fix. I'll first have to fix the problem in the `lz4_flex` crate and hopefully the `0.11.4` will get yanked.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
