### PR TITLE
Geneva Exporter: encode trace flags as u32 in OTLP encoder

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -180,7 +180,7 @@ impl OtlpEncoder {
             fields.push((FIELD_SPAN_ID.into(), BondDataType::BT_STRING));
         }
         if log.flags != 0 {
-            fields.push((FIELD_TRACE_FLAGS.into(), BondDataType::BT_INT32));
+            fields.push((FIELD_TRACE_FLAGS.into(), BondDataType::BT_UINT32));
         }
 
         // Part B - Core log fields
@@ -282,7 +282,7 @@ impl OtlpEncoder {
                     BondWriter::write_string(&mut buffer, hex_str);
                 }
                 FIELD_TRACE_FLAGS => {
-                    BondWriter::write_numeric(&mut buffer, log.flags as i32);
+                    BondWriter::write_numeric(&mut buffer, log.flags as u32);
                 }
                 FIELD_NAME => {
                     BondWriter::write_string(&mut buffer, &log.event_name);


### PR DESCRIPTION
## Changes

- Treat OTLP trace flags as unsigned 32-bit in the Geneva encoder.
- In geneva-uploader/src/payload_encoder/otlp_encoder.rs:

  - Schema: env_dt_traceFlags type changed from BondDataType::BT_INT32 to BondDataType::BT_UINT32.
  - Encoding: write_numeric cast changed from (log.flags as i32) to (log.flags as u32).

- Aligns with OTLP spec (trace flags are a bitmask/unsigned). No other files changed. Local build and tests pass.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
