### PR TITLE
feat: [Geneva Exporter] Add retry logic for Geneva uploader.

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -21,6 +21,8 @@ md5 = "0.8.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
 futures = "0.3"
+tokio = "1.0"
+rand = "0.8"
 
 [features]
 self_signed_certs = [] # Empty by default for security

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -21,7 +21,7 @@ md5 = "0.8.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
 futures = "0.3"
-tokio = "1.0"
+tokio = { version = "1.0", features = ["time"] }
 rand = "0.8"
 
 [features]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -23,6 +23,8 @@ pub struct GenevaClientConfig {
     pub role_instance: String,
     /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
     pub max_concurrent_uploads: Option<usize>,
+    /// Retry configuration for failed uploads. If None, uses default retry settings.
+    pub retry_config: Option<crate::RetryConfig>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }
 
@@ -73,6 +75,7 @@ impl GenevaClient {
             source_identity,
             environment: cfg.environment,
             config_version: config_version.clone(),
+            retry_config: cfg.retry_config.unwrap_or_default(),
         };
 
         let uploader = GenevaUploader::from_config_client(config_client, uploader_config)

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -51,6 +51,7 @@ mod tests {
                 source_identity,
                 environment: environment.clone(),
                 config_version,
+                retry_config: crate::RetryConfig::default(),
             };
 
             let config = GenevaConfigClientConfig {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -1,6 +1,7 @@
 mod config_service;
 mod ingestion_service;
 pub mod payload_encoder;
+pub mod retry;
 
 pub mod client;
 
@@ -19,3 +20,4 @@ pub(crate) use ingestion_service::uploader::{
 
 pub use client::{GenevaClient, GenevaClientConfig};
 pub use config_service::client::AuthMethod;
+pub use retry::RetryConfig;

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/retry.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/retry.rs
@@ -1,0 +1,176 @@
+//! Simple retry functionality that can be shared across services
+
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Simple retry configuration
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts (0 means no retries)
+    pub max_retries: u32,
+    /// Fixed delay between retries
+    pub delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            delay: Duration::from_millis(1000), // 1 second
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Create a new retry configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the maximum number of retry attempts
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Set the delay between retries
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
+    }
+}
+
+/// Execute a function with retry logic
+pub async fn retry_with_config<F, Fut, T, E>(
+    config: &RetryConfig,
+    operation_name: &str,
+    mut operation: F,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display + Clone,
+{
+    let max_attempts = config.max_retries + 1; // +1 for the initial attempt
+    let mut last_error = None;
+
+    for attempt in 0..max_attempts {
+        // Wait before retry (but not before the first attempt)
+        if attempt > 0 {
+            if !config.delay.is_zero() {
+                sleep(config.delay).await;
+            }
+        }
+
+        match operation().await {
+            Ok(result) => {
+                // Success! Log retry info if this wasn't the first attempt
+                if attempt > 0 {
+                    eprintln!(
+                        "{} succeeded on attempt {} after retries",
+                        operation_name,
+                        attempt + 1
+                    );
+                }
+                return Ok(result);
+            }
+            Err(error) => {
+                last_error = Some(error.clone());
+
+                // Only retry if we haven't reached max attempts
+                if attempt < max_attempts - 1 {
+                    eprintln!(
+                        "{} attempt {} failed: {}. Retrying in {:?}...",
+                        operation_name,
+                        attempt + 1,
+                        error,
+                        config.delay
+                    );
+                    continue;
+                } else {
+                    // We've exhausted all retries
+                    eprintln!(
+                        "{} failed after {} attempts: {}",
+                        operation_name, max_attempts, error
+                    );
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    // This should never be reached, but just in case
+    Err(last_error.unwrap())
+}
+
+/// Execute a function with retry logic that includes retriability checking
+pub async fn retry_with_config_and_check<F, Fut, T, E, R>(
+    config: &RetryConfig,
+    operation_name: &str,
+    mut operation: F,
+    is_retriable: R,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display + Clone,
+    R: Fn(&E) -> bool,
+{
+    let max_attempts = config.max_retries + 1; // +1 for the initial attempt
+    let mut last_error = None;
+
+    for attempt in 0..max_attempts {
+        // Wait before retry (but not before the first attempt)
+        if attempt > 0 {
+            if !config.delay.is_zero() {
+                sleep(config.delay).await;
+            }
+        }
+
+        match operation().await {
+            Ok(result) => {
+                // Success! Log retry info if this wasn't the first attempt
+                if attempt > 0 {
+                    eprintln!(
+                        "{} succeeded on attempt {} after retries",
+                        operation_name,
+                        attempt + 1
+                    );
+                }
+                return Ok(result);
+            }
+            Err(error) => {
+                last_error = Some(error.clone());
+
+                // Check if we should retry - only if we haven't reached max attempts AND error is retriable
+                if attempt < max_attempts - 1 && is_retriable(&error) {
+                    eprintln!(
+                        "{} attempt {} failed: {}. Retrying in {:?}...",
+                        operation_name,
+                        attempt + 1,
+                        error,
+                        config.delay
+                    );
+                    continue;
+                } else {
+                    // Either we've exhausted retries or the error is not retriable
+                    if attempt == max_attempts - 1 {
+                        eprintln!(
+                            "{} failed after {} attempts: {}",
+                            operation_name, max_attempts, error
+                        );
+                    } else {
+                        eprintln!(
+                            "{} failed with non-retriable error: {}",
+                            operation_name, error
+                        );
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    // This should never be reached, but just in case
+    Err(last_error.unwrap())
+}

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -63,6 +63,7 @@ async fn main() {
         role_name,
         role_instance,
         max_concurrent_uploads: None, // Use default
+        retry_config: None,           // Use default retry configuration
     };
 
     let geneva_client = GenevaClient::new(config)

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -124,6 +124,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             max_concurrent_uploads: None, // Use default
+            retry_config: None,           // Use default retry configuration
         };
 
         let client = GenevaClient::new(config).await?;
@@ -143,6 +144,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             max_concurrent_uploads: None, // Use default
+            retry_config: None,           // Use default retry configuration
         };
 
         let client = GenevaClient::new(config).await?;
@@ -198,6 +200,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             max_concurrent_uploads: None, // Use default
+            retry_config: None,           // Use default retry configuration
         };
 
         let client = GenevaClient::new(config).await?;


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

This PR introduces a new retry module and integrates it into the Geneva uploader to handle transient failures gracefully. The implementation provides configurable retry logic with support for retriability checking, while also including TODOs for future enhancements like exponential backoff and jitter.

1. **New Retry Module (`retry.rs`)**:
   - `RetryConfig` struct with configurable max retries and delay
   - `retry_with_config()` - Simple retry function with fixed delays
   - `retry_with_config_and_check()` - Advanced retry with retriability checking
   - TODOs for future exponential backoff and jitter support
   
2. **Uploader Integration (`uploader.rs`)**:
    - Added `retry_config` to `GenevaUploaderConfig`
    - Implemented `is_retriable()` method on `GenevaUploaderError` to intelligently determine which errors should trigger retries
    - Modified `upload()` method to use `retry_with_config_and_check()` for automatic retries.

3. **Client Integration (`client.rs`)**:
   - Added optional `retry_config` field to `GenevaClientConfig`
   - Passes retry configuration to the uploader during initialization
   - Uses default retry configuration if none is provided
  
4. ### Error Retriability Logic: The `is_retriable()` method implements smart error classification:
     -  **Network failures** (timeouts, connection refused, etc.) are retried as they're often transient
     - **Server errors** (5xx) and rate limiting (429) trigger retries
     - **Config service errors** are retried (may involve token refresh)
     - **Client errors** (parsing, internal logic) don't waste retry attempts


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
