### PR TITLE
feat: [Geneva Exporter] Add encoding benchmarks for OTLP log batch

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -92,28 +92,28 @@ mod benchmarks {
                 0 => AnyValue {
                     value: Some(
                         opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                            format!("string_value_{}", rng.gen::<u32>()),
+                            format!("string_value_{}", rng.random::<u32>()),
                         ),
                     ),
                 },
                 1 => AnyValue {
                     value: Some(
                         opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(
-                            rng.gen_range(0..1000),
+                            rng.random_range(0..1000),
                         ),
                     ),
                 },
                 2 => AnyValue {
                     value: Some(
                         opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(
-                            rng.gen_range(0.0..100.0),
+                            rng.random_range(0.0..100.0),
                         ),
                     ),
                 },
                 _ => AnyValue {
                     value: Some(
                         opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(
-                            rng.gen_bool(0.5),
+                            rng.random::<f64>() < 0.5,
                         ),
                     ),
                 },


### PR DESCRIPTION
## Changes
Adds Criterion-based microbenchmarks for OTLP log batch encoding, covering:

- Attribute count scaling (0, 4, 8, 16 attributes)
- Batch size scaling (1, 10, 100, 1000 logs)
- Schema cache effectiveness (100 logs, same schema)
- Mixed event names (100 logs, 3 event names)
Results
```
Attribute count scaling (10 logs each):
  - 0 attrs:   ~10.3 µs/op
  - 4 attrs:   ~15.7 µs/op
  - 8 attrs:   ~24.3 µs/op
  - 16 attrs:  ~44.1 µs/op

Batch size scaling (4 attributes per log):
  - 1 log:     ~1.63 µs/op
  - 10 logs:   ~16.4 µs/op
  - 100 logs:  ~161 µs/op
  - 1000 logs: ~1.59 ms/op

Schema cache effectiveness (100 logs, 4 attributes): ~165 µs/op

Mixed event names (100 logs, 3 event names, 4 attributes): ~168 µs/op
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
