### PR TITLE
chore: remove unwanted tracing dependency

### DIFF
--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -16,7 +16,6 @@ eventheader_dynamic = "0.4.0"
 opentelemetry = { version= "0.31", features = ["logs"] }
 opentelemetry_sdk = { version= "0.31", features = ["logs"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-tracing = { version = "0.1", optional = true }
 futures-executor = "0.3"
 
 [dev-dependencies]
@@ -31,7 +30,7 @@ serde_json = "1.0.140"
 
 [features]
 spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
-internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
+internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
 experimental_eventname_callback = []
 default = ["internal-logs"]
 

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -16,7 +16,6 @@ opentelemetry_sdk = { version= "0.31", features = ["metrics"] }
 opentelemetry-proto = { version= "0.31", features = ["gen-tonic", "metrics"], default-features = false }
 eventheader = { version = "= 0.4.1" }
 prost = "0.14"
-tracing = {version = "0.1", optional = true}
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
@@ -24,7 +23,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "st
 serde_json = "1.0"
 
 [features]
-internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
+internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
 default = ["internal-logs"]
 
 [package.metadata.cargo-machete]

--- a/opentelemetry-user-events-trace/Cargo.toml
+++ b/opentelemetry-user-events-trace/Cargo.toml
@@ -16,7 +16,6 @@ eventheader_dynamic = "0.4.0"
 opentelemetry = { version= "0.31", features = ["trace"] }
 opentelemetry_sdk = { version= "0.31", features = ["trace"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-tracing = { version = "0.1", optional = true }
 futures-executor = "0.3"
 
 [dev-dependencies]
@@ -28,7 +27,7 @@ criterion = "0.7"
 serde_json = "1.0.140"
 
 [features]
-internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
+internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
 default = ["internal-logs"]
 
 [[bench]]


### PR DESCRIPTION
Due to re-export, no need of direct dependency.