### PR TITLE
fix: [Geneva Exporter] Add retries for ingestion info retrieval

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.2"
 md5 = "0.8.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
+tokio = { version = "1", default-features = false, features = ["time"] } # Needed for tokio::time::sleep in library code
 
 [features]
 self_signed_certs = [] # Empty by default for security

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -394,11 +394,8 @@ impl GenevaConfigClient {
                         break;
                     }
                     Err(e) => {
-                        last_error = Some(e);
-                        if attempt < MAX_GCS_RETRIES
-                            && is_retriable_error(last_error.as_ref().unwrap())
-                        {
-                            let delay = match last_error.as_ref().unwrap() {
+                        if attempt < MAX_GCS_RETRIES && is_retriable_error(&e) {
+                            let delay = match &e {
                                 GenevaConfigClientError::RequestFailedWithRetryAfter {
                                     retry_after_secs: Some(s),
                                     ..
@@ -410,6 +407,7 @@ impl GenevaConfigClient {
                             };
                             tokio::time::sleep(delay).await;
                         }
+                        last_error = Some(e);
                     }
                 }
             }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -99,7 +99,7 @@ pub(crate) enum GenevaConfigClientError {
 #[allow(dead_code)]
 pub(crate) type Result<T> = std::result::Result<T, GenevaConfigClientError>;
 
-const MAX_GCS_RETRIES: usize = 5;
+const MAX_GCS_RETRIES: usize = 3;
 const FIXED_BACKOFF: [Duration; 3] = [
     Duration::from_millis(200),
     Duration::from_millis(400),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -550,9 +550,7 @@ fn extract_endpoint_from_token(token: &str) -> Result<String> {
 
 fn is_retriable_error(err: &GenevaConfigClientError) -> bool {
     match err {
-        GenevaConfigClientError::Http(e) => {
-            e.is_timeout() || e.is_connect()
-        }
+        GenevaConfigClientError::Http(e) => e.is_timeout() || e.is_connect(),
         GenevaConfigClientError::RequestFailed { status, .. } => {
             (*status >= 500 && *status < 600) || *status == 429
         }
@@ -598,14 +596,20 @@ mod retry_tests {
                 status,
                 message: String::new(),
             };
-            assert!(super::is_retriable_error(&err), "status {status} should be retriable");
+            assert!(
+                super::is_retriable_error(&err),
+                "status {status} should be retriable"
+            );
         }
         // 429
         let err_429 = GenevaConfigClientError::RequestFailed {
             status: 429,
             message: String::new(),
         };
-        assert!(super::is_retriable_error(&err_429), "status 429 should be retriable");
+        assert!(
+            super::is_retriable_error(&err_429),
+            "status 429 should be retriable"
+        );
     }
 
     #[test]
@@ -615,7 +619,10 @@ mod retry_tests {
                 status,
                 message: String::new(),
             };
-            assert!(!super::is_retriable_error(&err), "status {status} should NOT be retriable");
+            assert!(
+                !super::is_retriable_error(&err),
+                "status {status} should NOT be retriable"
+            );
         }
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -93,6 +93,8 @@ pub(crate) enum GenevaConfigClientError {
 #[allow(dead_code)]
 pub(crate) type Result<T> = std::result::Result<T, GenevaConfigClientError>;
 
+const MAX_GCS_RETRIES: usize = 5;
+
 /// Configuration for the Geneva Config Client.
 ///
 /// # Fields
@@ -370,10 +372,23 @@ impl GenevaConfigClient {
                 }
             }
         }
-        // Cache miss or expired token, fetch fresh data
-        // Perform actual fetch before acquiring write lock to minimize lock contention
-        let (fresh_ingestion_gateway_info, fresh_moniker_info) =
-            self.fetch_ingestion_info().await?;
+        // Cache miss or expired token, fetch fresh data with retry logic (up to 5 retries on retriable errors)
+        let (fresh_ingestion_gateway_info, fresh_moniker_info) = {
+            let mut attempt = 0;
+            loop {
+                match self.fetch_ingestion_info().await {
+                    Ok(v) => break v,
+                    Err(e) => {
+                        if attempt < MAX_GCS_RETRIES && is_retriable_error(&e) {
+                            attempt += 1;
+                            continue;
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+        };
 
         let token_expiry =
             Self::parse_token_expiry(&fresh_ingestion_gateway_info.auth_token_expiry_time)
@@ -533,6 +548,18 @@ fn extract_endpoint_from_token(token: &str) -> Result<String> {
     Ok(endpoint)
 }
 
+fn is_retriable_error(err: &GenevaConfigClientError) -> bool {
+    match err {
+        GenevaConfigClientError::Http(e) => {
+            e.is_timeout() || e.is_connect()
+        }
+        GenevaConfigClientError::RequestFailed { status, .. } => {
+            (*status >= 500 && *status < 600) || *status == 429
+        }
+        _ => false,
+    }
+}
+
 #[cfg(feature = "self_signed_certs")]
 fn configure_tls_connector(
     mut builder: native_tls::TlsConnectorBuilder,
@@ -557,4 +584,38 @@ fn configure_tls_connector(
         .min_protocol_version(Some(Protocol::Tlsv12))
         .max_protocol_version(Some(Protocol::Tlsv12));
     builder
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retriable_request_failed_statuses() {
+        // 500 range
+        for status in [500u16, 502, 503, 504, 599] {
+            let err = GenevaConfigClientError::RequestFailed {
+                status,
+                message: String::new(),
+            };
+            assert!(super::is_retriable_error(&err), "status {status} should be retriable");
+        }
+        // 429
+        let err_429 = GenevaConfigClientError::RequestFailed {
+            status: 429,
+            message: String::new(),
+        };
+        assert!(super::is_retriable_error(&err_429), "status 429 should be retriable");
+    }
+
+    #[test]
+    fn test_is_not_retriable_request_failed_statuses() {
+        for status in [400u16, 401, 403, 404, 422] {
+            let err = GenevaConfigClientError::RequestFailed {
+                status,
+                message: String::new(),
+            };
+            assert!(!super::is_retriable_error(&err), "status {status} should NOT be retriable");
+        }
+    }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -106,6 +106,11 @@ const FIXED_BACKOFF: [Duration; 3] = [
     Duration::from_millis(800),
 ];
 
+/// Minimum acceptable retry-after value in seconds for rate limiting responses
+const MIN_RETRY_AFTER_SECS: u64 = 1;
+/// Maximum acceptable retry-after value in seconds for rate limiting responses
+const MAX_RETRY_AFTER_SECS: u64 = 3;
+
 /// Configuration for the Geneva Config Client.
 ///
 /// # Fields
@@ -519,7 +524,7 @@ impl GenevaConfigClient {
         {
             let retry_after_secs = retry_after_header
                 .and_then(|s| s.parse::<u64>().ok())
-                .filter(|v| *v >= 1 && *v <= 3);
+                .filter(|v| *v >= MIN_RETRY_AFTER_SECS && *v <= MAX_RETRY_AFTER_SECS);
             Err(GenevaConfigClientError::RequestFailedWithRetryAfter {
                 status: status.as_u16(),
                 message: body,


### PR DESCRIPTION
towards:  #309 

## Summary
This PR adds retry logic to the Geneva Config Service client to improve resilience against transient network issues and server overload. The changes implement intelligent error handling with appropriate backoff strategies.

Key changes:

- Adds retry mechanism with up to 3 attempts for Geneva Config Service API calls
- Implements smart backoff strategy using server-provided Retry-After headers or fixed delays
- Introduces new error type for rate limiting scenarios with retry information
- No changes in upload API, as retry for upload failure is the responsibility of caller.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
