### PR TITLE
Force Geneva Uploader to use HTTP1.1 - 400% increase in throughput 

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use url::form_urlencoded::byte_serialize;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use uuid::Uuid;
 
 /// Error types for the Geneva Uploader
@@ -114,8 +113,7 @@ pub(crate) struct GenevaUploaderConfig {
 pub struct GenevaUploader {
     pub config_client: Arc<GenevaConfigClient>,
     pub config: GenevaUploaderConfig,
-    pub http_clients: Vec<Client>,     // pool of HTTP/1 clients (each can hold several sockets)
-    rr: Arc<AtomicUsize>,              // round-robin index}
+    pub http_client: Client,
 }
 
 impl GenevaUploader {
@@ -137,17 +135,12 @@ impl GenevaUploader {
             header::ACCEPT,
             header::HeaderValue::from_static("application/json"),
         );
-        let pool_size = 1; // Number of HTTP/1 clients to create
-        let mut clients = Vec::with_capacity(pool_size);
-        for _ in 0..pool_size {
-            clients.push(Self::build_h1_client(&headers)?);
-        }
+        let client = Self::build_h1_client(&headers)?;
 
         Ok(Self {
             config_client,
             config: uploader_config,
-            http_clients: clients,
-            rr: Arc::new(AtomicUsize::new(0)),
+            http_client: client,
         })
     }
 
@@ -155,24 +148,11 @@ impl GenevaUploader {
         Ok(Client::builder()
             .timeout(Duration::from_secs(30))
             .default_headers(headers.clone())
-            .build()?)
-        /*Ok(Client::builder()
             .http1_only()
-            // keep multiple warm sockets so bursts don't re-handshake
-            .pool_max_idle_per_host(8)
-            .pool_idle_timeout(Some(Duration::from_secs(60)))
-            .tcp_keepalive(Some(Duration::from_secs(60)))
             .tcp_nodelay(true)
-            .connect_timeout(Duration::from_secs(5))
+            .tcp_keepalive(Some(Duration::from_secs(60)))
             .timeout(Duration::from_secs(30))
-            .default_headers(headers.clone())
-            .build()?)*/
-    }
-
-    #[inline]
-    fn pick_client(&self) -> &Client {
-        let i = self.rr.fetch_add(1, Ordering::Relaxed);
-        &self.http_clients[i % self.http_clients.len()]
+            .build()?)
     }
 
     /// Creates the GIG upload URI with required parameters
@@ -254,7 +234,7 @@ impl GenevaUploader {
         );
         // Send the upload request
         let response = self
-            .pick_client()
+            .http_client
             .post(&full_url)
             .header(
                 header::AUTHORIZATION,

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -51,8 +51,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn create_test_logs() -> Vec<ResourceLogs> {
     let mut log_records = Vec::new();
 
-    // Create 500 simple log records
-    for i in 0..500 {
+    // Create 10 simple log records
+    for i in 0..10 {
         let log = LogRecord {
             observed_time_unix_nano: 1700000000000000000 + i,
             event_name: "StressTestEvent".to_string(),

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -51,8 +51,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn create_test_logs() -> Vec<ResourceLogs> {
     let mut log_records = Vec::new();
 
-    // Create 10 simple log records
-    for i in 0..10 {
+    // Create 500 simple log records
+    for i in 0..500 {
         let log = LogRecord {
             observed_time_unix_nano: 1700000000000000000 + i,
             event_name: "StressTestEvent".to_string(),


### PR DESCRIPTION
## Changes

The server doesn't scale well with HTTP2 connection. So forcing client to use HTTP1.1

For each request containing 500 events, and sending 500 such request concurrently (using HTTP1.1):
**Throughput : ~390K**
```
Progress: 35053 ops completed (35053 successful, 100.0%) in 45.02s = 778.53 ops/sec
Progress: 39231 ops completed (39231 successful, 100.0%) in 50.03s = 784.16 ops/sec
Progress: 43290 ops completed (43290 successful, 100.0%) in 55.03s = 786.66 ops/sec
```

And using HTTP2:
**Throughput: ~78K**
```
Progress: 7643 ops completed (7643 successful, 100.0%) in 50.03s = 152.77 ops/sec
Progress: 8445 ops completed (8445 successful, 100.0%) in 55.03s = 153.46 ops/sec
Progress: 9221 ops completed (9221 successful, 100.0%) in 60.04s = 153.59 ops/sec
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
