### PR TITLE
feat: [Geneva Exporter] Add configurable User-Agent Header

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -511,6 +511,7 @@ pub unsafe extern "C" fn geneva_client_new(
         role_name,
         role_instance,
         msi_resource,
+        user_agent_prefix: None, // FFI doesn't expose user agent prefix configuration
     };
 
     // Create client
@@ -1203,6 +1204,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            user_agent_prefix: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
 
@@ -1317,6 +1319,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            user_agent_prefix: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -25,7 +25,10 @@ pub struct GenevaClientConfig {
     pub max_concurrent_uploads: Option<usize>,
     /// User agent for the application. Will be formatted as "<application> (RustGenevaClient/0.1)".
     /// If None, defaults to "RustGenevaClient/0.1".
-    /// 
+    ///
+    /// The suffix must contain only ASCII printable characters, be non-empty (after trimming),
+    /// and not exceed 200 characters in length.
+    ///
     /// Examples:
     /// - None: "RustGenevaClient/0.1"
     /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (RustGenevaClient/0.1)"

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -69,7 +69,6 @@ impl GenevaClient {
             region: cfg.region,
             config_major_version: cfg.config_major_version,
             auth_method: cfg.auth_method,
-            user_agent_prefix: cfg.user_agent_prefix,
             static_headers: static_headers.clone(),
         };
         let config_client = Arc::new(

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -25,7 +25,7 @@ pub struct GenevaClientConfig {
     pub max_concurrent_uploads: Option<usize>,
     /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>-0.1".
     /// If None, defaults to "RustGenevaClient-0.1".
-    pub user_agent_suffix: Option<String>,
+    pub user_agent_suffix: Option<&'static str>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -85,6 +85,7 @@ impl GenevaClient {
             source_identity,
             environment: cfg.environment,
             config_version: config_version.clone(),
+            user_agent_prefix: cfg.user_agent_prefix,
         };
 
         let uploader = GenevaUploader::from_config_client(config_client, uploader_config)

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -1,11 +1,13 @@
 //! High-level GenevaClient for user code. Wraps config_service and ingestion_service.
 
+use crate::common::validate_user_agent_prefix;
 use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfigClientConfig};
 use crate::ingestion_service::uploader::{GenevaUploader, GenevaUploaderConfig};
 use crate::payload_encoder::lz4_chunked_compression::lz4_chunked_compression;
 use crate::payload_encoder::otlp_encoder::OtlpEncoder;
 use futures::stream::{self, StreamExt};
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use std::sync::Arc;
 
 /// Configuration for GenevaClient (user-facing)
@@ -35,6 +37,59 @@ pub struct GenevaClientConfig {
     /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
     pub user_agent_prefix: Option<&'static str>,
     // Add event name/version here if constant, or per-upload if you want them per call.
+}
+
+/// Builds a standardized User-Agent header for Geneva services
+///
+/// # Arguments
+/// * `user_agent_prefix` - Optional user agent prefix from the client configuration
+///
+/// # Returns
+/// * `Result<HeaderValue, String>` - A properly formatted User-Agent header value
+///
+/// # Format
+/// - If prefix is None or empty: "GenevaUploader/0.1"
+/// - If prefix is provided: "{prefix} (GenevaUploader/0.1)"
+///
+/// # Example
+/// ```ignore
+/// let header = build_user_agent_header(Some("MyApp/2.1.0"))?;
+/// // Results in: "MyApp/2.1.0 (GenevaUploader/0.1)"
+/// ```
+pub fn build_user_agent_header(user_agent_prefix: Option<&str>) -> Result<HeaderValue, String> {
+    let prefix = user_agent_prefix.unwrap_or("");
+
+    // Validate the prefix if provided
+    if !prefix.is_empty() {
+        validate_user_agent_prefix(prefix)
+            .map_err(|e| format!("Invalid user agent prefix: {e}"))?;
+    }
+
+    let user_agent = if prefix.is_empty() {
+        "GenevaUploader/0.1".to_string()
+    } else {
+        format!("{prefix} (GenevaUploader/0.1)")
+    };
+
+    HeaderValue::from_str(&user_agent)
+        .map_err(|e| format!("Failed to create User-Agent header: {e}"))
+}
+
+/// Builds a complete set of HTTP headers for Geneva services
+///
+/// # Arguments
+/// * `user_agent_prefix` - Optional user agent prefix from the client configuration
+///
+/// # Returns
+/// * `Result<HeaderMap, String>` - HTTP headers including User-Agent and Accept
+pub fn build_geneva_headers(user_agent_prefix: Option<&str>) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+
+    let user_agent = build_user_agent_header(user_agent_prefix)?;
+    headers.insert(USER_AGENT, user_agent);
+    headers.insert("accept", HeaderValue::from_static("application/json"));
+
+    Ok(headers)
 }
 
 /// Main user-facing client for Geneva ingestion.
