### PR TITLE
fix(tower): Use semantic convention bucket boundaries by default and document use of alternate boundaries.

### DIFF
--- a/opentelemetry-instrumentation-tower/CHANGELOG.md
+++ b/opentelemetry-instrumentation-tower/CHANGELOG.md
@@ -14,6 +14,8 @@
     - `HTTPMetricsLayerBuilder` → `HTTPLayerBuilder`
 * Added OpenTelemetry trace support
 * **BREAKING**: Update default  `http.server.request.duration` histogram boundaries to OTel semantic conventions.
+* **BREAKING**: Remove `with_request_duration_bounds` builder method.
+  Alternate histogram bucket boundaries can be applied with the standard OpenTelemetry Views; see `examples` directory in crate for usage.
 
 ### Migration Guide
 
@@ -49,23 +51,6 @@ let layer = HTTPLayer::new();
 - Replace `HTTPMetricsLayer` with `HTTPLayer`
 - Replace `HTTPMetricsService` with `HTTPService`
 - Replace `HTTPMetricsResponseFuture` with `HTTPResponseFuture`
-
-#### Default Bucket Boundary Changes
-
-Before:
-
-```rust
-let otel_service_layer = HTTPLayer::new();
-```
-
-After:
-
-```rust
-let otel_service_layer = HTTPLayerBuilder::builder()
-.with_request_duration_bounds(Vec::from(ALTERNATE_HTTP_SERVER_DURATION_BOUNDS)) // exported constant for previous defaults
-.build()
-.unwrap();
-```
 
 ## v0.17.0
 

--- a/opentelemetry-instrumentation-tower/CHANGELOG.md
+++ b/opentelemetry-instrumentation-tower/CHANGELOG.md
@@ -4,29 +4,34 @@
 
 ### Changed
 
-* **BREAKING**: Removed public `with_meter()` method. The middleware now uses global meter and tracer providers by default via `opentelemetry::global::meter()` and `opentelemetry::global::tracer()`. The `with_meter()` method is retained as a non-public test utility to allow injecting custom meters without relying on global state.
+* **BREAKING**: Removed public `with_meter()` method. The middleware now uses global meter and tracer providers by
+  default via `opentelemetry::global::meter()` and `opentelemetry::global::tracer()`. The `with_meter()` method is
+  retained as a non-public test utility to allow injecting custom meters without relying on global state.
 * **BREAKING**: Renamed types. Use the new names:
-  - `HTTPMetricsLayer` → `HTTPLayer`
-  - `HTTPMetricsService` → `HTTPService`
-  - `HTTPMetricsResponseFuture` → `HTTPResponseFuture`
-  - `HTTPMetricsLayerBuilder` → `HTTPLayerBuilder`
+    - `HTTPMetricsLayer` → `HTTPLayer`
+    - `HTTPMetricsService` → `HTTPService`
+    - `HTTPMetricsResponseFuture` → `HTTPResponseFuture`
+    - `HTTPMetricsLayerBuilder` → `HTTPLayerBuilder`
 * Added OpenTelemetry trace support
+* **BREAKING**: Update default  `http.server.request.duration` histogram boundaries to OTel semantic conventions.
 
 ### Migration Guide
 
 #### API Changes
 
 Before:
+
 ```rust
 use opentelemetry_instrumentation_tower::HTTPMetricsLayerBuilder;
 
 let layer = HTTPMetricsLayerBuilder::builder()
-    .with_meter(meter)
-    .build()
-    .unwrap();
+.with_meter(meter)
+.build()
+.unwrap();
 ```
 
 After:
