### PR TITLE
Fix: Remove unused futures dependency from geneva-uploader main deps

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -20,7 +20,6 @@ url = "2.2"
 md5 = "0.8.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
-futures = "0.3"
 
 [features]
 self_signed_certs = [] # Empty by default for security


### PR DESCRIPTION
## Description

This PR removes an unused dependency from the geneva-uploader crate. 

**Related:** Addresses comment in https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/398#discussion_r2263976523

## Changes Made

- **Removed** `futures = "0.3"` from the main `[dependencies]` section in `opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml`
- The `futures` crate remains available in `[dev-dependencies]` where it's actually used for tests

## Why This Change?

The `futures` crate was listed in the main dependencies but wasn't being used in the production code.

This is a cleanup change that removes unused dependencies without affecting functionality.

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
