### PR TITLE
chore: Try adding component owners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -1,0 +1,66 @@
+# Component Owners
+#
+# This file is used by .github/workflows/assign-reviewers.yml
+#
+# Each component identified by its path prefix has a list of users
+# who are responsible for that component. When a PR modifies files
+# matching a component's path, the listed users will be automatically
+# assigned as reviewers.
+#
+# Component owners are responsible for:
+#   - Reviewing and responding to issues and PRs for their components
+#   - Maintaining the component and keeping it up to date with the core SDK
+#   - Ensuring the component follows best practices and conventions
+#
+# To become a component owner, please read CONTRIBUTING.md and open a PR
+# adding yourself to this file for the relevant component(s).
+
+components:
+  opentelemetry-aws/:
+    - jj22ee
+
+  opentelemetry-config/:
+    - andborja
+
+  # opentelemetry-contrib/:
+  #   # TBD - seeking owners
+
+  opentelemetry-datadog/:
+    - gruebel
+
+  opentelemetry-etw-logs/:
+    - cijothomas
+    - lalitb
+
+  opentelemetry-etw-metrics/:
+    - cijothomas
+    - lalitb
+    - mattbodd
+    - psandana
+
+  # opentelemetry-exporter-geneva/:
+  #   # TBD - seeking owners
+
+  # opentelemetry-instrumentation-actix-web/:
+  #   # TBD - seeking owners
+
+  opentelemetry-instrumentation-tower/:
+    - francoposa
+
+  opentelemetry-resource-detectors/:
+    - gruebel
+
+  # opentelemetry-stackdriver/:
+  #   # TBD - seeking owners
+
+  opentelemetry-user-events-logs/:
+    - cijothomas
+    - lalitb
+
+  opentelemetry-user-events-metrics/:
+    - cijothomas
+    - lalitb
+
+  opentelemetry-user-events-trace/:
+    - cijothomas
+    - lalitb

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,23 @@
+name: 'Assign Reviewers'
+
+on:
+  # pull_request_target is suggested for projects where pull requests will be
+  # made from forked repositories. If pull_request is used in these cases,
+  # the github token will not have sufficient permission to update the PR.
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  assign:
+    permissions:
+      pull-requests: write # required for assigning reviewers to PRs
+    runs-on: ubuntu-24.04
+    name: Assign Reviewers
+    steps:
+      - uses: dyladan/component-owners@58bd86e9814d23f1525d0a970682cead459fa783 # v0.1.0
+        with:
+          # Only assign and request reviews for non-draft PRs
+          assign-owners: ${{ github.event.pull_request.draft == false }}
+          request-owner-reviews: ${{ github.event.pull_request.draft == false }}


### PR DESCRIPTION
Similar to many other contrib repos. Does not give approver access to owners. The GitHub action automatically notifies the owners for PRs in the component they own.
Follow up will update contributing guide etc.