### PR TITLE
fix: Geneva Uploader - update stress test to use current timestamp for events.

### DIFF
--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -251,7 +251,7 @@ async fn async_main(
     args_start_idx: usize,
     runtime_type: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Get timestamp once at the start to avoid repeated syscalls during stress test
+    // Get timestamp for events
     let base_timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -50,12 +50,18 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 // Helper functions
 fn create_test_logs() -> Vec<ResourceLogs> {
     let mut log_records = Vec::new();
+    // Get current timestamp once to avoid repeated syscalls
+    let base_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
 
     // Create 10 simple log records
     for i in 0..10 {
+        let timestamp = base_timestamp + i * 1_000_000; // 1 ms apart
         let log = LogRecord {
-            observed_time_unix_nano: 1700000000000000000 + i,
-            event_name: "StressTestEvent".to_string(),
+            observed_time_unix_nano: timestamp,
+            event_name: "Log".to_string(),
             severity_number: 9,
             severity_text: "INFO".to_string(),
             body: Some(AnyValue {

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -56,8 +56,8 @@ fn create_test_logs() -> Vec<ResourceLogs> {
         .unwrap()
         .as_nanos() as u64;
 
-    // Create 10 simple log records
-    for i in 0..10 {
+    // Create 1000 simple log records
+    for i in 0..1000 {
         let timestamp = base_timestamp + i * 1_000_000; // 1 ms apart
         let log = LogRecord {
             observed_time_unix_nano: timestamp,

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -51,8 +51,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn create_test_logs(base_timestamp: u64) -> Vec<ResourceLogs> {
     let mut log_records = Vec::new();
 
-    // Create 1000 simple log records
-    for i in 0..1000 {
+    // Create 10 simple log records
+    for i in 0..10 {
         let timestamp = base_timestamp + i * 1_000_000; // 1 ms apart
         let log = LogRecord {
             observed_time_unix_nano: timestamp,


### PR DESCRIPTION
## Changes

  Update stress test configuration
  - Modified to use current timestamps for event time instead of fixed timestamps, simplifying backend queries by eliminating the need to query for specific historical times
  - Changed event name to "Log" to reflect the most common usage scenario
## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
