### PR TITLE
perf: Use thread-local eventbuilders for ETW logs.

### DIFF
--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -32,12 +32,10 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
     "registry",
     "std",
 ] }
+criterion = "0.5"
 
 [features]
-spec_unstable_logs_enabled = [
-    "opentelemetry/spec_unstable_logs_enabled",
-    "opentelemetry_sdk/spec_unstable_logs_enabled",
-]
+spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
 internal-logs = [
     "tracing",
     "opentelemetry/internal-logs",
@@ -50,6 +48,11 @@ default = ["internal-logs"]
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
+
+[[bench]]
+name = "logs"
+harness = false
+required-features = ["spec_unstable_logs_enabled"]
 
 [lints]
 workspace = true

--- a/opentelemetry-etw-logs/benches/logs.rs
+++ b/opentelemetry-etw-logs/benches/logs.rs
@@ -2,7 +2,7 @@
     The benchmark results:
     criterion = "0.5.1"
 
-    Hardware: Apple M4 Pro
+    Hardware: AMD EPYC 7763 64-Core Processor 2.44 GHz, 64GB RAM, Cores:8 , Logical processors: 16
     Total Number of Cores:	16
     // When no listener
     | Test                        | Average time|
@@ -13,12 +13,12 @@
     // When listener is enabled
     | Test                        | Average time|
     |-----------------------------|-------------|
-    | Etw_4_Attributes            | 530 ns      |
-    | Etw_6_Attributes            | 586 ns      |
+    | Etw_4_Attributes            | 1.3659 µs   |
+    | Etw_6_Attributes            | 1.6487 µs   |
 */
 
 // running the following from the current directory
-// sudo -E ~/.cargo/bin/cargo bench --bench logs --all-features
+// cargo bench --bench logs --all-features
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry_appender_tracing::layer as tracing_layer;
@@ -30,7 +30,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::Registry;
 
 fn benchmark_with_ot_layer(c: &mut Criterion, name: &str, num_attributes: usize) {
-    let etw_processor = Processor::builder("myprovider").build().unwrap();
+    let etw_processor = Processor::builder("provider_name").build().unwrap();
     let provider = SdkLoggerProvider::builder()
         .with_resource(
             Resource::builder_empty()

--- a/opentelemetry-etw-logs/benches/logs.rs
+++ b/opentelemetry-etw-logs/benches/logs.rs
@@ -1,0 +1,84 @@
+/*
+    The benchmark results:
+    criterion = "0.5.1"
+
+    Hardware: Apple M4 Pro
+    Total Number of Cores:	16
+    // When no listener
+    | Test                        | Average time|
+    |-----------------------------|-------------|
+    | Etw_4_Attributes            | 8 ns        |
+    | Etw_6_Attributes            | 8 ns        |
+
+    // When listener is enabled
+    | Test                        | Average time|
+    |-----------------------------|-------------|
+    | Etw_4_Attributes            | 530 ns      |
+    | Etw_6_Attributes            | 586 ns      |
+*/
+
+// running the following from the current directory
+// sudo -E ~/.cargo/bin/cargo bench --bench logs --all-features
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry_appender_tracing::layer as tracing_layer;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::Resource;
+use opentelemetry_etw_logs::Processor;
+use tracing::error;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Registry;
+
+fn benchmark_with_ot_layer(c: &mut Criterion, name: &str, num_attributes: usize) {
+    let etw_processor = Processor::builder("myprovider").build().unwrap();
+    let provider = SdkLoggerProvider::builder()
+        .with_resource(
+            Resource::builder_empty()
+                .with_service_name("benchmark")
+                .build(),
+        )
+        .with_log_processor(etw_processor)
+        .build();
+    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
+    let subscriber = Registry::default().with(ot_layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        c.bench_function(name, |b| {
+            b.iter(|| {
+                if num_attributes == 4 {
+                    error!(
+                        name : "CheckoutFailed",
+                        field1 = "field1",
+                        field2 = "field2",
+                        field3 = "field3",
+                        field4 = "field4",
+                        message = "Unable to process checkout."
+                    );
+                } else if num_attributes == 6 {
+                    error!(
+                        name : "CheckoutFailed",
+                        field1 = "field1",
+                        field2 = "field2",
+                        field3 = "field3",
+                        field4 = "field4",
+                        field5 = "field5",
+                        field6 = "field6",
+                        message = "Unable to process checkout."
+                    );
+                }
+            });
+        });
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    benchmark_with_ot_layer(c, "Etw_4_Attributes", 4);
+    benchmark_with_ot_layer(c, "Etw_6_Attributes", 6);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -13,10 +13,10 @@ doc = false
 
 # below build is failing with otel v0.30. this needs to be enabled
 # while building for otel-v30
-#[[bin]]
-#name = "etw"
-#path = "src/etw_logs.rs"
-#doc = false
+[[bin]]
+name = "etw"
+path = "src/etw_logs.rs"
+doc = false
 
 [[bin]]
 name = "geneva_exporter"

--- a/stress/src/etw_logs.rs
+++ b/stress/src/etw_logs.rs
@@ -27,7 +27,7 @@ mod throughput;
 
 // Function to initialize the logger
 fn init_logger() -> SdkLoggerProvider {
-    let processor = Processor::builder("provider-name").build().unwrap();
+    let processor = Processor::builder("provider_name").build().unwrap();
 
     SdkLoggerProvider::builder()
         .with_log_processor(processor)


### PR DESCRIPTION
~30% improvement in benches/stress, when listener is enabled.