### PR TITLE
chore: remove upperbound of lz4_flex dependency

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 url = "2.2"
 md5 = "0.7.0"
 hex = "0.4"
-lz4_flex = { version = ">=0.11.0, <0.11.4", features = ["safe-encode"], default-features = false }
+lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
 
 [features]
 self_signed_certs = [] # Empty by default for security


### PR DESCRIPTION
## Changes

- a new version of `lz4_flex` was released and the old one was yanked, which makes the upperbound unneeded now (PSeitz/lz4_flex#187)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
