### PR TITLE
fix: [Geneva Exporter] Fix schema ID query parameter to use actual payload schemas instead of hardcoded values

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -109,11 +109,17 @@ impl GenevaClient {
                     let event_version = "Ver2v0"; // TODO - find the actual value to be populated
 
                     // Convert schema IDs to semicolon-separated string for the upload
-                    let schema_ids_str = schema_ids
-                        .iter()
-                        .map(|id| format!("{:x}", id))
-                        .collect::<Vec<_>>()
-                        .join(";");
+                    // Use pre-allocated capacity and write directly to avoid intermediate allocations
+                    let mut schema_ids_str = String::with_capacity(
+                        schema_ids.len() * 16 + schema_ids.len().saturating_sub(1),
+                    );
+                    for (i, id) in schema_ids.iter().enumerate() {
+                        if i > 0 {
+                            schema_ids_str.push(';');
+                        }
+                        use std::fmt::Write;
+                        write!(&mut schema_ids_str, "{:x}", id).unwrap();
+                    }
 
                     async move {
                         // TODO: Investigate using tokio::spawn_blocking for LZ4 compression to avoid blocking

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -44,15 +44,12 @@ mod tests {
             let source_identity = env::var("GENEVA_SOURCE_IDENTITY").unwrap_or_else(|_| {
                 "Tenant=Default/Role=Uploader/RoleInstance=devhost".to_string()
             });
-            let schema_ids =
-                "c1ce0ecea020359624c493bbe97f9e80;0da22cabbee419e000541a5eda732eb3".to_string();
 
             // Define uploader config
             let uploader_config = GenevaUploaderConfig {
                 namespace: namespace.clone(),
                 source_identity,
                 environment: environment.clone(),
-                schema_ids,
             };
 
             let config = GenevaConfigClientConfig {
@@ -123,7 +120,12 @@ mod tests {
         let start = Instant::now();
         let response = ctx
             .uploader
-            .upload(ctx.data, &ctx.event_name, &ctx.event_version)
+            .upload(
+                ctx.data,
+                &ctx.event_name,
+                &ctx.event_version,
+                "test_schema_id",
+            )
             .await
             .expect("Upload failed");
 
@@ -181,7 +183,12 @@ mod tests {
         let start_warmup = Instant::now();
         let _ = ctx
             .uploader
-            .upload(ctx.data.clone(), &ctx.event_name, &ctx.event_version)
+            .upload(
+                ctx.data.clone(),
+                &ctx.event_name,
+                &ctx.event_version,
+                "test_schema_id",
+            )
             .await
             .expect("Warm-up upload failed");
         let warmup_elapsed = start_warmup.elapsed();
@@ -201,7 +208,7 @@ mod tests {
             let handle = tokio::spawn(async move {
                 let start = Instant::now();
                 let resp = uploader
-                    .upload(data, &event_name, &event_version)
+                    .upload(data, &event_name, &event_version, "test_schema_id")
                     .await
                     .unwrap_or_else(|_| panic!("Upload {i} failed"));
                 let elapsed = start.elapsed();

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -106,7 +106,6 @@ pub(crate) struct GenevaUploaderConfig {
     pub source_identity: String,
     #[allow(dead_code)]
     pub environment: String,
-    pub schema_ids: String,
 }
 
 /// Client for uploading data to Geneva Ingestion Gateway (GIG)
@@ -157,6 +156,7 @@ impl GenevaUploader {
         data_size: usize,
         event_name: &str,
         event_version: &str,
+        schema_ids: &str,
     ) -> Result<String> {
         let now: DateTime<Utc> = Utc::now(); //TODO - this need to be calculated from the bond data
         let end_time = now + ChronoDuration::minutes(5); //TODO - this need to be calculated from the bond data
@@ -210,7 +210,7 @@ impl GenevaUploader {
             end_time,
             data_size,
             2,
-            self.config.schema_ids
+            schema_ids
         ).map_err(|e| GenevaUploaderError::InternalError(format!("Failed to write query string: {e}")))?;
         Ok(query)
     }
@@ -219,6 +219,9 @@ impl GenevaUploader {
     ///
     /// # Arguments
     /// * `data` - The encoded data to upload (already in the required format)
+    /// * `event_name` - Name of the event
+    /// * `event_version` - Version of the event
+    /// * `schema_ids` - Semicolon-separated string of schema IDs present in the payload
     ///
     /// # Returns
     /// * `Result<IngestionResponse>` - The response containing the ticket ID or an error
@@ -228,6 +231,7 @@ impl GenevaUploader {
         data: Vec<u8>,
         event_name: &str,
         event_version: &str,
+        schema_ids: &str,
     ) -> Result<IngestionResponse> {
         // Always get fresh auth info
         let (auth_info, moniker_info, monitoring_endpoint) =
@@ -239,6 +243,7 @@ impl GenevaUploader {
             data_size,
             event_name,
             event_version,
+            schema_ids,
         )?;
         let full_url = format!(
             "{}/{}",

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -106,8 +106,12 @@ impl OtlpEncoder {
         for (batch_event_name, (schema_entries, events)) in batches {
             let events_len = events.len();
 
-            // Extract schema IDs from the schema entries
-            let schema_ids: Vec<u64> = schema_entries.iter().map(|s| s.id).collect();
+            // Pre-allocate schema_ids Vec and build it directly from schema_entries
+            // This avoids the intermediate .collect() allocation
+            let mut schema_ids = Vec::with_capacity(schema_entries.len());
+            for schema_entry in &schema_entries {
+                schema_ids.push(schema_entry.id);
+            }
 
             let blob = CentralBlob {
                 version: 1,


### PR DESCRIPTION
## PR Description:

### Problem

The `schemaIds` query parameter was hardcoded to static values instead of reflecting the actual schemas present in the uploaded payload. While this doesn't affect ingestion functionality, it impacts backend operations including auditing, correlation, and pipeline routing that rely on accurate schema identification.

### Solution

- __Dynamic Schema ID Generation__: Extract actual schema IDs from encoded payload and pass them to the ingestion service
- __API Updates__: Enhanced upload method to accept dynamic schema IDs parameter

### Changes Made

1. __OTLP Encoder__ (`otlp_encoder.rs`):

   - Modified `encode_log_batch` to return schema IDs along with encoded data

2. __Geneva Client__ (`client.rs`):

   - Updated to extract schema IDs from encoder output

3. __Uploader__ (`uploader.rs`):

   - Enhanced `upload` method to accept dynamic `schema_ids` parameter
   - Updated query string generation to use actual schema IDs

4. __Tests__: Updated all test cases to use new method signature


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
