### PR TITLE
chore: prepare opentelemetry-user-events-metrcs 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ debug = 1
 opentelemetry = "0.30"
 opentelemetry-appender-tracing = "0.30"
 opentelemetry-http = "0.30"
-opentelemetry-proto = { version = "0.30", default-features = false }
+opentelemetry-proto = { version = "0.30.1", default-features = false }
 opentelemetry_sdk = { version = "0.30", default-features = false }
 opentelemetry-stdout = "0.30"
 opentelemetry-semantic-conventions = { version = "0.30", features = [

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+## v0.11.1
+
+Released 2025-Sep-17
+
+- Bump opentelemetry-proto version to 0.30.1
+- Bump prost version to 0.14
+
 ## v0.11.0
 
 Released 2025-May-27

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-user-events-metrics"
-version = "0.11.0"
+version = "0.11.1"
 description = "OpenTelemetry metrics exporter to user events"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
@@ -13,9 +13,9 @@ rust-version = "1.75.0"
 [dependencies]
 opentelemetry = { version= "0.30", features = ["metrics"] }
 opentelemetry_sdk = { version= "0.30", features = ["metrics"] }
-opentelemetry-proto = { version= "0.30", features = ["gen-tonic", "metrics"] }
+opentelemetry-proto = { version= "0.30.1", features = ["gen-tonic", "metrics"] }
 eventheader = { version = "= 0.4.1" }
-prost = "0.13"
+prost = "0.14"
 tracing = {version = "0.1", optional = true}
 
 [dev-dependencies]

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.75.0"
 [dependencies]
 opentelemetry = { version= "0.30", features = ["metrics"] }
 opentelemetry_sdk = { version= "0.30", features = ["metrics"] }
-opentelemetry-proto = { version= "0.30.1", features = ["gen-tonic", "metrics"], default-features = false } }
+opentelemetry-proto = { version= "0.30.1", features = ["gen-tonic", "metrics"], default-features = false }
 eventheader = { version = "= 0.4.1" }
 prost = "0.14"
 tracing = {version = "0.1", optional = true}


### PR DESCRIPTION
## Changes

Bump for otel-proto v0.30.1

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
