### PR TITLE
fix: [Geneva Exporter] Optimize OtlpEncoder schema ID calculation by combining with field collection

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -106,7 +106,9 @@ impl OtlpEncoder {
         use std::hash::{Hash, Hasher};
 
         // Pre-allocate with estimated capacity to avoid reallocations
-        let estimated_capacity = 7 + 4 + log.attributes.len();
+        const FIXED_FIELDS_COUNT: usize = 7; // Number of fixed fields always included in the schema
+        const CONDITIONAL_FIELDS_COUNT: usize = 4; // Average number of conditional fields based on log properties
+        let estimated_capacity = FIXED_FIELDS_COUNT + CONDITIONAL_FIELDS_COUNT + log.attributes.len();
         let mut fields = Vec::with_capacity(estimated_capacity);
         fields.push((Cow::Borrowed(FIELD_ENV_NAME), BondDataType::BT_STRING as u8));
         fields.push((FIELD_ENV_VER.into(), BondDataType::BT_STRING as u8));


### PR DESCRIPTION
Fixes #311

changes picked from copilot PR: #315

## Problem

The current implementation of `OtlpEncoder` performs schema field extraction and schema ID calculation as two separate steps:

1. `determine_fields()` builds a `Vec<FieldDef>` representing the schema fields for a log record
2. `calculate_schema_id()` makes a second pass over the same vector to compute a hash for the schema ID

This double traversal happens for every log record in the batch and can impact performance in high-throughput scenarios.

## Solution

This PR optimizes the encoder by calculating the schema ID hash in the same pass as field collection:

- Added `determine_fields_and_id()` method that combines both operations in a single iteration
- Updated `encode_log_batch()` to use the optimized method instead of separate calls
- As each field is processed, both the `Vec<FieldDef>` is built and the hash is updated incrementally
- Returns both the field definitions and computed schema ID as a tuple `(Vec<FieldDef>, u64)`

## Example

**Before:**
```rust
let field_specs = self.determine_fields(log_record);
let schema_id = Self::calculate_schema_id(&field_specs);
```

**After:**
```rust
let (field_specs, schema_id) = self.determine_fields_and_id(log_record);
```

## Benefits

- **Performance**: Eliminates redundant iteration over field collections in the hot path
- **Memory**: Reduces temporary allocations during schema ID computation  
- **Maintainability**: Single source of truth for field processing logic

## Testing

- Added comprehensive test `test_optimized_field_and_id_calculation()` to verify identical results between old and new approaches
- All existing tests continue to pass, confirming no regression in behavior
- The optimization maintains the exact same hashing logic and field ordering

Fixes #311.

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Share your feedback on Copilot coding agent for the chance to win a $200 gift card! Click [here](https://survey.alchemer.com/s3/8343779/Copilot-Coding-agent) to start the survey.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