+
 ```rust
 use opentelemetry_instrumentation_tower::HTTPLayer;
 
@@ -45,22 +50,41 @@ let layer = HTTPLayer::new();
 - Replace `HTTPMetricsService` with `HTTPService`
 - Replace `HTTPMetricsResponseFuture` with `HTTPResponseFuture`
 
+#### Default Bucket Boundary Changes
+
+Before:
+
+```rust
+let otel_service_layer = HTTPLayer::new();
+```
+
+After:
+
+```rust
+let otel_service_layer = HTTPLayerBuilder::builder()
+.with_request_duration_bounds(Vec::from(ALTERNATE_HTTP_SERVER_DURATION_BOUNDS)) // exported constant for previous defaults
+.build()
+.unwrap();
+```
+
 ## v0.17.0
 
 ### Changed
 
 * Update to OpenTelemetry v0.31
-* Migrate to use `opentelemetry-semantic-conventions` package for metric names and attribute keys instead of hardcoded strings
-* Add dependency on otel semantic conventions crate and use constants from it instead of hardcoded attribute names. The values are unchanged
-  - `HTTP_SERVER_ACTIVE_REQUESTS_METRIC` now uses `semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS`
-  - `HTTP_SERVER_REQUEST_BODY_SIZE_METRIC` now uses `semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE`
-  - `HTTP_SERVER_RESPONSE_BODY_SIZE_METRIC` now uses `semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE`
-  - `HTTP_SERVER_DURATION_METRIC` now uses `semconv::metric::HTTP_SERVER_REQUEST_DURATION`
+* Migrate to use `opentelemetry-semantic-conventions` package for metric names and attribute keys instead of hardcoded
+  strings
+* Add dependency on otel semantic conventions crate and use constants from it instead of hardcoded attribute names. The
+  values are unchanged
+    - `HTTP_SERVER_ACTIVE_REQUESTS_METRIC` now uses `semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS`
+    - `HTTP_SERVER_REQUEST_BODY_SIZE_METRIC` now uses `semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE`
+    - `HTTP_SERVER_RESPONSE_BODY_SIZE_METRIC` now uses `semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE`
+    - `HTTP_SERVER_DURATION_METRIC` now uses `semconv::metric::HTTP_SERVER_REQUEST_DURATION`
 * Update attribute keys to use semantic conventions constants:
-  - `NETWORK_PROTOCOL_NAME_LABEL` now uses `semconv::attribute::NETWORK_PROTOCOL_NAME`
-  - `HTTP_REQUEST_METHOD_LABEL` now uses `semconv::attribute::HTTP_REQUEST_METHOD`
-  - `HTTP_ROUTE_LABEL` now uses `semconv::attribute::HTTP_ROUTE`
-  - `HTTP_RESPONSE_STATUS_CODE_LABEL` now uses `semconv::attribute::HTTP_RESPONSE_STATUS_CODE`
+    - `NETWORK_PROTOCOL_NAME_LABEL` now uses `semconv::attribute::NETWORK_PROTOCOL_NAME`
+    - `HTTP_REQUEST_METHOD_LABEL` now uses `semconv::attribute::HTTP_REQUEST_METHOD`
+    - `HTTP_ROUTE_LABEL` now uses `semconv::attribute::HTTP_ROUTE`
+    - `HTTP_RESPONSE_STATUS_CODE_LABEL` now uses `semconv::attribute::HTTP_RESPONSE_STATUS_CODE`
 
 ### Added
 
@@ -75,10 +99,10 @@ Initial release of OpenTelemetry Tower instrumentation middleware for HTTP metri
 * HTTP server metrics middleware for Tower-compatible services
 * Support for Axum framework via `axum` feature flag
 * Metrics collection for:
-  - `http.server.request.duration` - Request duration histogram
-  - `http.server.active_requests` - Active requests counter
-  - `http.server.request.body.size` - Request body size histogram
-  - `http.server.response.body.size` - Response body size histogram
+    - `http.server.request.duration` - Request duration histogram
+    - `http.server.active_requests` - Active requests counter
+    - `http.server.request.body.size` - Request body size histogram
+    - `http.server.response.body.size` - Response body size histogram
 * Configurable request duration histogram boundaries
 * Custom request and response attribute extractors
 * Automatic protocol version, HTTP method, URL scheme, and status code labeling

--- a/opentelemetry-instrumentation-tower/README.md
+++ b/opentelemetry-instrumentation-tower/README.md
@@ -4,10 +4,10 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-| Status        |           |
-| ------------- |-----------|
-| Stability     | alpha     |
-| Owners        | [Franco Posa](https://github.com/francoposa) |
+| Status    |                                              |
+|-----------|----------------------------------------------|
+| Stability | alpha                                        |
+| Owners    | [Franco Posa](https://github.com/francoposa) |
 
 OpenTelemetry HTTP Metrics and Tracing Middleware for Tower-compatible Rust HTTP servers.
 
@@ -21,14 +21,12 @@ This middleware provides both metrics and distributed tracing for HTTP requests,
 - **Flexible Configuration**: Support for custom attribute extractors and tracer configuration
 - **Framework Support**: Works with any Tower-compatible HTTP framework (Axum, Hyper, Tonic etc.)
 
-## Usage
-
 ## Metrics
 
 The middleware exports the following metrics:
 
 - `http.server.request.duration` - Duration of HTTP requests
-- `http.server.active_requests` - Number of active HTTP requests  
+- `http.server.active_requests` - Number of active HTTP requests
 - `http.server.request.body.size` - Size of HTTP request bodies
 - `http.server.response.body.size` - Size of HTTP response bodies
 
@@ -42,6 +40,41 @@ HTTP spans are created with the following attributes (following OpenTelemetry se
 - `url.full` - Full URL
 - `user_agent.original` - User agent string
 - `http.response.status_code` - HTTP response status code
+
+## Recommended Usage
+
+### Histogram Bucket Boundaries
+
+This library defaults to the OpenTelemetry semantic conventions for `http.server.request.duration` bucket boundaries:
+`[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]` with seconds as the unit.
+
+These boundaries do not capture durations over 10 seconds, which may be limiting for an http server.
+
+To capture longer requests with some rough granularity on the upper end, the library also exports an alternate constant:
+
+```rust
+pub const ALTERNATE_HTTP_SERVER_DURATION_BOUNDS: [f64; 14] = [
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
+```
+
+The alternate constant or any other custom boundaries may be applied via the builder interface:
+
+```rust
+use opentelemetry_instrumentation_tower::{
+    HTTPLayerBuilder, ALTERNATE_HTTP_SERVER_DURATION_BOUNDS,
+};
+
+// ...
+
+fn main() {
+    let otel_service_layer = HTTPLayerBuilder::builder()
+        .with_request_duration_bounds(Vec::from(ALTERNATE_HTTP_SERVER_DURATION_BOUNDS))
+        .build()
+        .unwrap();
+    // ...
+}
+```
 
 ## Examples
 

--- a/opentelemetry-instrumentation-tower/README.md
+++ b/opentelemetry-instrumentation-tower/README.md
@@ -41,41 +41,6 @@ HTTP spans are created with the following attributes (following OpenTelemetry se
 - `user_agent.original` - User agent string
 - `http.response.status_code` - HTTP response status code
 
-## Recommended Usage
-
-### Histogram Bucket Boundaries
-
-This library defaults to the OpenTelemetry semantic conventions for `http.server.request.duration` bucket boundaries:
-`[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]` with seconds as the unit.
-
-These boundaries do not capture durations over 10 seconds, which may be limiting for an http server.
-
-To capture longer requests with some rough granularity on the upper end, the library also exports an alternate constant:
-
-```rust
-pub const ALTERNATE_HTTP_SERVER_DURATION_BOUNDS: [f64; 14] = [
-    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
-];
-```
-
-The alternate constant or any other custom boundaries may be applied via the builder interface:
-
-```rust
-use opentelemetry_instrumentation_tower::{
-    HTTPLayerBuilder, ALTERNATE_HTTP_SERVER_DURATION_BOUNDS,
-};
-
-// ...
-
-fn main() {
-    let otel_service_layer = HTTPLayerBuilder::builder()
-        .with_request_duration_bounds(Vec::from(ALTERNATE_HTTP_SERVER_DURATION_BOUNDS))
-        .build()
-        .unwrap();
-    // ...
-}
-```
-
 ## Examples
 
 See `examples` directory in repo for runnable code and supporting config files.

--- a/opentelemetry-instrumentation-tower/examples/axum-http-service/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/axum-http-service/Cargo.toml
@@ -10,11 +10,11 @@ rust-version = "1.75.0"
 opentelemetry_instrumentation_tower = { path = "../../", package = "opentelemetry-instrumentation-tower", features = ["axum"], default-features = false }
 axum = { features = ["http1", "tokio"], version = "0.8", default-features = false }
 bytes = { version = "1", default-features = false }
-opentelemetry = { workspace = true}
+opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, default-features = false }
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }
-rand_09 = { package = "rand", version = "0.9" }
+rand = { version = "0.9" }
 
 [lints]
 workspace = true

--- a/opentelemetry-instrumentation-tower/examples/axum-http-service/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/axum-http-service/Cargo.toml
@@ -11,7 +11,8 @@ opentelemetry_instrumentation_tower = { path = "../../", package = "opentelemetr
 axum = { features = ["http1", "tokio"], version = "0.8", default-features = false }
 bytes = { version = "1", default-features = false }
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true, default-features = false }
+opentelemetry_sdk = { workspace = true, features = ["spec_unstable_metrics_views"], default-features = false }
+opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"], default-features = false }
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }
 rand = { version = "0.9" }

--- a/opentelemetry-instrumentation-tower/examples/axum-http-service/src/main.rs
+++ b/opentelemetry-instrumentation-tower/examples/axum-http-service/src/main.rs
@@ -1,14 +1,15 @@
 use axum::routing::{get, post, put, Router};
 use bytes::Bytes;
 use opentelemetry::global;
-use opentelemetry_instrumentation_tower::{
-    HTTPLayerBuilder, ALTERNATE_HTTP_SERVER_DURATION_BOUNDS,
-};
+use opentelemetry_instrumentation_tower::HTTPLayerBuilder;
 use opentelemetry_otlp::{MetricExporter, SpanExporter};
+use opentelemetry_sdk::metrics::Aggregation::ExplicitBucketHistogram;
+use opentelemetry_sdk::metrics::{Instrument, Stream};
 use opentelemetry_sdk::{
     metrics::{PeriodicReader, SdkMeterProvider},
     trace::SdkTracerProvider,
 };
+use opentelemetry_semantic_conventions as semconv;
 use std::time::Duration;
 
 const SERVICE_NAME: &str = "example-axum-http-service";
@@ -45,6 +46,11 @@ async fn handle() -> Bytes {
     Bytes::from("hello world\n".repeat(body_size_multiple as usize))
 }
 
+// Example of alternate bucket bounds to capture granularity in higher latencies
+const HISTOGRAM_BUCKET_BOUNDS: [f64; 14] = [
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
+
 #[tokio::main]
 async fn main() {
     {
@@ -58,9 +64,25 @@ async fn main() {
             .with_interval(_OTEL_METRIC_EXPORT_INTERVAL)
             .build();
 
+        // Example of OTel View to apply alternate histogram bucket boundaries
+        let http_server_request_duration_view = |i: &Instrument| {
+            if i.name() == semconv::metric::HTTP_SERVER_REQUEST_DURATION {
+                Stream::builder()
+                    .with_aggregation(ExplicitBucketHistogram {
+                        boundaries: Vec::from(HISTOGRAM_BUCKET_BOUNDS),
+                        record_min_max: true,
+                    })
+                    .build()
+                    .ok()
+            } else {
+                None
+            }
+        };
+
         let provider = SdkMeterProvider::builder()
             .with_reader(reader)
             .with_resource(init_otel_resource())
+            .with_view(http_server_request_duration_view)
             .build();
 
         global::set_meter_provider(provider);
@@ -81,10 +103,7 @@ async fn main() {
         global::set_tracer_provider(provider);
     }
 
-    let otel_service_layer = HTTPLayerBuilder::builder()
-        .with_request_duration_bounds(Vec::from(ALTERNATE_HTTP_SERVER_DURATION_BOUNDS))
-        .build()
-        .unwrap();
+    let otel_service_layer = HTTPLayerBuilder::builder().build().unwrap();
 
     let app = Router::new()
         .route("/", get(handle))

--- a/opentelemetry-instrumentation-tower/examples/hyper-http-service/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/hyper-http-service/Cargo.toml
@@ -12,7 +12,8 @@ hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true, default-features = false }
+opentelemetry_sdk = { workspace = true, features = ["spec_unstable_metrics_views"], default-features = false }
+opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"], default-features = false }
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }

--- a/opentelemetry-instrumentation-tower/examples/hyper-http-service/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/hyper-http-service/Cargo.toml
@@ -11,12 +11,12 @@ opentelemetry_instrumentation_tower = { path = "../../", package = "opentelemetr
 hyper = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio"], default-features = false }
-opentelemetry = { workspace = true}
+opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, default-features = false }
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
-rand_09 = { package = "rand", version = "0.9" }
+rand = { version = "0.9" }
 
 [lints]
 workspace = true

--- a/opentelemetry-instrumentation-tower/examples/hyper-http-service/src/main.rs
+++ b/opentelemetry-instrumentation-tower/examples/hyper-http-service/src/main.rs
@@ -2,12 +2,15 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::{Request, Response};
 use opentelemetry::global;
-use opentelemetry_instrumentation_tower::{
-    HTTPLayerBuilder, ALTERNATE_HTTP_SERVER_DURATION_BOUNDS,
-};
+use opentelemetry_instrumentation_tower::HTTPLayerBuilder;
 use opentelemetry_otlp::{MetricExporter, SpanExporter};
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
-use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::metrics::Aggregation::ExplicitBucketHistogram;
+use opentelemetry_sdk::metrics::{Instrument, Stream};
+use opentelemetry_sdk::{
+    metrics::{PeriodicReader, SdkMeterProvider},
+    trace::SdkTracerProvider,
+};
+use opentelemetry_semantic_conventions as semconv;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -48,6 +51,11 @@ async fn handle(_req: Request<hyper::body::Incoming>) -> Result<Response<Full<By
     Ok(Response::new(Full::new(body)))
 }
 
+// Example of alternate bucket bounds to capture granularity in higher latencies
+const HISTOGRAM_BUCKET_BOUNDS: [f64; 14] = [
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
+
 #[tokio::main]
 async fn main() {
     {
@@ -61,9 +69,25 @@ async fn main() {
             .with_interval(_OTEL_METRIC_EXPORT_INTERVAL)
             .build();
 
+        // Example of OTel View to apply alternate histogram bucket boundaries
+        let http_server_request_duration_view = |i: &Instrument| {
+            if i.name() == semconv::metric::HTTP_SERVER_REQUEST_DURATION {
+                Stream::builder()
+                    .with_aggregation(ExplicitBucketHistogram {
+                        boundaries: Vec::from(HISTOGRAM_BUCKET_BOUNDS),
+                        record_min_max: true,
+                    })
+                    .build()
+                    .ok()
+            } else {
+                None
+            }
+        };
+
         let provider = SdkMeterProvider::builder()
             .with_reader(reader)
             .with_resource(init_otel_resource())
+            .with_view(http_server_request_duration_view)
             .build();
 
         global::set_meter_provider(provider);
@@ -84,10 +108,7 @@ async fn main() {
         global::set_tracer_provider(provider);
     }
 
-    let otel_service_layer = HTTPLayerBuilder::builder()
-        .with_request_duration_bounds(Vec::from(ALTERNATE_HTTP_SERVER_DURATION_BOUNDS))
-        .build()
-        .unwrap();
+    let otel_service_layer = HTTPLayerBuilder::builder().build().unwrap();
 
     let tower_service = ServiceBuilder::new()
         .layer(otel_service_layer)

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -27,11 +27,6 @@ const OTEL_DEFAULT_HTTP_SERVER_DURATION_BOUNDS: [f64; 14] = [
     0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
 ];
 
-// OTEL default does not capture duration over 10s which may be limiting for an http server;
-// this alternate set captures longer requests with some rough granularity on the upper end.
-pub const ALTERNATE_HTTP_SERVER_DURATION_BOUNDS: [f64; 14] = [
-    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
-];
 const HTTP_SERVER_ACTIVE_REQUESTS_METRIC: &str = semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS;
 const HTTP_SERVER_ACTIVE_REQUESTS_UNIT: &str = "{request}";
 

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -301,11 +301,6 @@ impl<ReqExt, ResExt> HTTPLayerBuilder<ReqExt, ResExt> {
         self
     }
 
-    pub fn with_request_duration_bounds(mut self, bounds: Vec<f64>) -> Self {
-        self.req_dur_bounds = Some(bounds);
-        self
-    }
-
     fn make_state(meter: Meter, req_dur_bounds: Vec<f64>) -> HTTPLayerState {
         HTTPLayerState {
             server_request_duration: meter

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -23,15 +23,13 @@ use tower_service::Service;
 const HTTP_SERVER_DURATION_METRIC: &str = semconv::metric::HTTP_SERVER_REQUEST_DURATION;
 const HTTP_SERVER_DURATION_UNIT: &str = "s";
 
-const _OTEL_DEFAULT_HTTP_SERVER_DURATION_BOUNDARIES: [f64; 14] = [
+const OTEL_DEFAULT_HTTP_SERVER_DURATION_BOUNDS: [f64; 14] = [
     0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
 ];
 
-// OTEL default does not capture duration over 10s - a poor choice for an arbitrary http server;
-// we want to capture longer requests with some rough granularity on the upper end.
-// These choices are adapted from various recommendations in
-// https://github.com/open-telemetry/semantic-conventions/issues/336.
-const LIBRARY_DEFAULT_HTTP_SERVER_DURATION_BOUNDARIES: [f64; 14] = [
+// OTEL default does not capture duration over 10s which may be limiting for an http server;
+// this alternate set captures longer requests with some rough granularity on the upper end.
+pub const ALTERNATE_HTTP_SERVER_DURATION_BOUNDS: [f64; 14] = [
     0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
 ];
 const HTTP_SERVER_ACTIVE_REQUESTS_METRIC: &str = semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS;
@@ -207,7 +205,7 @@ impl HTTPLayerBuilder {
     pub fn builder() -> Self {
         HTTPLayerBuilder {
             meter: None,
-            req_dur_bounds: Some(LIBRARY_DEFAULT_HTTP_SERVER_DURATION_BOUNDARIES.to_vec()),
+            req_dur_bounds: Some(Vec::from(OTEL_DEFAULT_HTTP_SERVER_DURATION_BOUNDS)),
             request_extractor: NoOpExtractor,
             response_extractor: NoOpExtractor,
         }
@@ -272,7 +270,7 @@ impl<ReqExt, ResExt> HTTPLayerBuilder<ReqExt, ResExt> {
     pub fn build(self) -> Result<HTTPLayer<ReqExt, ResExt>> {
         let req_dur_bounds = self
             .req_dur_bounds
-            .unwrap_or_else(|| LIBRARY_DEFAULT_HTTP_SERVER_DURATION_BOUNDARIES.to_vec());
+            .unwrap_or_else(|| Vec::from(OTEL_DEFAULT_HTTP_SERVER_DURATION_BOUNDS));
 
         let tracer = Arc::new(global::tracer("opentelemetry-instrumentation-tower"));
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/526
Design discussion issue (if applicable) #

## Changes

PR title, plus:
* README & CHANGELOG documentation for the change
* Updated example server code to demonstrate the usage of `with_request_duration_bounds`
* Removal of `rand_09` dependency alias in example s now that tokio is updated to use `rand` crate version `0.9`
* Some nice autoformatting applied to the markdown files for this crate

Link to the semantic convention here: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
> This metric SHOULD be specified with [ExplicitBucketBoundaries](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-advisory-parameters) of [ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ].

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
