### PR TITLE
perf: [Geneva Exporter] optimize schema creation in OTLP encoder to create only when required

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -242,19 +242,20 @@ mod benchmarks {
         criterion.final_summary();
     }
 
-    /// Benchmark specifically to test schema creation optimization
     /// This test focuses on scenarios where many log records share the same schema structure,
-    /// which is where our "create schema only when needed" optimization should show the most benefit.
+    ///    - Same event name ("IdenticalSchemaEvent")
+    ///    - Same set of attributes (4 attributes with identical keys and types)
+    ///
     #[test]
     #[ignore = "benchmark on crate private, ignored by default during normal test runs"]
-    // To run: $cargo test --release schema_optimization_benchmark -- --nocapture --ignored
-    fn schema_optimization_benchmark() {
+    // To run: $cargo test --release encode_log_batch_identical_schemas -- --nocapture --ignored
+    fn encode_log_batch_identical_schemas() {
         let mut criterion = Criterion::default();
         let encoder = OtlpEncoder::new();
         let metadata = "namespace=benchmark/eventVersion=Ver1v0";
 
         // Benchmark: Many logs with identical schema structure (should benefit most from optimization)
-        let mut group = criterion.benchmark_group("schema_optimization");
+        let mut group = criterion.benchmark_group("encode_log_batch_identical_schemas");
         for batch_size in [10, 50, 100, 500, 1000].iter() {
             group.bench_with_input(
                 BenchmarkId::new("identical_schemas", batch_size),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -241,4 +241,98 @@ mod benchmarks {
 
         criterion.final_summary();
     }
+
+    /// Benchmark specifically to test schema creation optimization
+    /// This test focuses on scenarios where many log records share the same schema structure,
+    /// which is where our "create schema only when needed" optimization should show the most benefit.
+    #[test]
+    #[ignore = "benchmark on crate private, ignored by default during normal test runs"]
+    // To run: $cargo test --release schema_optimization_benchmark -- --nocapture --ignored
+    fn schema_optimization_benchmark() {
+        let mut criterion = Criterion::default();
+        let encoder = OtlpEncoder::new();
+        let metadata = "namespace=benchmark/eventVersion=Ver1v0";
+
+        // Benchmark: Many logs with identical schema structure (should benefit most from optimization)
+        let mut group = criterion.benchmark_group("schema_optimization");
+        for batch_size in [10, 50, 100, 500, 1000].iter() {
+            group.bench_with_input(
+                BenchmarkId::new("identical_schemas", batch_size),
+                batch_size,
+                |b, &batch_size| {
+                    // Create logs with identical schema structure - all have same 4 attributes
+                    let logs: Vec<LogRecord> = (0..batch_size)
+                        .map(|i| {
+                            let mut log = LogRecord {
+                                observed_time_unix_nano: 1_700_000_000_000_000_000 + i as u64,
+                                severity_number: 9,
+                                severity_text: "INFO".to_string(),
+                                event_name: "IdenticalSchemaEvent".to_string(),
+                                body: Some(AnyValue {
+                                    value: Some(
+                                        opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                            "Log message".to_string(),
+                                        ),
+                                    ),
+                                }),
+                                ..Default::default()
+                            };
+
+                            // Add exactly the same 4 attributes to each log to ensure identical schemas
+                            log.attributes.push(KeyValue {
+                                key: "service_name".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(
+                                        opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                            "test-service".to_string(),
+                                        ),
+                                    ),
+                                }),
+                            });
+                            log.attributes.push(KeyValue {
+                                key: "request_id".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(
+                                        opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                            format!("req_{}", i),
+                                        ),
+                                    ),
+                                }),
+                            });
+                            log.attributes.push(KeyValue {
+                                key: "status_code".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(
+                                        opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(200),
+                                    ),
+                                }),
+                            });
+                            log.attributes.push(KeyValue {
+                                key: "duration_ms".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(
+                                        opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(
+                                            (i % 100) as f64 + 50.5,
+                                        ),
+                                    ),
+                                }),
+                            });
+
+                            log
+                        })
+                        .collect();
+
+                    b.iter(|| {
+                        let res = black_box(
+                            encoder.encode_log_batch(black_box(logs.iter()), black_box(metadata)),
+                        );
+                        black_box(res);
+                    });
+                },
+            );
+        }
+        group.finish();
+
+        criterion.final_summary();
+    }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -91,7 +91,6 @@ impl OtlpEncoder {
             let (field_info, schema_id) =
                 Self::determine_fields_and_schema_id(log_record, event_name_str);
 
-            let schema_entry = Self::create_schema(schema_id, field_info.as_slice());
             // 2. Encode row
             let row_buffer = self.write_row_data(log_record, &field_info);
             let level = log_record.severity_number as u8;
@@ -115,8 +114,9 @@ impl OtlpEncoder {
                 entry.metadata.end_time = entry.metadata.end_time.max(timestamp);
             }
 
-            // 4. Add schema entry if not already present (multiple schemas per event_name batch)
+            // 4. Add schema entry only if not already present (optimized: create only when needed)
             if !entry.schemas.iter().any(|s| s.id == schema_id) {
+                let schema_entry = Self::create_schema(schema_id, field_info.as_slice());
                 entry.schemas.push(schema_entry);
             }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -114,7 +114,7 @@ impl OtlpEncoder {
                 entry.metadata.end_time = entry.metadata.end_time.max(timestamp);
             }
 
-            // 4. Add schema entry only if not already present (optimized: create only when needed)
+            // 4. Add schema entry only if not already present (there could be multiple schemas per event_name batch)
             if !entry.schemas.iter().any(|s| s.id == schema_id) {
                 let schema_entry = Self::create_schema(schema_id, field_info.as_slice());
                 entry.schemas.push(schema_entry);


### PR DESCRIPTION
## Changes

Optimized the OTLP encoder to create schema entries only when they don't already exist in the batch, eliminating unnecessary schema creation for duplicate schemas.

### Changes

- __Modified `otlp_encoder.rs`__: Moved `Self::create_schema()` call inside the conditional check that verifies if a schema already exists
- __Added comprehensive benchmark__: New `schema_optimization_benchmark` to measure performance impact on identical schema scenarios
- __Performance improvement__: 69-74% faster processing for batches with identical schemas


### Performance Impact

Benchmark results for logs with identical schema structures:

| Batch Size | Before | After | Improvement |
|------------|--------|-------|-------------|
| 10 logs | 51.8 µs | 16.1 µs | **69% faster** |
| 50 logs | 261.7 µs | 69.5 µs | **73% faster** |
| 100 logs | 527.8 µs | 138.4 µs | **74% faster** |
| 500 logs | 2.64 ms | 679.7 µs | **74% faster** |
| 1000 logs | 5.14 ms | 1.33 ms | **74% faster** |

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
