### PR TITLE
feat: [Geneva Exporter] Add span upload support to Geneva exporter

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-opentelemetry-proto = {workspace = true, default-features = false, features = ["logs", "gen-tonic-messages"]}
+opentelemetry-proto = {workspace = true, default-features = false, features = ["logs", "trace", "gen-tonic-messages"]}
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct EncodedBatch {
     pub event_name: String,
-    pub name: Option<String>, // For spans: actual span name, for logs: event name
     pub data: Vec<u8>,
     pub metadata: crate::payload_encoder::central_blob::BatchMetadata,
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct EncodedBatch {
     pub event_name: String,
+    pub name: Option<String>, // For spans: actual span name, for logs: event name
     pub data: Vec<u8>,
     pub metadata: crate::payload_encoder::central_blob::BatchMetadata,
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -485,6 +485,7 @@ impl OtlpEncoder {
     }
 
     /// Write span row data directly from Span
+    // TODO - code duplication between write_span_row_data() and write_row_data() - consider extracting common field handling
     fn write_span_row_data(&self, span: &Span, sorted_fields: &[FieldDef]) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(sorted_fields.len() * 50);
 
@@ -545,7 +546,8 @@ impl OtlpEncoder {
                     BondWriter::write_string(&mut buffer, hex_str);
                 }
                 FIELD_LINKS => {
-                    // Serialize links as JSON, similar to the C# implementation
+                    // Serialize links as JSON
+                    // TODO - consider more efficient serialization if needed
                     let links_json = serde_json::to_string(
                         &span
                             .links

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -165,8 +165,7 @@ impl OtlpEncoder {
             let compressed = lz4_chunked_compression(&uncompressed)
                 .map_err(|e| format!("compression failed: {e}"))?;
             blobs.push(EncodedBatch {
-                event_name: batch_event_name.clone(),
-                name: Some(batch_event_name),
+                event_name: batch_event_name,
                 data: compressed,
                 metadata: batch_data.metadata,
             });
@@ -279,7 +278,6 @@ impl OtlpEncoder {
         
         Ok(vec![EncodedBatch {
             event_name: EVENT_NAME.to_string(),
-            name: first_span_name, // Use the first span's name for test validation
             data: compressed,
             metadata: batch_metadata,
         }])
@@ -1139,7 +1137,6 @@ mod tests {
         // Should create one batch with same event_name
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Span"); // All spans use "Span" event name for routing
-        assert_eq!(result[0].name, Some("database_query".to_string())); // Should capture first span's name
         assert!(!result[0].data.is_empty());
         // Should have 1 schema ID since both spans have same schema structure
         assert_eq!(result[0].metadata.schema_ids.matches(';').count(), 0); // 1 schema = 0 semicolons

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -7,6 +7,7 @@ use crate::payload_encoder::lz4_chunked_compression::lz4_chunked_compression;
 use chrono::{TimeZone, Utc};
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::logs::v1::LogRecord;
+use opentelemetry_proto::tonic::trace::v1::Span;
 use std::borrow::Cow;
 use std::sync::Arc;
 
@@ -21,6 +22,15 @@ const FIELD_NAME: &str = "name";
 const FIELD_SEVERITY_NUMBER: &str = "SeverityNumber";
 const FIELD_SEVERITY_TEXT: &str = "SeverityText";
 const FIELD_BODY: &str = "body";
+
+// Span-specific field constants
+const FIELD_KIND: &str = "kind";
+const FIELD_START_TIME: &str = "startTime";
+const FIELD_SUCCESS: &str = "success";
+const FIELD_TRACE_STATE: &str = "traceState";
+const FIELD_PARENT_ID: &str = "parentId";
+const FIELD_LINKS: &str = "links";
+const FIELD_STATUS_MESSAGE: &str = "statusMessage";
 
 /// Encoder to write OTLP payload in bond form.
 #[derive(Clone)]
@@ -163,6 +173,134 @@ impl OtlpEncoder {
         Ok(blobs)
     }
 
+    /// Encode a batch of spans into a vector of (event_name, compressed_bytes, schema_ids, start_time_nanos, end_time_nanos)
+    /// The returned `data` field contains LZ4 chunked compressed bytes.
+    /// On compression failure, the error is returned (no logging, no fallback).
+    pub(crate) fn encode_span_batch<'a, I>(
+        &self,
+        spans: I,
+        metadata: &str,
+    ) -> Result<Vec<EncodedBatch>, String>
+    where
+        I: IntoIterator<Item = &'a Span>,
+    {
+        use std::collections::HashMap;
+
+        // Internal struct to accumulate batch data before encoding
+        struct BatchData {
+            schemas: Vec<CentralSchemaEntry>,
+            events: Vec<CentralEventEntry>,
+            metadata: BatchMetadata,
+        }
+
+        impl BatchData {
+            fn format_schema_ids(&self) -> String {
+                use std::fmt::Write;
+
+                if self.schemas.is_empty() {
+                    return String::new();
+                }
+
+                // Pre-allocate capacity: Each MD5 hash is 32 hex chars + 1 semicolon (except last)
+                // Total: (32 chars per hash * num_schemas) + (semicolons = num_schemas - 1)
+                let estimated_capacity =
+                    self.schemas.len() * 32 + self.schemas.len().saturating_sub(1);
+
+                self.schemas.iter().enumerate().fold(
+                    String::with_capacity(estimated_capacity),
+                    |mut acc, (i, s)| {
+                        if i > 0 {
+                            acc.push(';');
+                        }
+                        let md5_hash = md5::compute(s.id.to_le_bytes());
+                        write!(&mut acc, "{md5_hash:x}").unwrap();
+                        acc
+                    },
+                )
+            }
+        }
+
+        let mut batches: HashMap<String, BatchData> = HashMap::new();
+
+        for span in spans {
+            // Use span name directly, fallback to "Span" if empty
+            let event_name_str = if span.name.is_empty() {
+                "Span"
+            } else {
+                span.name.as_str()
+            };
+
+            // 1. Get schema with optimized single-pass field collection and schema ID calculation
+            let (field_info, schema_id) =
+                Self::determine_span_fields_and_schema_id(span, event_name_str);
+
+            // 2. Encode row
+            let row_buffer = self.write_span_row_data(span, &field_info);
+            let level = 5; // Default level for spans (INFO equivalent)
+
+            // 3. Create or get existing batch entry with metadata tracking
+            let entry = batches
+                .entry(event_name_str.to_string())
+                .or_insert_with(|| BatchData {
+                    schemas: Vec::new(),
+                    events: Vec::new(),
+                    metadata: BatchMetadata {
+                        start_time: span.start_time_unix_nano,
+                        end_time: span.end_time_unix_nano,
+                        schema_ids: String::new(),
+                    },
+                });
+
+            // Update timestamp range
+            if span.start_time_unix_nano != 0 {
+                entry.metadata.start_time =
+                    entry.metadata.start_time.min(span.start_time_unix_nano);
+            }
+            if span.end_time_unix_nano != 0 {
+                entry.metadata.end_time = entry.metadata.end_time.max(span.end_time_unix_nano);
+            }
+
+            // 4. Add schema entry if not already present (multiple schemas per event_name batch)
+            if !entry.schemas.iter().any(|s| s.id == schema_id) {
+                let schema_entry = Self::create_span_schema(schema_id, field_info);
+                entry.schemas.push(schema_entry);
+            }
+
+            // 5. Create CentralEventEntry directly (optimization: no intermediate EncodedRow)
+            let central_event = CentralEventEntry {
+                schema_id,
+                level,
+                event_name: Arc::new(event_name_str.to_string()),
+                row: row_buffer,
+            };
+            entry.events.push(central_event);
+        }
+
+        // 6. Encode blobs (one per event_name, potentially multiple schemas per blob)
+        let mut blobs = Vec::with_capacity(batches.len());
+        for (batch_event_name, mut batch_data) in batches {
+            let schema_ids_string = batch_data.format_schema_ids();
+            batch_data.metadata.schema_ids = schema_ids_string;
+
+            let blob = CentralBlob {
+                version: 1,
+                format: 2,
+                metadata: metadata.to_string(),
+                schemas: batch_data.schemas,
+                events: batch_data.events,
+            };
+            let uncompressed = blob.to_bytes();
+            let compressed = lz4_chunked_compression(&uncompressed)
+                .map_err(|e| format!("compression failed: {e}"))?;
+            blobs.push(EncodedBatch {
+                event_name: batch_event_name,
+                data: compressed,
+                metadata: batch_data.metadata,
+            });
+        }
+        Ok(blobs)
+    }
+
     /// Determine fields and calculate schema ID in a single pass for optimal performance
     fn determine_fields_and_schema_id(log: &LogRecord, event_name: &str) -> (Vec<FieldDef>, u64) {
         use std::collections::hash_map::DefaultHasher;
@@ -245,6 +383,95 @@ impl OtlpEncoder {
         (field_defs, schema_id)
     }
 
+    /// Determine span fields and calculate schema ID in a single pass for optimal performance
+    fn determine_span_fields_and_schema_id(span: &Span, event_name: &str) -> (Vec<FieldDef>, u64) {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        // Pre-allocate with estimated capacity to avoid reallocations
+        let estimated_capacity = 10 + span.attributes.len();
+        let mut fields = Vec::with_capacity(estimated_capacity);
+
+        // Initialize hasher for schema ID calculation
+        let mut hasher = DefaultHasher::new();
+        event_name.hash(&mut hasher);
+
+        // Part A - Always present fields for spans
+        fields.push((Cow::Borrowed(FIELD_ENV_NAME), BondDataType::BT_STRING));
+        fields.push((FIELD_ENV_VER.into(), BondDataType::BT_STRING));
+        fields.push((FIELD_TIMESTAMP.into(), BondDataType::BT_STRING));
+        fields.push((FIELD_ENV_TIME.into(), BondDataType::BT_STRING));
+
+        // Span-specific required fields
+        fields.push((FIELD_KIND.into(), BondDataType::BT_INT32));
+        fields.push((FIELD_START_TIME.into(), BondDataType::BT_STRING));
+        fields.push((FIELD_SUCCESS.into(), BondDataType::BT_BOOL));
+
+        // Part A extension - Conditional fields
+        if !span.trace_id.is_empty() {
+            fields.push((FIELD_TRACE_ID.into(), BondDataType::BT_STRING));
+        }
+        if !span.span_id.is_empty() {
+            fields.push((FIELD_SPAN_ID.into(), BondDataType::BT_STRING));
+        }
+        if span.flags != 0 {
+            fields.push((FIELD_TRACE_FLAGS.into(), BondDataType::BT_UINT32));
+        }
+
+        // Part B - Span-specific optional fields
+        if !span.name.is_empty() {
+            fields.push((FIELD_NAME.into(), BondDataType::BT_STRING));
+        }
+        if !span.trace_state.is_empty() {
+            fields.push((FIELD_TRACE_STATE.into(), BondDataType::BT_STRING));
+        }
+        if !span.parent_span_id.is_empty() {
+            fields.push((FIELD_PARENT_ID.into(), BondDataType::BT_STRING));
+        }
+        if !span.links.is_empty() {
+            fields.push((FIELD_LINKS.into(), BondDataType::BT_STRING));
+        }
+        if let Some(status) = &span.status {
+            if !status.message.is_empty() {
+                fields.push((FIELD_STATUS_MESSAGE.into(), BondDataType::BT_STRING));
+            }
+        }
+
+        // Part C - Dynamic attributes
+        for attr in &span.attributes {
+            if let Some(val) = attr.value.as_ref().and_then(|v| v.value.as_ref()) {
+                let type_id = match val {
+                    Value::StringValue(_) => BondDataType::BT_STRING,
+                    Value::IntValue(_) => BondDataType::BT_INT64,
+                    Value::DoubleValue(_) => BondDataType::BT_DOUBLE,
+                    Value::BoolValue(_) => BondDataType::BT_BOOL,
+                    _ => continue,
+                };
+                fields.push((attr.key.clone().into(), type_id));
+            }
+        }
+
+        // Hash field names and types while converting to FieldDef
+        let field_defs: Vec<FieldDef> = fields
+            .into_iter()
+            .enumerate()
+            .map(|(i, (name, type_id))| {
+                // Hash field name and type for schema ID
+                name.hash(&mut hasher);
+                type_id.hash(&mut hasher);
+
+                FieldDef {
+                    name,
+                    type_id,
+                    field_id: (i + 1) as u16,
+                }
+            })
+            .collect();
+
+        let schema_id = hasher.finish();
+        (field_defs, schema_id)
+    }
+
     /// Create schema - always creates a new CentralSchemaEntry
     fn create_schema(schema_id: u64, field_info: Vec<FieldDef>) -> CentralSchemaEntry {
         let schema = BondEncodedSchema::from_fields("OtlpLogRecord", "telemetry", field_info); //TODO - use actual struct name and namespace
@@ -257,6 +484,114 @@ impl OtlpEncoder {
             md5: schema_md5,
             schema,
         }
+    }
+
+    /// Create span schema - always creates a new CentralSchemaEntry
+    fn create_span_schema(schema_id: u64, field_info: Vec<FieldDef>) -> CentralSchemaEntry {
+        let schema = BondEncodedSchema::from_fields("OtlpSpanRecord", "telemetry", field_info);
+
+        let schema_bytes = schema.as_bytes();
+        let schema_md5 = md5::compute(schema_bytes).0;
+
+        CentralSchemaEntry {
+            id: schema_id,
+            md5: schema_md5,
+            schema,
+        }
+    }
+
+    /// Write span row data directly from Span
+    fn write_span_row_data(&self, span: &Span, sorted_fields: &[FieldDef]) -> Vec<u8> {
+        let mut buffer = Vec::with_capacity(sorted_fields.len() * 50);
+
+        // Pre-calculate timestamps
+        let start_timestamp = Self::format_timestamp(span.start_time_unix_nano);
+        let formatted_timestamp = start_timestamp.clone(); // Use start time as primary timestamp
+
+        for field in sorted_fields {
+            match field.name.as_ref() {
+                FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, "TestEnv"), // TODO - placeholder
+                FIELD_ENV_VER => BondWriter::write_string(&mut buffer, "4.0"), // TODO - placeholder
+                FIELD_TIMESTAMP | FIELD_ENV_TIME => {
+                    BondWriter::write_string(&mut buffer, &formatted_timestamp);
+                }
+                FIELD_KIND => {
+                    BondWriter::write_numeric(&mut buffer, span.kind);
+                }
+                FIELD_START_TIME => {
+                    BondWriter::write_string(&mut buffer, &start_timestamp);
+                }
+                FIELD_SUCCESS => {
+                    // Determine success based on status
+                    let success = match &span.status {
+                        Some(status) => {
+                            use opentelemetry_proto::tonic::trace::v1::status::StatusCode;
+                            match StatusCode::try_from(status.code) {
+                                Ok(StatusCode::Ok) => true,
+                                Ok(StatusCode::Error) => false,
+                                _ => true, // Unset or unknown defaults to true
+                            }
+                        }
+                        None => true, // No status defaults to true
+                    };
+                    BondWriter::write_bool(&mut buffer, success);
+                }
+                FIELD_TRACE_ID => {
+                    let hex_bytes = Self::encode_id_to_hex::<32>(&span.trace_id);
+                    let hex_str = std::str::from_utf8(&hex_bytes).unwrap();
+                    BondWriter::write_string(&mut buffer, hex_str);
+                }
+                FIELD_SPAN_ID => {
+                    let hex_bytes = Self::encode_id_to_hex::<16>(&span.span_id);
+                    let hex_str = std::str::from_utf8(&hex_bytes).unwrap();
+                    BondWriter::write_string(&mut buffer, hex_str);
+                }
+                FIELD_TRACE_FLAGS => {
+                    BondWriter::write_numeric(&mut buffer, span.flags);
+                }
+                FIELD_NAME => {
+                    BondWriter::write_string(&mut buffer, &span.name);
+                }
+                FIELD_TRACE_STATE => {
+                    BondWriter::write_string(&mut buffer, &span.trace_state);
+                }
+                FIELD_PARENT_ID => {
+                    let hex_bytes = Self::encode_id_to_hex::<16>(&span.parent_span_id);
+                    let hex_str = std::str::from_utf8(&hex_bytes).unwrap();
+                    BondWriter::write_string(&mut buffer, hex_str);
+                }
+                FIELD_LINKS => {
+                    // Serialize links as JSON, similar to the C# implementation
+                    let links_json = serde_json::to_string(
+                        &span
+                            .links
+                            .iter()
+                            .map(|link| {
+                                serde_json::json!({
+                                    "toSpanId": hex::encode(&link.span_id),
+                                    "toTraceId": hex::encode(&link.trace_id)
+                                })
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .unwrap_or_default();
+                    BondWriter::write_string(&mut buffer, &links_json);
+                }
+                FIELD_STATUS_MESSAGE => {
+                    if let Some(status) = &span.status {
+                        BondWriter::write_string(&mut buffer, &status.message);
+                    }
+                }
+                _ => {
+                    // Handle dynamic attributes
+                    if let Some(attr) = span.attributes.iter().find(|a| a.key == field.name) {
+                        self.write_attribute_value(&mut buffer, attr, field.type_id);
+                    }
+                }
+            }
+        }
+
+        buffer
     }
 
     /// Write row data directly from LogRecord
@@ -673,5 +1008,174 @@ mod tests {
         assert_eq!(system_alert.metadata.schema_ids.matches(';').count(), 0); // 1 schema = 0 semicolons
         assert!(!log_batch.data.is_empty()); // Should have encoded data
         assert_eq!(log_batch.metadata.schema_ids.matches(';').count(), 0); // 1 schema = 0 semicolons
+    }
+
+    #[test]
+    fn test_span_encoding() {
+        let encoder = OtlpEncoder::new();
+
+        let mut span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            parent_span_id: vec![3; 8],
+            name: "test_span".to_string(),
+            kind: 1, // CLIENT
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            flags: 1,
+            trace_state: "key=value".to_string(),
+            ..Default::default()
+        };
+
+        // Add some attributes
+        span.attributes.push(KeyValue {
+            key: "http.method".to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue("GET".to_string())),
+            }),
+        });
+
+        span.attributes.push(KeyValue {
+            key: "http.status_code".to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::IntValue(200)),
+            }),
+        });
+
+        let metadata = "namespace=testNamespace/eventVersion=Ver1v0";
+        let result = encoder.encode_span_batch([span].iter(), metadata).unwrap();
+
+        assert!(!result.is_empty());
+        assert_eq!(result[0].event_name, "test_span");
+        assert!(!result[0].data.is_empty());
+    }
+
+    #[test]
+    fn test_span_with_links() {
+        use opentelemetry_proto::tonic::trace::v1::span::Link;
+
+        let encoder = OtlpEncoder::new();
+
+        let mut span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "linked_span".to_string(),
+            kind: 2, // SERVER
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+
+        // Add some links
+        span.links.push(Link {
+            trace_id: vec![4; 16],
+            span_id: vec![5; 8],
+            ..Default::default()
+        });
+
+        span.links.push(Link {
+            trace_id: vec![6; 16],
+            span_id: vec![7; 8],
+            ..Default::default()
+        });
+
+        let result = encoder.encode_span_batch([span].iter(), "test").unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_name, "linked_span");
+        assert!(!result[0].data.is_empty());
+    }
+
+    #[test]
+    fn test_span_with_status() {
+        use opentelemetry_proto::tonic::trace::v1::{status::StatusCode, Status};
+
+        let encoder = OtlpEncoder::new();
+
+        let mut span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "error_span".to_string(),
+            kind: 1,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+
+        span.status = Some(Status {
+            message: "Something went wrong".to_string(),
+            code: StatusCode::Error as i32,
+        });
+
+        let result = encoder.encode_span_batch([span].iter(), "test").unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_name, "error_span");
+        assert!(!result[0].data.is_empty());
+    }
+
+    #[test]
+    fn test_empty_span_name_defaults_to_span() {
+        let encoder = OtlpEncoder::new();
+
+        let span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "".to_string(),
+            kind: 1,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+
+        let result = encoder.encode_span_batch([span].iter(), "test").unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_name, "Span"); // Should default to "Span"
+        assert!(!result[0].data.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_spans_same_name() {
+        let encoder = OtlpEncoder::new();
+
+        let span1 = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "database_query".to_string(),
+            kind: 3, // CLIENT
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+
+        let mut span2 = Span {
+            trace_id: vec![3; 16],
+            span_id: vec![4; 8],
+            name: "database_query".to_string(),
+            kind: 3,
+            start_time_unix_nano: 1_700_000_002_000_000_000,
+            end_time_unix_nano: 1_700_000_003_000_000_000,
+            ..Default::default()
+        };
+
+        // Add attributes to span2 to create different schema
+        span2.attributes.push(KeyValue {
+            key: "db.table".to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue("users".to_string())),
+            }),
+        });
+
+        let result = encoder
+            .encode_span_batch([span1, span2].iter(), "test")
+            .unwrap();
+
+        // Should create one batch with same event_name
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_name, "database_query");
+        assert!(!result[0].data.is_empty());
+        // Should have 2 different schema IDs (semicolon-separated)
+        assert_eq!(result[0].metadata.schema_ids.matches(';').count(), 1); // 2 schemas = 1 semicolon
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -192,13 +192,8 @@ impl OtlpEncoder {
         let mut events = Vec::new();
         let mut start_time = u64::MAX;
         let mut end_time = 0u64;
-        let mut first_span_name: Option<String> = None;
 
         for span in spans {
-            // Capture the first non-empty span name for the batch
-            if first_span_name.is_none() && !span.name.is_empty() {
-                first_span_name = Some(span.name.clone());
-            }
             // 1. Get schema with optimized single-pass field collection and schema ID calculation
             let (field_info, schema_id) =
                 Self::determine_span_fields_and_schema_id(span, EVENT_NAME);

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -1145,27 +1145,4 @@ mod tests {
         assert_eq!(result[0].metadata.schema_ids.matches(';').count(), 0); // 1 schema = 0 semicolons
     }
 
-    #[test]
-    fn test_span_name_validation() {
-        let encoder = OtlpEncoder::new();
-
-        let span = Span {
-            trace_id: vec![1; 16],
-            span_id: vec![2; 8],
-            name: "test_operation".to_string(),
-            kind: 1, // CLIENT
-            start_time_unix_nano: 1_700_000_000_000_000_000,
-            end_time_unix_nano: 1_700_000_001_000_000_000,
-            ..Default::default()
-        };
-
-        let result = encoder.encode_span_batch([span].iter(), "test").unwrap();
-
-        assert_eq!(result.len(), 1);
-        // Validate that event_name is "Span" for routing
-        assert_eq!(result[0].event_name, "Span");
-        // Validate that name contains the actual span name
-        assert_eq!(result[0].name, Some("test_operation".to_string()));
-        assert!(!result[0].data.is_empty());
-    }
 }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "opentelemetry-exporter-geneva"
-description = "OpenTelemetry exporter for Geneva logs"
+description = "OpenTelemetry exporter for Geneva logs and traces"
 version = "0.1.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
 rust-version = "1.75.0"
-keywords = ["opentelemetry", "geneva", "logs", "exporter"]
+keywords = ["opentelemetry", "geneva", "logs", "traces", "exporter"]
 license = "Apache-2.0"
 
 [dependencies]
-opentelemetry_sdk = {workspace = true, default-features = false, features = ["logs"]}
-opentelemetry-proto = {workspace = true, default-features = false, features = ["logs"]}
+opentelemetry_sdk = {workspace = true, default-features = false, features = ["logs", "trace"]}
+opentelemetry-proto = {workspace = true, default-features = false, features = ["logs", "trace"]}
 geneva-uploader = { path = "../geneva-uploader", version = "0.1.0" }
 futures = "0.3"
 
 [dev-dependencies]
 opentelemetry-appender-tracing = {workspace = true}
+opentelemetry = {workspace = true}
 opentelemetry_sdk = { workspace = true, features = ["logs", "trace", "experimental_logs_batch_log_processor_with_async_runtime", "experimental_async_runtime", "rt-tokio"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -4,7 +4,7 @@ use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
 use geneva_uploader::AuthMethod;
 use opentelemetry::{global, trace::Tracer, KeyValue};
 use opentelemetry_exporter_geneva::GenevaTraceExporter;
-use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
+use opentelemetry_sdk::trace::{SimpleSpanProcessor, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use std::env;
 use std::path::PathBuf;
@@ -63,8 +63,8 @@ async fn main() {
     // Create Geneva trace exporter
     let exporter = GenevaTraceExporter::new(geneva_client);
     
-    // Create batch span processor
-    let span_processor = BatchSpanProcessor::builder(exporter).build();
+    // Create simple span processor (exports spans immediately)
+    let span_processor = SimpleSpanProcessor::new(exporter);
 
     // Create tracer provider
     let tracer_provider = SdkTracerProvider::builder()
@@ -194,11 +194,10 @@ async fn main() {
 
     drop(_api_span);
 
-    println!("Spans created successfully!");
+    println!("Spans created and exported successfully!");
 
-    // Wait for spans to be exported
-    println!("Waiting for spans to be exported...");
-    thread::sleep(Duration::from_secs(3));
+    // SimpleSpanProcessor exports spans immediately, so no need to wait
+    println!("All spans have been exported to Geneva!");
 
     // Shutdown the tracer provider
     tracer_provider.shutdown().expect("Failed to shutdown tracer provider");

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -1,0 +1,206 @@
+//! run with `$ cargo run --example trace_basic
+
+use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
+use geneva_uploader::AuthMethod;
+use opentelemetry::{global, trace::Tracer, KeyValue};
+use opentelemetry_exporter_geneva::GenevaTraceExporter;
+use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
+use opentelemetry_sdk::Resource;
+use std::env;
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+/*
+export GENEVA_ENDPOINT="https://abc.azurewebsites.net"
+export GENEVA_ENVIRONMENT="Test"
+export GENEVA_ACCOUNT="myaccount"
+export GENEVA_NAMESPACE="myns"
+export GENEVA_REGION="eastus"
+export GENEVA_CERT_PATH="/tmp/client.p12"
+export GENEVA_CERT_PASSWORD="password"
+export GENEVA_CONFIG_MAJOR_VERSION=2
+*/
+
+#[tokio::main]
+async fn main() {
+    let endpoint = env::var("GENEVA_ENDPOINT").expect("GENEVA_ENDPOINT is required");
+    let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT is required");
+    let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT is required");
+    let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE is required");
+    let region = env::var("GENEVA_REGION").expect("GENEVA_REGION is required");
+    let cert_path =
+        PathBuf::from(env::var("GENEVA_CERT_PATH").expect("GENEVA_CERT_PATH is required"));
+    let cert_password = env::var("GENEVA_CERT_PASSWORD").expect("GENEVA_CERT_PASSWORD is required");
+    let config_major_version: u32 = env::var("GENEVA_CONFIG_MAJOR_VERSION")
+        .expect("GENEVA_CONFIG_MAJOR_VERSION is required")
+        .parse()
+        .expect("GENEVA_CONFIG_MAJOR_VERSION must be a u32");
+
+    let tenant = env::var("GENEVA_TENANT").unwrap_or_else(|_| "default-tenant".to_string());
+    let role_name = env::var("GENEVA_ROLE_NAME").unwrap_or_else(|_| "default-role".to_string());
+    let role_instance =
+        env::var("GENEVA_ROLE_INSTANCE").unwrap_or_else(|_| "default-instance".to_string());
+
+    let config = GenevaClientConfig {
+        endpoint,
+        environment,
+        account,
+        namespace,
+        region,
+        config_major_version,
+        auth_method: AuthMethod::Certificate {
+            path: cert_path,
+            password: cert_password,
+        },
+        tenant,
+        role_name,
+        role_instance,
+    };
+
+    let geneva_client = GenevaClient::new(config).expect("Failed to create GenevaClient");
+
+    // Create Geneva trace exporter
+    let exporter = GenevaTraceExporter::new(geneva_client);
+    
+    // Create batch span processor
+    let span_processor = BatchSpanProcessor::builder(exporter).build();
+
+    // Create tracer provider
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_span_processor(span_processor)
+        .with_resource(
+            Resource::builder()
+                .with_service_name("geneva-trace-exporter-example")
+                .build(),
+        )
+        .build();
+
+    // Set the global tracer provider
+    global::set_tracer_provider(tracer_provider.clone());
+
+    // Get a tracer
+    let tracer = global::tracer("geneva-trace-example");
+
+    // Create some example spans
+    println!("Creating example spans...");
+
+    // Root span for a user registration flow
+    let _registration_span = tracer
+        .span_builder("user_registration")
+        .with_attributes(vec![
+            KeyValue::new("user.id", "user123"),
+            KeyValue::new("user.email", "user123@example.com"),
+            KeyValue::new("operation.type", "registration"),
+        ])
+        .start(&tracer);
+
+    // Database query span
+    let _db_span = tracer
+        .span_builder("database_query")
+        .with_attributes(vec![
+            KeyValue::new("db.system", "postgresql"),
+            KeyValue::new("db.name", "users"),
+            KeyValue::new("db.operation", "INSERT"),
+            KeyValue::new("db.statement", "INSERT INTO users (email, name) VALUES (?, ?)"),
+        ])
+        .start(&tracer);
+
+    thread::sleep(Duration::from_millis(50)); // Simulate database work
+
+    drop(_db_span);
+
+    // HTTP request span
+    let _http_span = tracer
+        .span_builder("send_welcome_email")
+        .with_attributes(vec![
+            KeyValue::new("http.method", "POST"),
+            KeyValue::new("http.url", "https://api.email-service.com/send"),
+            KeyValue::new("http.status_code", 200),
+            KeyValue::new("email.type", "welcome"),
+        ])
+        .start(&tracer);
+
+    thread::sleep(Duration::from_millis(100)); // Simulate HTTP request
+
+    drop(_http_span);
+    drop(_registration_span);
+
+    // E-commerce checkout flow
+    let _checkout_span = tracer
+        .span_builder("checkout_process")
+        .with_attributes(vec![
+            KeyValue::new("user.id", "user456"),
+            KeyValue::new("cart.total", 99.99),
+            KeyValue::new("currency", "USD"),
+        ])
+        .start(&tracer);
+
+    // Payment processing span
+    let _payment_span = tracer
+        .span_builder("process_payment")
+        .with_attributes(vec![
+            KeyValue::new("payment.method", "credit_card"),
+            KeyValue::new("payment.amount", 99.99),
+            KeyValue::new("payment.processor", "stripe"),
+        ])
+        .start(&tracer);
+
+    thread::sleep(Duration::from_millis(200)); // Simulate payment processing
+
+    drop(_payment_span);
+
+    // Inventory update span
+    let _inventory_span = tracer
+        .span_builder("update_inventory")
+        .with_attributes(vec![
+            KeyValue::new("product.id", "prod789"),
+            KeyValue::new("quantity.reserved", 2),
+            KeyValue::new("inventory.operation", "reserve"),
+        ])
+        .start(&tracer);
+
+    thread::sleep(Duration::from_millis(30)); // Simulate inventory update
+
+    drop(_inventory_span);
+    drop(_checkout_span);
+
+    // Error scenario - failed login
+    let _failed_login_span = tracer
+        .span_builder("user_login")
+        .with_attributes(vec![
+            KeyValue::new("user.email", "invalid@example.com"),
+            KeyValue::new("login.result", "failed"),
+            KeyValue::new("error.type", "authentication_error"),
+        ])
+        .start(&tracer);
+
+    thread::sleep(Duration::from_millis(10)); // Simulate failed login
+
+    drop(_failed_login_span);
+
+    // API request span
+    let _api_span = tracer
+        .span_builder("api_request")
+        .with_attributes(vec![
+            KeyValue::new("http.method", "GET"),
+            KeyValue::new("http.route", "/api/users/:id"),
+            KeyValue::new("http.status_code", 200),
+            KeyValue::new("user.id", "user789"),
+        ])
+        .start(&tracer);
+
+    thread::sleep(Duration::from_millis(75)); // Simulate API processing
+
+    drop(_api_span);
+
+    println!("Spans created successfully!");
+
+    // Wait for spans to be exported
+    println!("Waiting for spans to be exported...");
+    thread::sleep(Duration::from_secs(3));
+
+    // Shutdown the tracer provider
+    tracer_provider.shutdown().expect("Failed to shutdown tracer provider");
+    println!("Tracer provider shut down successfully!");
+}

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -85,9 +85,9 @@ async fn main() {
     // Create some example spans
     println!("Creating example spans...");
 
-    // Example 1: User registration flow with nested spans
+    // Example 1: User registration flow
     {
-        let registration_span = tracer
+        let _registration_span = tracer
             .span_builder("user_registration")
             .with_attributes(vec![
                 KeyValue::new("user.id", "user123"),
@@ -95,11 +95,10 @@ async fn main() {
                 KeyValue::new("operation.type", "registration"),
             ])
             .start(&tracer);
-        let _guard = registration_span.enter();
 
-        // Nested database operation
+        // Database operation span
         {
-            let db_span = tracer
+            let _db_span = tracer
                 .span_builder("database_query")
                 .with_attributes(vec![
                     KeyValue::new("db.system", "postgresql"),
@@ -111,13 +110,12 @@ async fn main() {
                     ),
                 ])
                 .start(&tracer);
-            let _db_guard = db_span.enter();
             thread::sleep(Duration::from_millis(50)); // Simulate database work
-        }
+        } // db_span ends here
 
-        // Nested email operation
+        // Email operation span
         {
-            let email_span = tracer
+            let _email_span = tracer
                 .span_builder("send_welcome_email")
                 .with_attributes(vec![
                     KeyValue::new("http.method", "POST"),
@@ -126,14 +124,13 @@ async fn main() {
                     KeyValue::new("email.type", "welcome"),
                 ])
                 .start(&tracer);
-            let _email_guard = email_span.enter();
             thread::sleep(Duration::from_millis(100)); // Simulate HTTP request
-        }
-    }
+        } // email_span ends here
+    } // registration_span ends here
 
-    // Example 2: E-commerce checkout flow with nested spans
+    // Example 2: E-commerce checkout flow
     {
-        let checkout_span = tracer
+        let _checkout_span = tracer
             .span_builder("checkout_process")
             .with_attributes(vec![
                 KeyValue::new("user.id", "user456"),
@@ -141,11 +138,10 @@ async fn main() {
                 KeyValue::new("currency", "USD"),
             ])
             .start(&tracer);
-        let _guard = checkout_span.enter();
 
-        // Nested payment processing
+        // Payment processing span
         {
-            let payment_span = tracer
+            let _payment_span = tracer
                 .span_builder("process_payment")
                 .with_attributes(vec![
                     KeyValue::new("payment.method", "credit_card"),
@@ -153,13 +149,12 @@ async fn main() {
                     KeyValue::new("payment.processor", "stripe"),
                 ])
                 .start(&tracer);
-            let _payment_guard = payment_span.enter();
             thread::sleep(Duration::from_millis(200)); // Simulate payment processing
-        }
+        } // payment_span ends here
 
-        // Nested inventory update
+        // Inventory update span
         {
-            let inventory_span = tracer
+            let _inventory_span = tracer
                 .span_builder("update_inventory")
                 .with_attributes(vec![
                     KeyValue::new("product.id", "prod789"),
@@ -167,14 +162,13 @@ async fn main() {
                     KeyValue::new("inventory.operation", "reserve"),
                 ])
                 .start(&tracer);
-            let _inventory_guard = inventory_span.enter();
             thread::sleep(Duration::from_millis(30)); // Simulate inventory update
-        }
-    }
+        } // inventory_span ends here
+    } // checkout_span ends here
 
-    // Example 3: Error scenario - failed login (simple span)
+    // Example 3: Error scenario - failed login
     {
-        let failed_login_span = tracer
+        let _failed_login_span = tracer
             .span_builder("user_login")
             .with_attributes(vec![
                 KeyValue::new("user.email", "invalid@example.com"),
@@ -182,13 +176,12 @@ async fn main() {
                 KeyValue::new("error.type", "authentication_error"),
             ])
             .start(&tracer);
-        let _guard = failed_login_span.enter();
         thread::sleep(Duration::from_millis(10)); // Simulate failed login
-    }
+    } // failed_login_span ends here
 
-    // Example 4: API request (simple span)
+    // Example 4: API request
     {
-        let api_span = tracer
+        let _api_span = tracer
             .span_builder("api_request")
             .with_attributes(vec![
                 KeyValue::new("http.method", "GET"),
@@ -197,9 +190,8 @@ async fn main() {
                 KeyValue::new("user.id", "user789"),
             ])
             .start(&tracer);
-        let _guard = api_span.enter();
         thread::sleep(Duration::from_millis(75)); // Simulate API processing
-    }
+    } // api_span ends here
 
     println!("Spans created and exported successfully!");
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -4,7 +4,7 @@ use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
 use geneva_uploader::AuthMethod;
 use opentelemetry::{global, trace::Tracer, KeyValue};
 use opentelemetry_exporter_geneva::GenevaTraceExporter;
-use opentelemetry_sdk::trace::{SimpleSpanProcessor, SdkTracerProvider};
+use opentelemetry_sdk::trace::{SdkTracerProvider, SimpleSpanProcessor};
 use opentelemetry_sdk::Resource;
 use std::env;
 use std::path::PathBuf;
@@ -62,7 +62,7 @@ async fn main() {
 
     // Create Geneva trace exporter
     let exporter = GenevaTraceExporter::new(geneva_client);
-    
+
     // Create simple span processor (exports spans immediately)
     let span_processor = SimpleSpanProcessor::new(exporter);
 
@@ -102,7 +102,10 @@ async fn main() {
             KeyValue::new("db.system", "postgresql"),
             KeyValue::new("db.name", "users"),
             KeyValue::new("db.operation", "INSERT"),
-            KeyValue::new("db.statement", "INSERT INTO users (email, name) VALUES (?, ?)"),
+            KeyValue::new(
+                "db.statement",
+                "INSERT INTO users (email, name) VALUES (?, ?)",
+            ),
         ])
         .start(&tracer);
 
@@ -200,6 +203,8 @@ async fn main() {
     println!("All spans have been exported to Geneva!");
 
     // Shutdown the tracer provider
-    tracer_provider.shutdown().expect("Failed to shutdown tracer provider");
+    tracer_provider
+        .shutdown()
+        .expect("Failed to shutdown tracer provider");
     println!("Tracer provider shut down successfully!");
 }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/lib.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/lib.rs
@@ -4,5 +4,7 @@
 #![warn(missing_debug_implementations, missing_docs)]
 
 mod logs;
+mod trace;
 
 pub use logs::*;
+pub use trace::*;

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
@@ -84,8 +84,7 @@ impl SpanExporter for GenevaTraceExporter {
 
     fn shutdown(&mut self) -> OTelSdkResult {
         // Set shutdown flag to true
-        self._is_shutdown
-            .store(true, atomic::Ordering::Relaxed);
+        self._is_shutdown.store(true, atomic::Ordering::Relaxed);
         Ok(())
     }
 }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
@@ -85,6 +85,7 @@ impl SpanExporter for GenevaTraceExporter {
     fn shutdown(&mut self) -> OTelSdkResult {
         // Set shutdown flag to true
         self._is_shutdown.store(true, atomic::Ordering::Relaxed);
+        // TODO: Use the is_shutdown value in export() method to prevent exports after shutdown
         Ok(())
     }
 }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
@@ -1,0 +1,91 @@
+use core::fmt;
+use futures::stream::{self, StreamExt};
+use geneva_uploader::client::GenevaClient;
+use opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema;
+use opentelemetry_proto::transform::trace::tonic::group_spans_by_resource_and_scope;
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::trace::SpanExporter;
+use std::sync::{atomic, Arc};
+
+/// An OpenTelemetry exporter that writes spans to Geneva exporter
+pub struct GenevaTraceExporter {
+    resource: ResourceAttributesWithSchema,
+    _is_shutdown: atomic::AtomicBool,
+    geneva_client: Arc<GenevaClient>,
+    max_concurrent_uploads: usize,
+}
+
+// TODO - Add builder pattern for GenevaTraceExporter to allow more flexible configuration
+impl GenevaTraceExporter {
+    /// Create a new GenevaTraceExporter
+    pub fn new(geneva_client: GenevaClient) -> Self {
+        Self::new_with_concurrency(geneva_client, 4) // Default to 4 concurrent uploads
+    }
+
+    /// Create a new GenevaTraceExporter with custom concurrency level
+    pub fn new_with_concurrency(
+        geneva_client: GenevaClient,
+        max_concurrent_uploads: usize,
+    ) -> Self {
+        Self {
+            resource: ResourceAttributesWithSchema::default(),
+            _is_shutdown: atomic::AtomicBool::new(false),
+            geneva_client: Arc::new(geneva_client),
+            max_concurrent_uploads,
+        }
+    }
+}
+
+impl fmt::Debug for GenevaTraceExporter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Geneva trace exporter")
+    }
+}
+
+impl SpanExporter for GenevaTraceExporter {
+    async fn export(&self, batch: Vec<opentelemetry_sdk::trace::SpanData>) -> OTelSdkResult {
+        let otlp = group_spans_by_resource_and_scope(batch, &self.resource);
+
+        // Encode and compress spans into batches
+        let compressed_batches = match self.geneva_client.encode_and_compress_spans(&otlp) {
+            Ok(batches) => batches,
+            Err(e) => return Err(OTelSdkError::InternalFailure(e)),
+        };
+
+        // Execute uploads concurrently within the same async task using buffer_unordered.
+        // This processes up to max_concurrent_uploads batches simultaneously without
+        // spawning new tasks or threads, using async I/O concurrency instead.
+        // All batch uploads are processed asynchronously in the same task context that
+        // called the export() method.
+        let errors: Vec<String> = stream::iter(compressed_batches)
+            .map(|batch| {
+                let client = self.geneva_client.clone();
+                async move { client.upload_batch(&batch).await }
+            })
+            .buffer_unordered(self.max_concurrent_uploads)
+            .filter_map(|result| async move { result.err() })
+            .collect()
+            .await;
+
+        // Return error if any uploads failed
+        if !errors.is_empty() {
+            return Err(OTelSdkError::InternalFailure(format!(
+                "Upload failures: {}",
+                errors.join("; ")
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.resource = resource.into();
+    }
+
+    fn shutdown(&mut self) -> OTelSdkResult {
+        // Set shutdown flag to true
+        self._is_shutdown
+            .store(true, atomic::Ordering::Relaxed);
+        Ok(())
+    }
+}

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/mod.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/mod.rs
@@ -1,0 +1,2 @@
+mod exporter;
+pub use exporter::GenevaTraceExporter;


### PR DESCRIPTION
Adds OpenTelemetry span upload functionality to the Geneva exporter, enabling trace data ingestion alongside existing log support.

__Key Changes:__

- __geneva-uploader__: Added span encoding with Bond format, single payload approach using "Span" event name for routing
- __opentelemetry-exporter-geneva__: New `GenevaTraceExporter` implementing `SpanExporter` trait with concurrent upload support
- __Dependencies__: Added "trace" feature to opentelemetry-proto for OTLP span data structures
- __Example__: Added `trace_basic.rs` demonstrating span creation and export with SimpleSpanProcessor
- JSON serialization for span links (C# compatibility)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
