### PR TITLE
feat: [Geneva Exporter] Add concurrent uploads to GenevaClient with configurable parallelism

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -20,6 +20,7 @@ url = "2.2"
 md5 = "0.8.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
+futures = "0.3"
 
 [features]
 self_signed_certs = [] # Empty by default for security

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -4,6 +4,7 @@ use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfig
 use crate::ingestion_service::uploader::{GenevaUploader, GenevaUploaderConfig};
 use crate::payload_encoder::lz4_chunked_compression::lz4_chunked_compression;
 use crate::payload_encoder::otlp_encoder::OtlpEncoder;
+use futures::stream::{self, StreamExt};
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use std::sync::Arc;
 
@@ -20,6 +21,8 @@ pub struct GenevaClientConfig {
     pub tenant: String,
     pub role_name: String,
     pub role_instance: String,
+    /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
+    pub max_concurrent_uploads: Option<usize>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }
 
@@ -29,6 +32,7 @@ pub struct GenevaClient {
     uploader: Arc<GenevaUploader>,
     encoder: OtlpEncoder,
     metadata: String,
+    max_concurrent_uploads: usize,
 }
 
 impl GenevaClient {
@@ -76,10 +80,16 @@ impl GenevaClient {
             cfg.role_name,
             cfg.role_instance,
         );
+        let max_concurrent_uploads = cfg.max_concurrent_uploads.unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|p| p.get())
+                .unwrap_or(4)
+        });
         Ok(Self {
             uploader: Arc::new(uploader),
             encoder: OtlpEncoder::new(),
             metadata,
+            max_concurrent_uploads,
         })
     }
 
@@ -90,16 +100,47 @@ impl GenevaClient {
             .flat_map(|resource_log| resource_log.scope_logs.iter())
             .flat_map(|scope_log| scope_log.log_records.iter());
         let blobs = self.encoder.encode_log_batch(log_iter, &self.metadata);
-        for (_schema_id, event_name, encoded_blob, _row_count) in blobs {
-            // TODO - log encoded_blob for debugging
-            let compressed_blob = lz4_chunked_compression(&encoded_blob)
-                .map_err(|e| format!("LZ4 compression failed: {e}"))?;
-            // TODO - log compressed_blob for debugging
-            let event_version = "Ver2v0"; // TODO - find the actual value to be populated
-            self.uploader
-                .upload(compressed_blob, &event_name, event_version)
-                .await
-                .map_err(|e| format!("Geneva upload failed: {e}"))?;
+
+        // create an iterator that yields futures for each upload
+        let upload_futures =
+            blobs
+                .into_iter()
+                .map(|(_schema_id, event_name, encoded_blob, _row_count)| {
+                    let uploader = Arc::clone(&self.uploader);
+                    let event_version = "Ver2v0"; // TODO - find the actual value to be populated
+                    async move {
+                        let compressed_blob = match lz4_chunked_compression(&encoded_blob) {
+                            Ok(blob) => blob,
+                            Err(e) => {
+                                return Err(format!(
+                                    "LZ4 compression failed: {e} Event: {event_name}"
+                                ))
+                            }
+                        };
+                        match uploader
+                            .upload(compressed_blob, &event_name, event_version)
+                            .await
+                        {
+                            Ok(_) => Ok(()),
+                            Err(e) => Err(format!("Geneva upload failed: {e} Event: {event_name}")),
+                        }
+                    }
+                });
+        // Execute uploads concurrently with configurable concurrency
+        let results: Vec<Result<(), String>> = stream::iter(upload_futures)
+            .buffer_unordered(self.max_concurrent_uploads)
+            .collect()
+            .await;
+
+        // Collect any errors
+        let errors: Vec<String> = results
+            .into_iter()
+            .filter_map(|result| result.err())
+            .collect();
+
+        // Return error if any uploads failed
+        if !errors.is_empty() {
+            return Err(format!("Upload failures: {}", errors.join("; ")));
         }
         Ok(())
     }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -82,6 +82,7 @@ impl GenevaClient {
         );
         let max_concurrent_uploads = cfg.max_concurrent_uploads.unwrap_or_else(|| {
             // TODO - Use a more sophisticated method to determine concurrency if needed
+            // currently using number of CPU cores
             std::thread::available_parallelism()
                 .map(|p| p.get())
                 .unwrap_or(4)

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -107,7 +107,6 @@ impl GenevaClient {
         let upload_futures = blobs
             .into_iter()
             .map(|(event_name, encoded_blob, _row_count)| {
-                let uploader = Arc::clone(&self.uploader);
                 let event_version = "Ver2v0"; // TODO - find the actual value to be populated
                 async move {
                     // TODO: Investigate using tokio::spawn_blocking for LZ4 compression to avoid blocking

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -62,6 +62,7 @@ async fn main() {
         tenant,
         role_name,
         role_instance,
+        max_concurrent_uploads: None, // Use default
     };
 
     let geneva_client = GenevaClient::new(config)

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -55,7 +55,7 @@ fn create_test_logs() -> Vec<ResourceLogs> {
     for i in 0..10 {
         let log = LogRecord {
             observed_time_unix_nano: 1700000000000000000 + i,
-            event_name: format!("StressTestEvent_{}", i % 2),
+            event_name: "StressTestEvent".to_string(),
             severity_number: 9,
             severity_text: "INFO".to_string(),
             body: Some(AnyValue {

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -51,7 +51,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn create_test_logs() -> Vec<ResourceLogs> {
     let mut log_records = Vec::new();
 
-    // Create 10 simple log records (5 records for each of two different events)
+    // Create 10 simple log records
     for i in 0..10 {
         let log = LogRecord {
             observed_time_unix_nano: 1700000000000000000 + i,

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -51,11 +51,11 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn create_test_logs() -> Vec<ResourceLogs> {
     let mut log_records = Vec::new();
 
-    // Create 10 simple log records
+    // Create 10 simple log records (5 records for each of two different events)
     for i in 0..10 {
         let log = LogRecord {
             observed_time_unix_nano: 1700000000000000000 + i,
-            event_name: "StressTestEvent".to_string(),
+            event_name: format!("StressTestEvent_{}", i % 2),
             severity_number: 9,
             severity_text: "INFO".to_string(),
             body: Some(AnyValue {
@@ -123,6 +123,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             tenant: std::env::var("GENEVA_TENANT").unwrap_or_else(|_| "test".to_string()),
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
+            max_concurrent_uploads: None, // Use default
         };
 
         let client = GenevaClient::new(config).await?;
@@ -141,6 +142,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             tenant: "test".to_string(),
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
+            max_concurrent_uploads: None, // Use default
         };
 
         let client = GenevaClient::new(config).await?;
@@ -195,6 +197,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             tenant: "test".to_string(),
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
+            max_concurrent_uploads: None, // Use default
         };
 
         let client = GenevaClient::new(config).await?;


### PR DESCRIPTION
Towards 4th point of #306.

## Changes

Enhanced GenevaClient to support concurrent uploads with configurable parallelism, improving throughput for bulk log ingestion.

## Changes
- Added `max_concurrent_uploads` configuration option to `GenevaClientConfig`
- Modified `upload_logs()` to use `buffer_unordered` for concurrent upload processing
- Moved LZ4 compression into async tasks to enable concurrent compression
- Defaults to number of CPU cores if `max_concurrent_uploads` is not specified
- Enhanced error messages to include event names for better debugging

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
