### PR TITLE
fix: [Geneva Exporter] Use config version for event_version in payload upload URL generation

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -67,11 +67,7 @@ impl GenevaClient {
         // Metadata string for the blob
         let metadata = format!(
             "namespace={}/eventVersion={}/tenant={}/role={}/roleinstance={}",
-            cfg.namespace,
-            config_version,
-            cfg.tenant,
-            cfg.role_name,
-            cfg.role_instance,
+            cfg.namespace, config_version, cfg.tenant, cfg.role_name, cfg.role_instance,
         );
 
         // Uploader config

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -61,8 +61,20 @@ impl GenevaClient {
         let schema_ids =
             "c1ce0ecea020359624c493bbe97f9e80;0da22cabbee419e000541a5eda732eb3".to_string(); // TODO - find the actual value to be populated
 
-        // Uploader config
+        // Define config_version before using it
         let config_version = format!("Ver{}v0", cfg.config_major_version);
+
+        // Metadata string for the blob
+        let metadata = format!(
+            "namespace={}/eventVersion={}/tenant={}/role={}/roleinstance={}",
+            cfg.namespace,
+            config_version,
+            cfg.tenant,
+            cfg.role_name,
+            cfg.role_instance,
+        );
+
+        // Uploader config
         let uploader_config = GenevaUploaderConfig {
             namespace: cfg.namespace.clone(),
             source_identity,
@@ -74,14 +86,6 @@ impl GenevaClient {
         let uploader = GenevaUploader::from_config_client(config_client, uploader_config)
             .await
             .map_err(|e| format!("GenevaUploader init failed: {e}"))?;
-        let metadata = format!(
-            "namespace={}/eventVersion={}/tenant={}/role={}/roleinstance={}",
-            cfg.namespace,
-            config_version,
-            cfg.tenant,
-            cfg.role_name,
-            cfg.role_instance,
-        );
         let max_concurrent_uploads = cfg.max_concurrent_uploads.unwrap_or_else(|| {
             // TODO - Use a more sophisticated method to determine concurrency if needed
             // currently using number of CPU cores

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -48,11 +48,13 @@ mod tests {
                 "c1ce0ecea020359624c493bbe97f9e80;0da22cabbee419e000541a5eda732eb3".to_string();
 
             // Define uploader config
+            let config_version = format!("Ver{}v0", config_major_version);
             let uploader_config = GenevaUploaderConfig {
                 namespace: namespace.clone(),
                 source_identity,
                 environment: environment.clone(),
                 schema_ids,
+                config_version,
             };
 
             let config = GenevaConfigClientConfig {
@@ -123,7 +125,7 @@ mod tests {
         let start = Instant::now();
         let response = ctx
             .uploader
-            .upload(ctx.data, &ctx.event_name, &ctx.event_version)
+            .upload(ctx.data, &ctx.event_name)
             .await
             .expect("Upload failed");
 
@@ -181,7 +183,7 @@ mod tests {
         let start_warmup = Instant::now();
         let _ = ctx
             .uploader
-            .upload(ctx.data.clone(), &ctx.event_name, &ctx.event_version)
+            .upload(ctx.data.clone(), &ctx.event_name)
             .await
             .expect("Warm-up upload failed");
         let warmup_elapsed = start_warmup.elapsed();
@@ -196,12 +198,10 @@ mod tests {
             let uploader = ctx.uploader.clone();
             let data = ctx.data.clone();
             let event_name = ctx.event_name.to_string();
-            let event_version = ctx.event_version.to_string();
-
             let handle = tokio::spawn(async move {
                 let start = Instant::now();
                 let resp = uploader
-                    .upload(data, &event_name, &event_version)
+                    .upload(data, &event_name)
                     .await
                     .unwrap_or_else(|_| panic!("Upload {i} failed"));
                 let elapsed = start.elapsed();

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -17,7 +17,6 @@ mod tests {
             pub data: Vec<u8>,
             pub uploader: GenevaUploader,
             pub event_name: String,
-            pub event_version: String,
         }
 
         pub async fn build_test_upload_context() -> TestUploadContext {
@@ -48,7 +47,7 @@ mod tests {
                 "c1ce0ecea020359624c493bbe97f9e80;0da22cabbee419e000541a5eda732eb3".to_string();
 
             // Define uploader config
-            let config_version = format!("Ver{}v0", config_major_version);
+            let config_version = format!("Ver{config_major_version}v0");
             let uploader_config = GenevaUploaderConfig {
                 namespace: namespace.clone(),
                 source_identity,
@@ -80,13 +79,11 @@ mod tests {
 
             // Event name/version
             let event_name = "Log".to_string();
-            let event_version = "Ver2v0".to_string();
 
             TestUploadContext {
                 data,
                 uploader,
                 event_name,
-                event_version,
             }
         }
     }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -107,6 +107,7 @@ pub(crate) struct GenevaUploaderConfig {
     #[allow(dead_code)]
     pub environment: String,
     pub schema_ids: String,
+    pub config_version: String,
 }
 
 /// Client for uploading data to Geneva Ingestion Gateway (GIG)
@@ -156,7 +157,6 @@ impl GenevaUploader {
         moniker: &str,
         data_size: usize,
         event_name: &str,
-        event_version: &str,
     ) -> Result<String> {
         let now: DateTime<Utc> = Utc::now(); //TODO - this need to be calculated from the bond data
         let end_time = now + ChronoDuration::minutes(5); //TODO - this need to be calculated from the bond data
@@ -203,7 +203,7 @@ impl GenevaUploader {
             moniker,
             self.config.namespace,
             event_name,
-            event_version,
+            self.config.config_version,
             source_unique_id,
             encoded_source_identity,
             start_time,
@@ -227,7 +227,6 @@ impl GenevaUploader {
         &self,
         data: Vec<u8>,
         event_name: &str,
-        event_version: &str,
     ) -> Result<IngestionResponse> {
         // Always get fresh auth info
         let (auth_info, moniker_info, monitoring_endpoint) =
@@ -238,7 +237,6 @@ impl GenevaUploader {
             &moniker_info.name,
             data_size,
             event_name,
-            event_version,
         )?;
         let full_url = format!(
             "{}/{}",


### PR DESCRIPTION

## Changes

Replace hardcoded event versions with config-driven versions in Geneva uploader. The `event_version` parameter in URL generation now comes from `config_major_version` and is formatted as `Ver{major_version}v0`.
 
## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