@@ -143,5 +198,68 @@ impl GenevaClient {
             return Err(format!("Upload failures: {}", errors.join("; ")));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::USER_AGENT;
+
+    #[test]
+    fn test_build_user_agent_header_without_prefix() {
+        let header = build_user_agent_header(None).unwrap();
+        assert_eq!(header.to_str().unwrap(), "GenevaUploader/0.1");
+    }
+
+    #[test]
+    fn test_build_user_agent_header_with_empty_prefix() {
+        let header = build_user_agent_header(Some("")).unwrap();
+        assert_eq!(header.to_str().unwrap(), "GenevaUploader/0.1");
+    }
+
+    #[test]
+    fn test_build_user_agent_header_with_valid_prefix() {
+        let header = build_user_agent_header(Some("MyApp/2.1.0")).unwrap();
+        assert_eq!(header.to_str().unwrap(), "MyApp/2.1.0 (GenevaUploader/0.1)");
+    }
+
+    #[test]
+    fn test_build_user_agent_header_with_invalid_prefix() {
+        let result = build_user_agent_header(Some("Invalid\nPrefix"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid user agent prefix"));
+    }
+
+    #[test]
+    fn test_build_geneva_headers_complete() {
+        let headers = build_geneva_headers(Some("TestApp/1.0")).unwrap();
+
+        let user_agent = headers.get(USER_AGENT).unwrap();
+        assert_eq!(
+            user_agent.to_str().unwrap(),
+            "TestApp/1.0 (GenevaUploader/0.1)"
+        );
+
+        let accept = headers.get("accept").unwrap();
+        assert_eq!(accept.to_str().unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_build_geneva_headers_without_prefix() {
+        let headers = build_geneva_headers(None).unwrap();
+
+        let user_agent = headers.get(USER_AGENT).unwrap();
+        assert_eq!(user_agent.to_str().unwrap(), "GenevaUploader/0.1");
+
+        let accept = headers.get("accept").unwrap();
+        assert_eq!(accept.to_str().unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_build_geneva_headers_with_invalid_prefix() {
+        let result = build_geneva_headers(Some("Invalid\rPrefix"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid user agent prefix"));
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -1,6 +1,6 @@
 //! High-level GenevaClient for user code. Wraps config_service and ingestion_service.
 
-use crate::common::{build_geneva_headers, validate_user_agent_prefix};
+use crate::common::build_geneva_headers;
 use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfigClientConfig};
 // ManagedIdentitySelector removed; no re-export needed.
 use crate::ingestion_service::uploader::{GenevaUploader, GenevaUploaderConfig};
@@ -65,16 +65,12 @@ impl GenevaClient {
             account = %cfg.account,
             "Initializing GenevaClient"
         );
-      
-        // Validate user agent prefix once and build headers once for both services
-        // This avoids duplicate validation and header building in config and ingestion services
-        if let Some(prefix) = cfg.user_agent_prefix {
-            validate_user_agent_prefix(prefix)
-                .map_err(|e| format!("Invalid user agent prefix: {e}"))?;
-        }
+
+        // Build headers once for both services
+        // HeaderValue::from_str() in build_geneva_headers will automatically reject control characters
         let static_headers = build_geneva_headers(cfg.user_agent_prefix)
             .map_err(|e| format!("Failed to build Geneva headers: {e}"))?;
-      
+
         // Validate MSI resource presence for managed identity variants
         match cfg.auth_method {
             AuthMethod::SystemManagedIdentity

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -23,16 +23,16 @@ pub struct GenevaClientConfig {
     pub role_instance: String,
     /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
     pub max_concurrent_uploads: Option<usize>,
-    /// User agent for the application. Will be formatted as "<application> (RustGenevaClient/0.1)".
-    /// If None, defaults to "RustGenevaClient/0.1".
+    /// User agent for the application. Will be formatted as "<application> (GenevaUploader/0.1)".
+    /// If None, defaults to "GenevaUploader/0.1".
     ///
     /// The suffix must contain only ASCII printable characters, be non-empty (after trimming),
     /// and not exceed 200 characters in length.
     ///
     /// Examples:
-    /// - None: "RustGenevaClient/0.1"
-    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (RustGenevaClient/0.1)"
-    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (RustGenevaClient/0.1)"
+    /// - None: "GenevaUploader/0.1"
+    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (GenevaUploader/0.1)"
+    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
     pub user_agent_suffix: Option<&'static str>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -23,8 +23,8 @@ pub struct GenevaClientConfig {
     pub role_instance: String,
     /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
     pub max_concurrent_uploads: Option<usize>,
-    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>".
-    /// If None, defaults to "RustGenevaClient".
+    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>-0.1".
+    /// If None, defaults to "RustGenevaClient-0.1".
     pub user_agent_suffix: Option<String>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -32,16 +32,16 @@ pub struct GenevaClientConfig {
     pub tenant: String,
     pub role_name: String,
     pub role_instance: String,
-    /// User agent prefix for the application. Will be formatted as "`<prefix>` (GenevaUploader/0.1)".
-    /// If None, defaults to "GenevaUploader/0.1".
+    /// User agent prefix for the application. Will be formatted as "`<prefix>` (RustGenevaClient/0.1)".
+    /// If None, defaults to "RustGenevaClient/0.1".
     ///
     /// The prefix must contain only ASCII printable characters, be non-empty (after trimming),
     /// and not exceed 200 characters in length.
     ///
     /// Examples:
-    /// - None: "GenevaUploader/0.1"
-    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (GenevaUploader/0.1)"
-    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
+    /// - None: "RustGenevaClient/0.1"
+    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (RustGenevaClient/0.1)"
+    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (RustGenevaClient/0.1)"
     pub user_agent_prefix: Option<&'static str>,
     pub msi_resource: Option<String>, // Required for Managed Identity variants
                                       // Add event name/version here if constant, or per-upload if you want them per call.

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -23,6 +23,9 @@ pub struct GenevaClientConfig {
     pub role_instance: String,
     /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
     pub max_concurrent_uploads: Option<usize>,
+    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>".
+    /// If None, defaults to "RustGenevaClient".
+    pub user_agent_suffix: Option<String>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }
 
@@ -47,6 +50,7 @@ impl GenevaClient {
             region: cfg.region,
             config_major_version: cfg.config_major_version,
             auth_method: cfg.auth_method,
+            user_agent_suffix: cfg.user_agent_suffix,
         };
         let config_client = Arc::new(
             GenevaConfigClient::new(config_client_config)

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -1,13 +1,11 @@
 //! High-level GenevaClient for user code. Wraps config_service and ingestion_service.
 
-use crate::common::validate_user_agent_prefix;
 use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfigClientConfig};
 use crate::ingestion_service::uploader::{GenevaUploader, GenevaUploaderConfig};
 use crate::payload_encoder::lz4_chunked_compression::lz4_chunked_compression;
 use crate::payload_encoder::otlp_encoder::OtlpEncoder;
 use futures::stream::{self, StreamExt};
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
-use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use std::sync::Arc;
 
 /// Configuration for GenevaClient (user-facing)
@@ -37,59 +35,6 @@ pub struct GenevaClientConfig {
     /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
     pub user_agent_prefix: Option<&'static str>,
     // Add event name/version here if constant, or per-upload if you want them per call.
-}
-
-/// Builds a standardized User-Agent header for Geneva services
-///
-/// # Arguments
-/// * `user_agent_prefix` - Optional user agent prefix from the client configuration
-///
-/// # Returns
-/// * `Result<HeaderValue, String>` - A properly formatted User-Agent header value
-///
-/// # Format
-/// - If prefix is None or empty: "GenevaUploader/0.1"
-/// - If prefix is provided: "{prefix} (GenevaUploader/0.1)"
-///
-/// # Example
-/// ```ignore
-/// let header = build_user_agent_header(Some("MyApp/2.1.0"))?;
-/// // Results in: "MyApp/2.1.0 (GenevaUploader/0.1)"
-/// ```
-pub fn build_user_agent_header(user_agent_prefix: Option<&str>) -> Result<HeaderValue, String> {
-    let prefix = user_agent_prefix.unwrap_or("");
-
-    // Validate the prefix if provided
-    if !prefix.is_empty() {
-        validate_user_agent_prefix(prefix)
-            .map_err(|e| format!("Invalid user agent prefix: {e}"))?;
-    }
-
-    let user_agent = if prefix.is_empty() {
-        "GenevaUploader/0.1".to_string()
-    } else {
-        format!("{prefix} (GenevaUploader/0.1)")
-    };
-
-    HeaderValue::from_str(&user_agent)
-        .map_err(|e| format!("Failed to create User-Agent header: {e}"))
-}
-
-/// Builds a complete set of HTTP headers for Geneva services
-///
-/// # Arguments
-/// * `user_agent_prefix` - Optional user agent prefix from the client configuration
-///
-/// # Returns
-/// * `Result<HeaderMap, String>` - HTTP headers including User-Agent and Accept
-pub fn build_geneva_headers(user_agent_prefix: Option<&str>) -> Result<HeaderMap, String> {
-    let mut headers = HeaderMap::new();
-
-    let user_agent = build_user_agent_header(user_agent_prefix)?;
-    headers.insert(USER_AGENT, user_agent);
-    headers.insert("accept", HeaderValue::from_static("application/json"));
-
-    Ok(headers)
 }
 
 /// Main user-facing client for Geneva ingestion.
@@ -198,68 +143,5 @@ impl GenevaClient {
             return Err(format!("Upload failures: {}", errors.join("; ")));
         }
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use reqwest::header::USER_AGENT;
-
-    #[test]
-    fn test_build_user_agent_header_without_prefix() {
-        let header = build_user_agent_header(None).unwrap();
-        assert_eq!(header.to_str().unwrap(), "GenevaUploader/0.1");
-    }
-
-    #[test]
-    fn test_build_user_agent_header_with_empty_prefix() {
-        let header = build_user_agent_header(Some("")).unwrap();
-        assert_eq!(header.to_str().unwrap(), "GenevaUploader/0.1");
-    }
-
-    #[test]
-    fn test_build_user_agent_header_with_valid_prefix() {
-        let header = build_user_agent_header(Some("MyApp/2.1.0")).unwrap();
-        assert_eq!(header.to_str().unwrap(), "MyApp/2.1.0 (GenevaUploader/0.1)");
-    }
-
-    #[test]
-    fn test_build_user_agent_header_with_invalid_prefix() {
-        let result = build_user_agent_header(Some("Invalid\nPrefix"));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid user agent prefix"));
-    }
-
-    #[test]
-    fn test_build_geneva_headers_complete() {
-        let headers = build_geneva_headers(Some("TestApp/1.0")).unwrap();
-
-        let user_agent = headers.get(USER_AGENT).unwrap();
-        assert_eq!(
-            user_agent.to_str().unwrap(),
-            "TestApp/1.0 (GenevaUploader/0.1)"
-        );
-
-        let accept = headers.get("accept").unwrap();
-        assert_eq!(accept.to_str().unwrap(), "application/json");
-    }
-
-    #[test]
-    fn test_build_geneva_headers_without_prefix() {
-        let headers = build_geneva_headers(None).unwrap();
-
-        let user_agent = headers.get(USER_AGENT).unwrap();
-        assert_eq!(user_agent.to_str().unwrap(), "GenevaUploader/0.1");
-
-        let accept = headers.get("accept").unwrap();
-        assert_eq!(accept.to_str().unwrap(), "application/json");
-    }
-
-    #[test]
-    fn test_build_geneva_headers_with_invalid_prefix() {
-        let result = build_geneva_headers(Some("Invalid\rPrefix"));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid user agent prefix"));
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -23,17 +23,17 @@ pub struct GenevaClientConfig {
     pub role_instance: String,
     /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
     pub max_concurrent_uploads: Option<usize>,
-    /// User agent for the application. Will be formatted as "<application> (GenevaUploader/0.1)".
+    /// User agent prefix for the application. Will be formatted as "<prefix> (GenevaUploader/0.1)".
     /// If None, defaults to "GenevaUploader/0.1".
     ///
-    /// The suffix must contain only ASCII printable characters, be non-empty (after trimming),
+    /// The prefix must contain only ASCII printable characters, be non-empty (after trimming),
     /// and not exceed 200 characters in length.
     ///
     /// Examples:
     /// - None: "GenevaUploader/0.1"
     /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (GenevaUploader/0.1)"
     /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
-    pub user_agent_suffix: Option<&'static str>,
+    pub user_agent_prefix: Option<&'static str>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }
 
@@ -58,7 +58,7 @@ impl GenevaClient {
             region: cfg.region,
             config_major_version: cfg.config_major_version,
             auth_method: cfg.auth_method,
-            user_agent_suffix: cfg.user_agent_suffix,
+            user_agent_prefix: cfg.user_agent_prefix,
         };
         let config_client = Arc::new(
             GenevaConfigClient::new(config_client_config)

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -23,8 +23,13 @@ pub struct GenevaClientConfig {
     pub role_instance: String,
     /// Maximum number of concurrent uploads. If None, defaults to number of CPU cores.
     pub max_concurrent_uploads: Option<usize>,
-    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>-0.1".
-    /// If None, defaults to "RustGenevaClient-0.1".
+    /// User agent for the application. Will be formatted as "<application> (RustGenevaClient/0.1)".
+    /// If None, defaults to "RustGenevaClient/0.1".
+    /// 
+    /// Examples:
+    /// - None: "RustGenevaClient/0.1"
+    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (RustGenevaClient/0.1)"
+    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (RustGenevaClient/0.1)"
     pub user_agent_suffix: Option<&'static str>,
     // Add event name/version here if constant, or per-upload if you want them per call.
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -32,7 +32,7 @@ pub struct GenevaClientConfig {
     pub tenant: String,
     pub role_name: String,
     pub role_instance: String,
-    /// User agent prefix for the application. Will be formatted as "<prefix> (GenevaUploader/0.1)".
+    /// User agent prefix for the application. Will be formatted as "`<prefix>` (GenevaUploader/0.1)".
     /// If None, defaults to "GenevaUploader/0.1".
     ///
     /// The prefix must contain only ASCII printable characters, be non-empty (after trimming),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
@@ -1,0 +1,141 @@
+//! Common utilities and validation functions shared across the Geneva uploader crate.
+
+use thiserror::Error;
+
+/// Common validation errors
+#[derive(Debug, Error)]
+pub(crate) enum ValidationError {
+    #[error("Invalid user agent prefix: {0}")]
+    InvalidUserAgentPrefix(String),
+}
+
+pub(crate) type Result<T> = std::result::Result<T, ValidationError>;
+
+/// Validates a user agent prefix for HTTP header compliance
+///
+/// # Arguments
+/// * `prefix` - The user agent prefix to validate
+///
+/// # Returns
+/// * `Ok(())` if valid
+/// * `Err(ValidationError::InvalidUserAgentPrefix)` if invalid
+///
+/// # Validation Rules
+/// - Must contain only ASCII printable characters (0x20-0x7E)
+/// - Must not contain control characters (especially \r, \n, \0)
+/// - Must not exceed 200 characters in length
+/// - Must not be empty or only whitespace
+pub(crate) fn validate_user_agent_prefix(prefix: &str) -> Result<()> {
+    if prefix.trim().is_empty() {
+        return Err(ValidationError::InvalidUserAgentPrefix(
+            "User agent prefix cannot be empty or only whitespace".to_string(),
+        ));
+    }
+
+    if prefix.len() > 200 {
+        return Err(ValidationError::InvalidUserAgentPrefix(format!(
+            "User agent prefix too long: {len} characters (max 200)",
+            len = prefix.len()
+        )));
+    }
+
+    // Check for invalid characters
+    for (i, ch) in prefix.char_indices() {
+        match ch {
+            // Control characters that would break HTTP headers
+            '\r' | '\n' | '\0' => {
+                return Err(ValidationError::InvalidUserAgentPrefix(format!(
+                    "Invalid control character at position {i}: {ch:?}"
+                )));
+            }
+            // Non-ASCII or non-printable characters
+            ch if !ch.is_ascii() || (ch as u8) < 0x20 || (ch as u8) > 0x7E => {
+                return Err(ValidationError::InvalidUserAgentPrefix(format!(
+                    "Invalid character at position {i}: {ch:?} (must be ASCII printable)"
+                )));
+            }
+            _ => {} // Valid character
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_user_agent_prefix_valid() {
+        assert!(validate_user_agent_prefix("MyApp/1.0").is_ok());
+        assert!(validate_user_agent_prefix("Production-Service-2.1.0").is_ok());
+        assert!(validate_user_agent_prefix("TestApp_v3").is_ok());
+        assert!(validate_user_agent_prefix("App-Name.1.2.3").is_ok());
+        assert!(validate_user_agent_prefix("Simple123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_user_agent_prefix_empty() {
+        assert!(validate_user_agent_prefix("").is_err());
+        assert!(validate_user_agent_prefix("   ").is_err());
+        assert!(validate_user_agent_prefix("\t\n").is_err());
+
+        if let Err(e) = validate_user_agent_prefix("") {
+            assert!(e.to_string().contains("cannot be empty"));
+        }
+    }
+
+    #[test]
+    fn test_validate_user_agent_prefix_too_long() {
+        let long_prefix = "a".repeat(201);
+        let result = validate_user_agent_prefix(&long_prefix);
+        assert!(result.is_err());
+
+        if let Err(e) = result {
+            assert!(e.to_string().contains("too long"));
+            assert!(e.to_string().contains("201 characters"));
+        }
+
+        // Test exactly at the limit should be OK
+        let max_length_prefix = "a".repeat(200);
+        assert!(validate_user_agent_prefix(&max_length_prefix).is_ok());
+    }
+
+    #[test]
+    fn test_validate_user_agent_prefix_invalid_chars() {
+        // Test control characters
+        assert!(validate_user_agent_prefix("App\nName").is_err());
+        assert!(validate_user_agent_prefix("App\rName").is_err());
+        assert!(validate_user_agent_prefix("App\0Name").is_err());
+        assert!(validate_user_agent_prefix("App\tName").is_err());
+
+        // Test non-ASCII characters
+        assert!(validate_user_agent_prefix("App🚀Name").is_err());
+        assert!(validate_user_agent_prefix("Appé").is_err());
+        assert!(validate_user_agent_prefix("App中文").is_err());
+
+        // Test non-printable ASCII
+        assert!(validate_user_agent_prefix("AppName").is_err()); // Unit separator
+        assert!(validate_user_agent_prefix("AppName").is_err()); // DEL character
+
+        // Verify error messages contain position information
+        if let Err(e) = validate_user_agent_prefix("App\nName") {
+            assert!(e.to_string().contains("position 3"));
+            assert!(e.to_string().contains("control character"));
+        }
+    }
+
+    #[test]
+    fn test_character_validation_edge_cases() {
+        // Test ASCII printable range boundaries
+        assert!(validate_user_agent_prefix(" ").is_err()); // Space only should be trimmed to empty
+        assert!(validate_user_agent_prefix("App Space").is_ok()); // Space in middle is OK
+        assert!(validate_user_agent_prefix("~").is_ok()); // Last printable ASCII (0x7E)
+        assert!(validate_user_agent_prefix("!").is_ok()); // First printable ASCII after space (0x21)
+
+        // Test that spaces at the beginning and end are allowed (they're ASCII printable)
+        assert!(validate_user_agent_prefix("  ValidApp  ").is_ok()); // Leading/trailing spaces are valid ASCII printable chars
+                                                                     // But strings that trim to empty should fail
+        assert!(validate_user_agent_prefix("  ").is_err()); // Only spaces should fail
+    }
+}

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
@@ -62,23 +62,11 @@ pub(crate) fn validate_user_agent_prefix(prefix: &str) -> Result<()> {
     Ok(())
 }
 
-/// Builds a standardized User-Agent header for Geneva services
-///
-/// # Arguments
-/// * `user_agent_prefix` - Optional user agent prefix from the client configuration
-///
-/// # Returns
-/// * `Result<HeaderValue>` - A properly formatted User-Agent header value
-///
-/// # Format
-/// - If prefix is None or empty: "GenevaUploader/0.1"
-/// - If prefix is provided: "{prefix} (GenevaUploader/0.1)"
-///
-/// # Example
-/// ```ignore
-/// let header = build_user_agent_header(Some("MyApp/2.1.0"))?;
-/// // Results in: "MyApp/2.1.0 (GenevaUploader/0.1)"
-/// ```
+// Builds a standardized User-Agent header for Geneva services
+// TODO: Update the user agent format based on whether custom config will come first or later
+// Current format:
+// - If prefix is None or empty: "GenevaUploader/0.1"
+// - If prefix is provided: "{prefix} (GenevaUploader/0.1)"
 pub(crate) fn build_user_agent_header(user_agent_prefix: Option<&str>) -> Result<HeaderValue> {
     let prefix = user_agent_prefix.unwrap_or("");
 
@@ -98,13 +86,8 @@ pub(crate) fn build_user_agent_header(user_agent_prefix: Option<&str>) -> Result
     })
 }
 
-/// Builds a complete set of HTTP headers for Geneva services
-///
-/// # Arguments
-/// * `user_agent_prefix` - Optional user agent prefix from the client configuration
-///
-/// # Returns
-/// * `Result<HeaderMap>` - HTTP headers including User-Agent and Accept
+// Builds a complete set of HTTP headers for Geneva services
+// Returns HTTP headers including User-Agent and Accept
 pub(crate) fn build_geneva_headers(user_agent_prefix: Option<&str>) -> Result<HeaderMap> {
     let mut headers = HeaderMap::new();
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
@@ -12,20 +12,12 @@ pub(crate) enum ValidationError {
 
 pub(crate) type Result<T> = std::result::Result<T, ValidationError>;
 
-/// Validates a user agent prefix for HTTP header compliance
-///
-/// # Arguments
-/// * `prefix` - The user agent prefix to validate
-///
-/// # Returns
-/// * `Ok(())` if valid
-/// * `Err(ValidationError::InvalidUserAgentPrefix)` if invalid
-///
-/// # Validation Rules
-/// - Must contain only ASCII printable characters (0x20-0x7E)
-/// - Must not contain control characters (especially \r, \n, \0)
-/// - Must not exceed 200 characters in length
-/// - Must not be empty or only whitespace
+// Validates a user agent prefix for HTTP header compliance
+// Validation Rules:
+// - Must contain only ASCII printable characters (0x20-0x7E)
+// - Must not contain control characters (especially \r, \n, \0)
+// - Must not exceed 200 characters in length
+// - Must not be empty or only whitespace
 pub(crate) fn validate_user_agent_prefix(prefix: &str) -> Result<()> {
     if prefix.trim().is_empty() {
         return Err(ValidationError::InvalidUserAgentPrefix(

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
@@ -6,76 +6,56 @@ use thiserror::Error;
 /// Common validation errors
 #[derive(Debug, Error)]
 pub(crate) enum ValidationError {
-    #[error("Invalid user agent prefix: {0}")]
-    InvalidUserAgentPrefix(String),
+    #[error("Invalid user agent: {0}")]
+    InvalidUserAgent(String),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, ValidationError>;
 
-// Validates a user agent prefix for HTTP header compliance
-// Validation Rules:
-// - Must contain only ASCII printable characters (0x20-0x7E)
-// - Must not contain control characters (especially \r, \n, \0)
-// - Must not exceed 200 characters in length
-// - Must not be empty or only whitespace
-pub(crate) fn validate_user_agent_prefix(prefix: &str) -> Result<()> {
-    if prefix.trim().is_empty() {
-        return Err(ValidationError::InvalidUserAgentPrefix(
-            "User agent prefix cannot be empty or only whitespace".to_string(),
-        ));
-    }
-
-    if prefix.len() > 200 {
-        return Err(ValidationError::InvalidUserAgentPrefix(format!(
-            "User agent prefix too long: {len} characters (max 200)",
-            len = prefix.len()
-        )));
-    }
-
-    // Check for invalid characters
-    for (i, ch) in prefix.char_indices() {
-        match ch {
-            // Control characters that would break HTTP headers
-            '\r' | '\n' | '\0' => {
-                return Err(ValidationError::InvalidUserAgentPrefix(format!(
-                    "Invalid control character at position {i}: {ch:?}"
-                )));
-            }
-            // Non-ASCII or non-printable characters
-            ch if !ch.is_ascii() || (ch as u8) < 0x20 || (ch as u8) > 0x7E => {
-                return Err(ValidationError::InvalidUserAgentPrefix(format!(
-                    "Invalid character at position {i}: {ch:?} (must be ASCII printable)"
-                )));
-            }
-            _ => {} // Valid character
-        }
-    }
-
-    Ok(())
-}
-
 // Builds a standardized User-Agent header for Geneva services
-// TODO: Update the user agent format based on whether custom config will come first or later
-// Current format:
-// - If prefix is None or empty: "GenevaUploader/0.1"
-// - If prefix is provided: "{prefix} (GenevaUploader/0.1)"
+// Format:
+// - If prefix is None or empty: "RustGenevaClient/0.1"
+// - If prefix is provided: "{prefix} (RustGenevaClient/0.1)"
+//
+// Validation:
+// - HeaderValue::from_str() automatically rejects control characters (\r, \n, \0)
+// - We additionally verify the header can be represented as ASCII via to_str()
 pub(crate) fn build_user_agent_header(user_agent_prefix: Option<&str>) -> Result<HeaderValue> {
     let prefix = user_agent_prefix.unwrap_or("");
 
-    // Validate the prefix if provided
+    // Basic validation - length and non-empty checks
     if !prefix.is_empty() {
-        validate_user_agent_prefix(prefix)?;
+        if prefix.trim().is_empty() {
+            return Err(ValidationError::InvalidUserAgent(
+                "User agent prefix cannot be only whitespace".to_string(),
+            ));
+        }
+        if prefix.len() > 200 {
+            return Err(ValidationError::InvalidUserAgent(format!(
+                "User agent prefix too long: {} characters (max 200)",
+                prefix.len()
+            )));
+        }
     }
 
     let user_agent = if prefix.is_empty() {
-        "GenevaUploader/0.1".to_string()
+        "RustGenevaClient/0.1".to_string()
     } else {
-        format!("{prefix} (GenevaUploader/0.1)")
+        format!("{prefix} (RustGenevaClient/0.1)")
     };
 
-    HeaderValue::from_str(&user_agent).map_err(|e| {
-        ValidationError::InvalidUserAgentPrefix(format!("Failed to create User-Agent header: {e}"))
-    })
+    // Create the HeaderValue - rejects control characters
+    let header_value = HeaderValue::from_str(&user_agent).map_err(|e| {
+        ValidationError::InvalidUserAgent(format!("Invalid User-Agent header: {e}"))
+    })?;
+
+    // Verify the header can be represented as valid ASCII string
+    // This rejects non-ASCII characters like emojis, Chinese chars, etc.
+    header_value.to_str().map_err(|_| {
+        ValidationError::InvalidUserAgent("User-Agent contains non-ASCII characters".to_string())
+    })?;
+
+    Ok(header_value)
 }
 
 // Builds a complete set of HTTP headers for Geneva services
@@ -95,107 +75,70 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_validate_user_agent_prefix_valid() {
-        assert!(validate_user_agent_prefix("MyApp/1.0").is_ok());
-        assert!(validate_user_agent_prefix("Production-Service-2.1.0").is_ok());
-        assert!(validate_user_agent_prefix("TestApp_v3").is_ok());
-        assert!(validate_user_agent_prefix("App-Name.1.2.3").is_ok());
-        assert!(validate_user_agent_prefix("Simple123").is_ok());
-    }
-
-    #[test]
-    fn test_validate_user_agent_prefix_empty() {
-        assert!(validate_user_agent_prefix("").is_err());
-        assert!(validate_user_agent_prefix("   ").is_err());
-        assert!(validate_user_agent_prefix("\t\n").is_err());
-
-        if let Err(e) = validate_user_agent_prefix("") {
-            assert!(e.to_string().contains("cannot be empty"));
-        }
-    }
-
-    #[test]
-    fn test_validate_user_agent_prefix_too_long() {
-        let long_prefix = "a".repeat(201);
-        let result = validate_user_agent_prefix(&long_prefix);
-        assert!(result.is_err());
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("too long"));
-            assert!(e.to_string().contains("201 characters"));
-        }
-
-        // Test exactly at the limit should be OK
-        let max_length_prefix = "a".repeat(200);
-        assert!(validate_user_agent_prefix(&max_length_prefix).is_ok());
-    }
-
-    #[test]
-    fn test_validate_user_agent_prefix_invalid_chars() {
-        // Test control characters
-        assert!(validate_user_agent_prefix("App\nName").is_err());
-        assert!(validate_user_agent_prefix("App\rName").is_err());
-        assert!(validate_user_agent_prefix("App\0Name").is_err());
-        assert!(validate_user_agent_prefix("App\tName").is_err());
-
-        // Test non-ASCII characters
-        assert!(validate_user_agent_prefix("App🚀Name").is_err());
-        assert!(validate_user_agent_prefix("Appé").is_err());
-        assert!(validate_user_agent_prefix("App中文").is_err());
-
-        // Test non-printable ASCII - construct strings with actual control characters
-        let unit_separator = format!("App{}Name", '\u{001F}');
-        let del_char = format!("App{}Name", '\u{007F}');
-        assert!(validate_user_agent_prefix(&unit_separator).is_err()); // Unit separator (0x1F)
-        assert!(validate_user_agent_prefix(&del_char).is_err()); // DEL character (0x7F)
-
-        // Verify error messages contain position information
-        if let Err(e) = validate_user_agent_prefix("App\nName") {
-            assert!(e.to_string().contains("position 3"));
-            assert!(e.to_string().contains("control character"));
-        }
-    }
-
-    #[test]
-    fn test_character_validation_edge_cases() {
-        // Test ASCII printable range boundaries
-        assert!(validate_user_agent_prefix(" ").is_err()); // Space only should be trimmed to empty
-        assert!(validate_user_agent_prefix("App Space").is_ok()); // Space in middle is OK
-        assert!(validate_user_agent_prefix("~").is_ok()); // Last printable ASCII (0x7E)
-        assert!(validate_user_agent_prefix("!").is_ok()); // First printable ASCII after space (0x21)
-
-        // Test that spaces at the beginning and end are allowed (they're ASCII printable)
-        assert!(validate_user_agent_prefix("  ValidApp  ").is_ok()); // Leading/trailing spaces are valid ASCII printable chars
-                                                                     // But strings that trim to empty should fail
-        assert!(validate_user_agent_prefix("  ").is_err()); // Only spaces should fail
-    }
-
-    #[test]
     fn test_build_user_agent_header_without_prefix() {
         let header = build_user_agent_header(None).unwrap();
-        assert_eq!(header.to_str().unwrap(), "GenevaUploader/0.1");
+        assert_eq!(header.to_str().unwrap(), "RustGenevaClient/0.1");
     }
 
     #[test]
     fn test_build_user_agent_header_with_empty_prefix() {
         let header = build_user_agent_header(Some("")).unwrap();
-        assert_eq!(header.to_str().unwrap(), "GenevaUploader/0.1");
+        assert_eq!(header.to_str().unwrap(), "RustGenevaClient/0.1");
     }
 
     #[test]
     fn test_build_user_agent_header_with_valid_prefix() {
         let header = build_user_agent_header(Some("MyApp/2.1.0")).unwrap();
-        assert_eq!(header.to_str().unwrap(), "MyApp/2.1.0 (GenevaUploader/0.1)");
+        assert_eq!(
+            header.to_str().unwrap(),
+            "MyApp/2.1.0 (RustGenevaClient/0.1)"
+        );
     }
 
     #[test]
-    fn test_build_user_agent_header_with_invalid_prefix() {
-        let result = build_user_agent_header(Some("Invalid\nPrefix"));
+    fn test_build_user_agent_header_with_invalid_control_chars() {
+        // Control characters are automatically rejected by HeaderValue::from_str()
+        assert!(build_user_agent_header(Some("Invalid\nPrefix")).is_err());
+        assert!(build_user_agent_header(Some("App\rName")).is_err());
+        assert!(build_user_agent_header(Some("App\0Name")).is_err());
+    }
+
+    #[test]
+    fn test_build_user_agent_header_with_non_ascii() {
+        // Non-ASCII characters should be rejected because we validate with to_str()
+        assert!(build_user_agent_header(Some("App€Name")).is_err());
+        assert!(build_user_agent_header(Some("App🌏Name")).is_err());
+        assert!(build_user_agent_header(Some("App🚀Name")).is_err());
+        assert!(build_user_agent_header(Some("App中文Name")).is_err());
+
+        // Verify error message mentions non-ASCII
+        let result = build_user_agent_header(Some("App中文"));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid user agent prefix"));
+        assert!(result.unwrap_err().to_string().contains("non-ASCII"));
+    }
+
+    #[test]
+    fn test_build_user_agent_header_length_validation() {
+        // Test too long prefix
+        let long_prefix = "a".repeat(201);
+        let result = build_user_agent_header(Some(&long_prefix));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too long"));
+
+        // Test exactly at the limit
+        let max_prefix = "a".repeat(200);
+        assert!(build_user_agent_header(Some(&max_prefix)).is_ok());
+    }
+
+    #[test]
+    fn test_build_user_agent_header_whitespace_validation() {
+        // Only whitespace should fail
+        assert!(build_user_agent_header(Some("   ")).is_err());
+        assert!(build_user_agent_header(Some("\t")).is_err());
+
+        // Whitespace within valid text is OK
+        assert!(build_user_agent_header(Some("My App")).is_ok());
+        assert!(build_user_agent_header(Some("  MyApp  ")).is_ok());
     }
 
     #[test]
@@ -205,7 +148,7 @@ mod tests {
         let user_agent = headers.get(USER_AGENT).unwrap();
         assert_eq!(
             user_agent.to_str().unwrap(),
-            "TestApp/1.0 (GenevaUploader/0.1)"
+            "TestApp/1.0 (RustGenevaClient/0.1)"
         );
 
         let accept = headers.get(ACCEPT).unwrap();
@@ -217,7 +160,7 @@ mod tests {
         let headers = build_geneva_headers(None).unwrap();
 
         let user_agent = headers.get(USER_AGENT).unwrap();
-        assert_eq!(user_agent.to_str().unwrap(), "GenevaUploader/0.1");
+        assert_eq!(user_agent.to_str().unwrap(), "RustGenevaClient/0.1");
 
         let accept = headers.get(ACCEPT).unwrap();
         assert_eq!(accept.to_str().unwrap(), "application/json");
@@ -230,6 +173,6 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Invalid user agent prefix"));
+            .contains("Invalid User-Agent"));
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/common.rs
@@ -1,6 +1,5 @@
 //! Common utilities and validation functions shared across the Geneva uploader crate.
 
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use thiserror::Error;
 
 /// Common validation errors
@@ -62,40 +61,8 @@ pub(crate) fn validate_user_agent_prefix(prefix: &str) -> Result<()> {
     Ok(())
 }
 
-/// Builds static HTTP headers including User-Agent for Geneva clients
-///
-/// # Arguments
-/// * `agent_identity` - The identity of the agent (e.g., "GenevaUploader")
-/// * `agent_version` - The version of the agent (e.g., "0.1")
-/// * `user_agent_prefix` - Optional user agent prefix (can be empty string)
-///
-/// # Returns
-/// * `Result<HeaderMap>` - Headers with User-Agent and Accept headers set
-///
-/// # User-Agent Format
-/// - If prefix is empty: "{agent_identity}/{agent_version}"
-/// - If prefix is provided: "{prefix} ({agent_identity}/{agent_version})"
-pub(crate) fn build_static_headers(
-    agent_identity: &str,
-    agent_version: &str,
-    user_agent_prefix: &str,
-) -> Result<HeaderMap> {
-    let mut headers = HeaderMap::new();
-    let user_agent = if user_agent_prefix.is_empty() {
-        format!("{agent_identity}/{agent_version}")
-    } else {
-        format!("{user_agent_prefix} ({agent_identity}/{agent_version})")
-    };
-
-    // Safe header construction with proper error handling
-    let header_value = HeaderValue::from_str(&user_agent).map_err(|e| {
-        ValidationError::InvalidUserAgentPrefix(format!("Failed to create User-Agent header: {e}"))
-    })?;
-
-    headers.insert(USER_AGENT, header_value);
-    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
-    Ok(headers)
-}
+// Note: build_static_headers has been moved to client.rs as build_geneva_headers
+// for centralized user-agent building across all Geneva services
 
 #[cfg(test)]
 mod tests {
@@ -177,32 +144,5 @@ mod tests {
         assert!(validate_user_agent_prefix("  ").is_err()); // Only spaces should fail
     }
 
-    #[test]
-    fn test_build_static_headers_safe() {
-        let headers = build_static_headers("GenevaUploader", "0.1", "ValidApp/2.0");
-        assert!(headers.is_ok());
-
-        let headers = headers.unwrap();
-        let user_agent = headers.get(USER_AGENT).unwrap().to_str().unwrap();
-        assert_eq!(user_agent, "ValidApp/2.0 (GenevaUploader/0.1)");
-
-        // Test empty prefix
-        let headers = build_static_headers("GenevaUploader", "0.1", "");
-        assert!(headers.is_ok());
-
-        let headers = headers.unwrap();
-        let user_agent = headers.get(USER_AGENT).unwrap().to_str().unwrap();
-        assert_eq!(user_agent, "GenevaUploader/0.1");
-    }
-
-    #[test]
-    fn test_build_static_headers_invalid() {
-        // This should not happen in practice due to validation, but test the safety mechanism
-        let result = build_static_headers("TestAgent", "1.0", "Invalid\nPrefix");
-        assert!(result.is_err());
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("Failed to create User-Agent header"));
-        }
-    }
+    // Note: Header building tests have been moved to client.rs where the functionality now resides
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -129,8 +129,8 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) region: String,
     pub(crate) config_major_version: u32,
     pub(crate) auth_method: AuthMethod,
-    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>".
-    /// If None, defaults to "RustGenevaClient".
+    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>-0.1".
+    /// If None, defaults to "RustGenevaClient-0.1".
     pub(crate) user_agent_suffix: Option<String>,
 }
 
@@ -262,7 +262,7 @@ impl GenevaConfigClient {
             }
         }
 
-        let agent_identity = "GenevaUploader";
+        let agent_identity = "RustGenevaClient";
         let agent_version = "0.1";
         let user_agent_suffix = config.user_agent_suffix.as_deref().unwrap_or("");
         let static_headers =
@@ -308,15 +308,15 @@ impl GenevaConfigClient {
     }
 
     fn build_static_headers(
-        _agent_identity: &str,
-        _agent_version: &str,
+        agent_identity: &str,
+        agent_version: &str,
         user_agent_suffix: &str,
     ) -> HeaderMap {
         let mut headers = HeaderMap::new();
         let user_agent = if user_agent_suffix.is_empty() {
-            "RustGenevaClient".to_string()
+            format!("{}-{}", agent_identity, agent_version)
         } else {
-            format!("RustGenevaClient-{}", user_agent_suffix)
+            format!("{}-{}-{}", agent_identity, user_agent_suffix, agent_version)
         };
         headers.insert(USER_AGENT, HeaderValue::from_str(&user_agent).unwrap());
         headers.insert(ACCEPT, HeaderValue::from_static("application/json"));

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -2,7 +2,7 @@
 
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::{
-    header::{HeaderMap, HeaderValue, AUTHORIZATION},
+    header::{HeaderMap, AUTHORIZATION},
     Client,
 };
 use serde::Deserialize;
@@ -593,7 +593,7 @@ impl GenevaConfigClient {
     ///   - `ConfigMajorVersion`: Version string (format: "Ver{major_version}v0")
     ///   - `TagId`: UUID for request tracking
     /// - **Headers**:
-    ///   - `User-Agent`: "{agent_identity}-{agent_version}"
+    ///   - `User-Agent`: "{prefix} (RustGenevaClient/0.1)" or "RustGenevaClient/0.1" if no prefix
     ///   - `x-ms-client-request-id`: UUID for request tracking
     ///   - `Accept`: "application/json"
     ///

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -133,16 +133,16 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) region: String,
     pub(crate) config_major_version: u32,
     pub(crate) auth_method: AuthMethod,
-    /// User agent for the application. Will be formatted as "<application> (RustGenevaClient/0.1)".
-    /// If None, defaults to "RustGenevaClient/0.1".
+    /// User agent for the application. Will be formatted as "<application> (GenevaUploader/0.1)".
+    /// If None, defaults to "GenevaUploader/0.1".
     ///
     /// The suffix must contain only ASCII printable characters, be non-empty (after trimming),
     /// and not exceed 200 characters in length.
     ///
     /// Examples:
-    /// - None: "RustGenevaClient/0.1"
-    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (RustGenevaClient/0.1)"
-    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (RustGenevaClient/0.1)"
+    /// - None: "GenevaUploader/0.1"
+    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (GenevaUploader/0.1)"
+    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
     pub(crate) user_agent_suffix: Option<&'static str>,
 }
 
@@ -329,7 +329,7 @@ impl GenevaConfigClient {
             }
         }
 
-        let agent_identity = "RustGenevaClient";
+        let agent_identity = "GenevaUploader";
         let agent_version = "0.1";
         let user_agent_suffix = config.user_agent_suffix.unwrap_or("");
         let static_headers =
@@ -713,20 +713,21 @@ mod tests {
 
     #[test]
     fn test_build_static_headers_safe() {
-        let headers = GenevaConfigClient::build_static_headers("TestAgent", "1.0", "ValidApp/2.0");
+        let headers =
+            GenevaConfigClient::build_static_headers("GenevaUploader", "0.1", "ValidApp/2.0");
         assert!(headers.is_ok());
 
         let headers = headers.unwrap();
         let user_agent = headers.get(USER_AGENT).unwrap().to_str().unwrap();
-        assert_eq!(user_agent, "ValidApp/2.0 (TestAgent/1.0)");
+        assert_eq!(user_agent, "ValidApp/2.0 (GenevaUploader/0.1)");
 
         // Test empty suffix
-        let headers = GenevaConfigClient::build_static_headers("TestAgent", "1.0", "");
+        let headers = GenevaConfigClient::build_static_headers("GenevaUploader", "0.1", "");
         assert!(headers.is_ok());
 
         let headers = headers.unwrap();
         let user_agent = headers.get(USER_AGENT).unwrap().to_str().unwrap();
-        assert_eq!(user_agent, "TestAgent/1.0");
+        assert_eq!(user_agent, "GenevaUploader/0.1");
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -126,7 +126,6 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) region: String,
     pub(crate) config_major_version: u32,
     pub(crate) auth_method: AuthMethod,
-    pub(crate) user_agent_prefix: Option<&'static str>,
     pub(crate) static_headers: HeaderMap,
 }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -3,7 +3,7 @@
 use crate::common::{build_static_headers, validate_user_agent_prefix};
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::{
-    header::{HeaderMap, USER_AGENT},
+    header::HeaderMap,
     Client,
 };
 use serde::Deserialize;
@@ -568,6 +568,7 @@ fn configure_tls_connector(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::header::USER_AGENT;
 
     #[test]
     fn test_build_static_headers_safe() {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -546,5 +546,3 @@ fn configure_tls_connector(
         .max_protocol_version(Some(Protocol::Tlsv12));
     builder
 }
-
-// Note: Tests for build_geneva_headers are in common.rs where the functionality is implemented

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -561,37 +561,4 @@ fn configure_tls_connector(
     builder
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::common::build_geneva_headers;
-    use reqwest::header::USER_AGENT;
-
-    #[test]
-    fn test_build_geneva_headers_safe() {
-        let headers = build_geneva_headers(Some("ValidApp/2.0"));
-        assert!(headers.is_ok());
-
-        let headers = headers.unwrap();
-        let user_agent = headers.get(USER_AGENT).unwrap().to_str().unwrap();
-        assert_eq!(user_agent, "ValidApp/2.0 (GenevaUploader/0.1)");
-
-        // Test empty prefix
-        let headers = build_geneva_headers(None);
-        assert!(headers.is_ok());
-
-        let headers = headers.unwrap();
-        let user_agent = headers.get(USER_AGENT).unwrap().to_str().unwrap();
-        assert_eq!(user_agent, "GenevaUploader/0.1");
-    }
-
-    #[test]
-    fn test_build_geneva_headers_invalid() {
-        // This should not happen in practice due to validation, but test the safety mechanism
-        let result = build_geneva_headers(Some("Invalid\nPrefix"));
-        assert!(result.is_err());
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("Invalid user agent prefix"));
-        }
-    }
-}
+// Note: Tests for build_geneva_headers are in common.rs where the functionality is implemented

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -129,8 +129,13 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) region: String,
     pub(crate) config_major_version: u32,
     pub(crate) auth_method: AuthMethod,
-    /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>-0.1".
-    /// If None, defaults to "RustGenevaClient-0.1".
+    /// User agent for the application. Will be formatted as "<application> (RustGenevaClient/0.1)".
+    /// If None, defaults to "RustGenevaClient/0.1".
+    /// 
+    /// Examples:
+    /// - None: "RustGenevaClient/0.1"
+    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (RustGenevaClient/0.1)"
+    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (RustGenevaClient/0.1)"
     pub(crate) user_agent_suffix: Option<&'static str>,
 }
 
@@ -314,9 +319,9 @@ impl GenevaConfigClient {
     ) -> HeaderMap {
         let mut headers = HeaderMap::new();
         let user_agent = if user_agent_suffix.is_empty() {
-            format!("{}-{}", agent_identity, agent_version)
+            format!("{}/{}", agent_identity, agent_version)
         } else {
-            format!("{}-{}-{}", agent_identity, user_agent_suffix, agent_version)
+            format!("{} ({}/{})", user_agent_suffix, agent_identity, agent_version)
         };
         headers.insert(USER_AGENT, HeaderValue::from_str(&user_agent).unwrap());
         headers.insert(ACCEPT, HeaderValue::from_static("application/json"));

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -131,7 +131,7 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) auth_method: AuthMethod,
     /// User agent suffix for the client. Will be formatted as "RustGenevaClient-<suffix>-0.1".
     /// If None, defaults to "RustGenevaClient-0.1".
-    pub(crate) user_agent_suffix: Option<String>,
+    pub(crate) user_agent_suffix: Option<&'static str>,
 }
 
 #[allow(dead_code)]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1,6 +1,6 @@
 // Geneva Config Client with TLS (PKCS#12) and TODO: Managed Identity support
 
-use crate::client::build_geneva_headers;
+use crate::common::build_geneva_headers;
 use crate::common::validate_user_agent_prefix;
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::{header::HeaderMap, Client};
@@ -270,7 +270,7 @@ impl GenevaConfigClient {
         }
 
         let static_headers = build_geneva_headers(config.user_agent_prefix)
-            .map_err(|e| GenevaConfigClientError::InvalidUserAgentPrefix(e))?;
+            .map_err(|e| GenevaConfigClientError::InvalidUserAgentPrefix(e.to_string()))?;
 
         let agent_identity = "GenevaUploader";
         let identity = format!("Tenant=Default/Role=GcsClient/RoleInstance={agent_identity}");
@@ -563,7 +563,7 @@ fn configure_tls_connector(
 
 #[cfg(test)]
 mod tests {
-    use crate::client::build_geneva_headers;
+    use crate::common::build_geneva_headers;
     use reqwest::header::USER_AGENT;
 
     #[test]
@@ -591,7 +591,7 @@ mod tests {
         assert!(result.is_err());
 
         if let Err(e) = result {
-            assert!(e.contains("Invalid user agent prefix"));
+            assert!(e.to_string().contains("Invalid user agent prefix"));
         }
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -267,14 +267,9 @@ impl GenevaConfigClient {
         let agent_identity = "GenevaUploader";
         let agent_version = "0.1";
 
-        // Merge static headers from config
-        let mut headers = config.static_headers.clone();
-        headers.insert("Accept", HeaderValue::from_static("application/json"));
-        // Add User-Agent header with agent identity and version
-        let user_agent = format!("{}-{}", agent_identity, agent_version);
-        if let Ok(ua_value) = HeaderValue::from_str(&user_agent) {
-            headers.insert("User-Agent", ua_value);
-        }
+        // Use static headers from config
+        // Note: User-Agent and Accept are already set in static_headers from build_geneva_headers()
+        let headers = config.static_headers.clone();
 
         let mut client_builder = Client::builder()
             .http1_only()

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -133,16 +133,6 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) region: String,
     pub(crate) config_major_version: u32,
     pub(crate) auth_method: AuthMethod,
-    /// User agent for the application. Will be formatted as "<application> (GenevaUploader/0.1)".
-    /// If None, defaults to "GenevaUploader/0.1".
-    ///
-    /// The suffix must contain only ASCII printable characters, be non-empty (after trimming),
-    /// and not exceed 200 characters in length.
-    ///
-    /// Examples:
-    /// - None: "GenevaUploader/0.1"
-    /// - Some("MyApp/2.1.0"): "MyApp/2.1.0 (GenevaUploader/0.1)"
-    /// - Some("ProductionService-1.0"): "ProductionService-1.0 (GenevaUploader/0.1)"
     pub(crate) user_agent_suffix: Option<&'static str>,
 }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -21,7 +21,7 @@ mod tests {
             region: "region".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::ManagedIdentity,
-            user_agent_suffix: Some("TestApp/1.0"),
+            user_agent_prefix: Some("TestApp/1.0"),
         };
 
         assert_eq!(config.environment, "env");
@@ -108,7 +108,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("MockClient/1.0"),
+            user_agent_prefix: Some("MockClient/1.0"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -154,7 +154,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("ErrorTestApp/1.0"),
+            user_agent_prefix: Some("ErrorTestApp/1.0"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -203,7 +203,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("MissingInfoTestApp/1.0"),
+            user_agent_prefix: Some("MissingInfoTestApp/1.0"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -235,7 +235,7 @@ mod tests {
                 path: PathBuf::from("/nonexistent/path.p12".to_string()),
                 password: "test".to_string(),
             },
-            user_agent_suffix: Some("InvalidCertTestApp/1.0"),
+            user_agent_prefix: Some("InvalidCertTestApp/1.0"),
         };
 
         let result = GenevaConfigClient::new(config);
@@ -299,7 +299,7 @@ mod tests {
                 path: PathBuf::from(cert_path),
                 password: cert_password,
             },
-            user_agent_suffix: Some("RealServerTestApp/1.0"),
+            user_agent_prefix: Some("RealServerTestApp/1.0"),
         };
 
         println!("Connecting to real Geneva Config service...");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -21,7 +21,7 @@ mod tests {
             region: "region".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::ManagedIdentity,
-            user_agent_suffix: Some("TestConfig"),
+            user_agent_suffix: Some("TestApp/1.0"),
         };
 
         assert_eq!(config.environment, "env");
@@ -108,7 +108,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("MockedTest"),
+            user_agent_suffix: Some("MockClient/1.0"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -154,7 +154,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("ErrorHandlingTest"),
+            user_agent_suffix: Some("ErrorTestApp/1.0"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -203,7 +203,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("MissingInfoTest"),
+            user_agent_suffix: Some("MissingInfoTestApp/1.0"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -235,7 +235,7 @@ mod tests {
                 path: PathBuf::from("/nonexistent/path.p12".to_string()),
                 password: "test".to_string(),
             },
-            user_agent_suffix: Some("InvalidCertTest"),
+            user_agent_suffix: Some("InvalidCertTestApp/1.0"),
         };
 
         let result = GenevaConfigClient::new(config);
@@ -299,7 +299,7 @@ mod tests {
                 path: PathBuf::from(cert_path),
                 password: cert_password,
             },
-            user_agent_suffix: Some("RealServerTest"),
+            user_agent_suffix: Some("RealServerTestApp/1.0"),
         };
 
         println!("Connecting to real Geneva Config service...");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -24,7 +24,6 @@ mod tests {
             region: "region".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::ManagedIdentity,
-            user_agent_prefix: Some("TestApp/1.0"),
             static_headers,
         };
 
@@ -115,7 +114,6 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_prefix: Some("MockClient/1.0"),
             static_headers,
         };
 
@@ -165,7 +163,6 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_prefix: Some("ErrorTestApp/1.0"),
             static_headers,
         };
 
@@ -218,7 +215,6 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_prefix: Some("MissingInfoTestApp/1.0"),
             static_headers,
         };
 
@@ -254,7 +250,6 @@ mod tests {
                 path: PathBuf::from("/nonexistent/path.p12".to_string()),
                 password: "test".to_string(),
             },
-            user_agent_prefix: Some("InvalidCertTestApp/1.0"),
             static_headers,
         };
 
@@ -322,7 +317,6 @@ mod tests {
                 path: PathBuf::from(cert_path),
                 password: cert_password,
             },
-            user_agent_prefix: Some("RealServerTestApp/1.0"),
             static_headers,
         };
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -21,6 +21,7 @@ mod tests {
             region: "region".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::ManagedIdentity,
+            user_agent_suffix: Some("TestConfig".to_string()),
         };
 
         assert_eq!(config.environment, "env");
@@ -107,6 +108,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
+            user_agent_suffix: Some("MockedTest".to_string()),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -152,6 +154,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
+            user_agent_suffix: Some("ErrorHandlingTest".to_string()),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -200,6 +203,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
+            user_agent_suffix: Some("MissingInfoTest".to_string()),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -231,6 +235,7 @@ mod tests {
                 path: PathBuf::from("/nonexistent/path.p12".to_string()),
                 password: "test".to_string(),
             },
+            user_agent_suffix: Some("InvalidCertTest".to_string()),
         };
 
         let result = GenevaConfigClient::new(config);
@@ -294,6 +299,7 @@ mod tests {
                 path: PathBuf::from(cert_path),
                 password: cert_password,
             },
+            user_agent_suffix: Some("RealServerTest".to_string()),
         };
 
         println!("Connecting to real Geneva Config service...");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -13,6 +13,9 @@ mod tests {
 
     #[test]
     fn test_config_fields() {
+        let static_headers = crate::common::build_geneva_headers(Some("TestApp/1.0"))
+            .expect("Failed to build Geneva headers");
+
         let config = GenevaConfigClientConfig {
             endpoint: "https://example.com".to_string(),
             environment: "env".to_string(),
@@ -22,6 +25,7 @@ mod tests {
             config_major_version: 1,
             auth_method: AuthMethod::ManagedIdentity,
             user_agent_prefix: Some("TestApp/1.0"),
+            static_headers,
         };
 
         assert_eq!(config.environment, "env");
@@ -97,6 +101,9 @@ mod tests {
 
         let (temp_p12_file, password) = generate_self_signed_p12();
 
+        let static_headers = crate::common::build_geneva_headers(Some("MockClient/1.0"))
+            .expect("Failed to build Geneva headers");
+
         let config = GenevaConfigClientConfig {
             endpoint: mock_server.uri(),
             environment: "mockenv".into(),
@@ -109,6 +116,7 @@ mod tests {
                 password,
             },
             user_agent_prefix: Some("MockClient/1.0"),
+            static_headers,
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -143,6 +151,9 @@ mod tests {
 
         let (temp_p12_file, password) = generate_self_signed_p12();
 
+        let static_headers = crate::common::build_geneva_headers(Some("ErrorTestApp/1.0"))
+            .expect("Failed to build Geneva headers");
+
         let config = GenevaConfigClientConfig {
             endpoint: mock_server.uri(),
             environment: "mockenv".into(),
@@ -155,6 +166,7 @@ mod tests {
                 password,
             },
             user_agent_prefix: Some("ErrorTestApp/1.0"),
+            static_headers,
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -192,6 +204,9 @@ mod tests {
 
         let (temp_p12_file, password) = generate_self_signed_p12();
 
+        let static_headers = crate::common::build_geneva_headers(Some("MissingInfoTestApp/1.0"))
+            .expect("Failed to build Geneva headers");
+
         let config = GenevaConfigClientConfig {
             endpoint: mock_server.uri(),
             environment: "mockenv".into(),
@@ -204,6 +219,7 @@ mod tests {
                 password,
             },
             user_agent_prefix: Some("MissingInfoTestApp/1.0"),
+            static_headers,
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -224,6 +240,9 @@ mod tests {
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn test_invalid_certificate_path() {
+        let static_headers = crate::common::build_geneva_headers(Some("InvalidCertTestApp/1.0"))
+            .expect("Failed to build Geneva headers");
+
         let config = GenevaConfigClientConfig {
             endpoint: "https://example.com".to_string(),
             environment: "env".to_string(),
@@ -236,6 +255,7 @@ mod tests {
                 password: "test".to_string(),
             },
             user_agent_prefix: Some("InvalidCertTestApp/1.0"),
+            static_headers,
         };
 
         let result = GenevaConfigClient::new(config);
@@ -288,6 +308,9 @@ mod tests {
             .parse::<u32>() // Convert string to u32
             .expect("GENEVA_CONFIG_MAJOR_VERSION must be a valid unsigned integer");
 
+        let static_headers = crate::common::build_geneva_headers(Some("RealServerTestApp/1.0"))
+            .expect("Failed to build Geneva headers");
+
         let config = GenevaConfigClientConfig {
             endpoint,
             environment,
@@ -300,6 +323,7 @@ mod tests {
                 password: cert_password,
             },
             user_agent_prefix: Some("RealServerTestApp/1.0"),
+            static_headers,
         };
 
         println!("Connecting to real Geneva Config service...");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -21,7 +21,7 @@ mod tests {
             region: "region".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::ManagedIdentity,
-            user_agent_suffix: Some("TestConfig".to_string()),
+            user_agent_suffix: Some("TestConfig"),
         };
 
         assert_eq!(config.environment, "env");
@@ -108,7 +108,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("MockedTest".to_string()),
+            user_agent_suffix: Some("MockedTest"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -154,7 +154,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("ErrorHandlingTest".to_string()),
+            user_agent_suffix: Some("ErrorHandlingTest"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -203,7 +203,7 @@ mod tests {
                 path: PathBuf::from(temp_p12_file.path().to_string_lossy().to_string()),
                 password,
             },
-            user_agent_suffix: Some("MissingInfoTest".to_string()),
+            user_agent_suffix: Some("MissingInfoTest"),
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -235,7 +235,7 @@ mod tests {
                 path: PathBuf::from("/nonexistent/path.p12".to_string()),
                 password: "test".to_string(),
             },
-            user_agent_suffix: Some("InvalidCertTest".to_string()),
+            user_agent_suffix: Some("InvalidCertTest"),
         };
 
         let result = GenevaConfigClient::new(config);
@@ -299,7 +299,7 @@ mod tests {
                 path: PathBuf::from(cert_path),
                 password: cert_password,
             },
-            user_agent_suffix: Some("RealServerTest".to_string()),
+            user_agent_suffix: Some("RealServerTest"),
         };
 
         println!("Connecting to real Geneva Config service...");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -51,6 +51,7 @@ mod tests {
                 source_identity,
                 environment: environment.clone(),
                 config_version,
+                user_agent_prefix: Some("TestUploader"),
             };
 
             let config = GenevaConfigClientConfig {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -64,7 +64,7 @@ mod tests {
                     path: cert_path,
                     password: cert_password,
                 },
-                user_agent_suffix: Some("TestUploader"),
+                user_agent_prefix: Some("TestUploader"),
             };
 
             // Build client and uploader

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -70,7 +70,6 @@ mod tests {
                     path: cert_path,
                     password: cert_password,
                 },
-                user_agent_prefix: Some("TestUploader"),
                 static_headers,
             };
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -64,6 +64,7 @@ mod tests {
                     path: cert_path,
                     password: cert_password,
                 },
+                user_agent_suffix: Some("TestUploader".to_string()),
             };
 
             // Build client and uploader

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -64,7 +64,7 @@ mod tests {
                     path: cert_path,
                     password: cert_password,
                 },
-                user_agent_suffix: Some("TestUploader".to_string()),
+                user_agent_suffix: Some("TestUploader"),
             };
 
             // Build client and uploader

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -46,12 +46,17 @@ mod tests {
 
             // Define uploader config
             let config_version = format!("Ver{config_major_version}v0");
+
+            // Build the static headers once for both services
+            let static_headers = crate::common::build_geneva_headers(Some("TestUploader"))
+                .expect("Failed to build Geneva headers");
+
             let uploader_config = GenevaUploaderConfig {
                 namespace: namespace.clone(),
                 source_identity,
                 environment: environment.clone(),
                 config_version,
-                user_agent_prefix: Some("TestUploader"),
+                static_headers: static_headers.clone(),
             };
 
             let config = GenevaConfigClientConfig {
@@ -66,6 +71,7 @@ mod tests {
                     password: cert_password,
                 },
                 user_agent_prefix: Some("TestUploader"),
+                static_headers,
             };
 
             // Build client and uploader

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -1,4 +1,4 @@
-use crate::client::build_geneva_headers;
+use crate::common::build_geneva_headers;
 use crate::common::validate_user_agent_prefix;
 use crate::config_service::client::{GenevaConfigClient, GenevaConfigClientError};
 use crate::payload_encoder::central_blob::BatchMetadata;
@@ -141,7 +141,7 @@ impl GenevaUploader {
         }
 
         let static_headers = build_geneva_headers(uploader_config.user_agent_prefix)
-            .map_err(|e| GenevaUploaderError::InvalidUserAgentPrefix(e))?;
+            .map_err(|e| GenevaUploaderError::InvalidUserAgentPrefix(e.to_string()))?;
 
         let http_client = Client::builder()
             .timeout(Duration::from_secs(30))

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -133,23 +133,23 @@ impl GenevaUploader {
         config_client: Arc<GenevaConfigClient>,
         uploader_config: GenevaUploaderConfig,
     ) -> Result<Self> {
-let mut headers = header::HeaderMap::new();
-headers.insert(
-    header::ACCEPT,
-    header::HeaderValue::from_static("application/json"),
-);
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::ACCEPT,
+            header::HeaderValue::from_static("application/json"),
+        );
 
-// Merge static headers from uploader_config
-for (key, value) in uploader_config.static_headers.iter() {
-    headers.insert(key.clone(), value.clone());
-}
+        // Merge static headers from uploader_config
+        for (key, value) in uploader_config.static_headers.iter() {
+            headers.insert(key.clone(), value.clone());
+        }
 
-let http_client = Self::build_h1_client(headers)?;
+        let http_client = Self::build_h1_client(headers)?;
 
         Ok(Self {
             config_client,
             config: uploader_config,
-            http_client: client,
+            http_client,
         })
     }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -1,4 +1,5 @@
-use crate::common::{build_static_headers, validate_user_agent_prefix};
+use crate::client::build_geneva_headers;
+use crate::common::validate_user_agent_prefix;
 use crate::config_service::client::{GenevaConfigClient, GenevaConfigClientError};
 use crate::payload_encoder::central_blob::BatchMetadata;
 use reqwest::{header, Client};
@@ -139,11 +140,8 @@ impl GenevaUploader {
                 .map_err(|e| GenevaUploaderError::InvalidUserAgentPrefix(e.to_string()))?;
         }
 
-        let agent_identity = "GenevaUploader";
-        let agent_version = "0.1";
-        let user_agent_prefix = uploader_config.user_agent_prefix.unwrap_or("");
-        let static_headers = build_static_headers(agent_identity, agent_version, user_agent_prefix)
-            .map_err(|e| GenevaUploaderError::InvalidUserAgentPrefix(e.to_string()))?;
+        let static_headers = build_geneva_headers(uploader_config.user_agent_prefix)
+            .map_err(|e| GenevaUploaderError::InvalidUserAgentPrefix(e))?;
 
         let http_client = Client::builder()
             .timeout(Duration::from_secs(30))

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -1,3 +1,4 @@
+mod common;
 mod config_service;
 mod ingestion_service;
 pub mod payload_encoder;

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -63,7 +63,7 @@ async fn main() {
         role_name,
         role_instance,
         max_concurrent_uploads: None, // Use default
-        user_agent_suffix: Some("BasicExample".to_string()),
+        user_agent_suffix: Some("BasicExample"),
     };
 
     let geneva_client = GenevaClient::new(config)

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -63,7 +63,7 @@ async fn main() {
         role_name,
         role_instance,
         max_concurrent_uploads: None, // Use default
-        user_agent_suffix: Some("BasicExample"),
+        user_agent_prefix: Some("BasicExample"),
     };
 
     let geneva_client = GenevaClient::new(config)

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -63,6 +63,7 @@ async fn main() {
         role_name,
         role_instance,
         max_concurrent_uploads: None, // Use default
+        user_agent_suffix: Some("BasicExample".to_string()),
     };
 
     let geneva_client = GenevaClient::new(config)

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
@@ -104,6 +104,7 @@ async fn main() {
         role_name,
         role_instance,
         auth_method,
+        user_agent_prefix: None,
         msi_resource,
     };
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
@@ -83,6 +83,7 @@ async fn main() {
         role_name,
         role_instance,
         auth_method,
+        user_agent_prefix: None,
         msi_resource: None, // Not used for Workload Identity
     };
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -56,6 +56,7 @@ async fn main() {
         tenant,
         role_name,
         role_instance,
+        user_agent_prefix: None,
         msi_resource: None,
     };
 

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -124,6 +124,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             max_concurrent_uploads: None, // Use default
+            user_agent_suffix: Some("GenevaStressTest/1.0"),
         };
 
         let client = GenevaClient::new(config).await?;
@@ -143,6 +144,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             max_concurrent_uploads: None, // Use default
+            user_agent_suffix: Some("GenevaStressTest/1.0"),
         };
 
         let client = GenevaClient::new(config).await?;
@@ -198,6 +200,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             max_concurrent_uploads: None, // Use default
+            user_agent_suffix: Some("GenevaStressTest/1.0"),
         };
 
         let client = GenevaClient::new(config).await?;

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -124,7 +124,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             max_concurrent_uploads: None, // Use default
-            user_agent_suffix: Some("GenevaStressTest/1.0"),
+            user_agent_prefix: Some("GenevaStressTest/1.0"),
         };
 
         let client = GenevaClient::new(config).await?;
@@ -144,7 +144,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             max_concurrent_uploads: None, // Use default
-            user_agent_suffix: Some("GenevaStressTest/1.0"),
+            user_agent_prefix: Some("GenevaStressTest/1.0"),
         };
 
         let client = GenevaClient::new(config).await?;
@@ -200,7 +200,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             max_concurrent_uploads: None, // Use default
-            user_agent_suffix: Some("GenevaStressTest/1.0"),
+            user_agent_prefix: Some("GenevaStressTest/1.0"),
         };
 
         let client = GenevaClient::new(config).await?;


### PR DESCRIPTION
## Changes
The `User-Agent` HTTP header should ideally identify the application making the request, not just the library. 
This PR adds configurable User-Agent header support to the Geneva Uploader, allowing applications to identify themselves in HTTP requests to Geneva services. 

So the approach with the PR is:

| Configuration | Resulting User-Agent |
|---------------|----------------------|
| `None` | `RustGenevaClient/0.1` |
| `Some("MyApp/2.1.0")` | `MyApp/2.1.0 (RustGenevaClient/0.1)` |

##

Also added support to provide the user-agent header in the Ingestion Service (along with Config Service)



## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
