### PR TITLE
perf(geneva-uploader): Optimize encoding hot path: attribute lookup, event name reuse, and UTF-16 caching

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
@@ -207,7 +207,10 @@ impl CentralBlob {
         // EVENTS (type 2)
         for event in &self.events {
             debug_assert!(
-                self.events.first().map_or(true, |first| Arc::ptr_eq(&first.event_name, &event.event_name)),
+                self.events.first().map_or(true, |first| Arc::ptr_eq(
+                    &first.event_name,
+                    &event.event_name
+                )),
                 "CentralBlob invariant violated: all events must share the same event name"
             );
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
@@ -160,9 +160,13 @@ impl CentralBlob {
         //   + 8 (terminator, u64)
         let meta_utf16 = utf8_to_utf16le_bytes(&self.metadata);
 
-        // Cache UTF-16 event name conversion. Events within a blob typically share the same
-        // event name (Arc), so we convert once and reuse by checking Arc pointer identity.
-        let mut evname_cache: Option<(usize, Vec<u8>)> = None; // (Arc ptr, utf16 bytes)
+        // A CentralBlob is homogeneous by event name: logs are grouped by event_name in
+        // encode_log_batch, and spans all use "Span". Precompute UTF-16LE once.
+        let evname_utf16 = self
+            .events
+            .first()
+            .map(|e| utf8_to_utf16le_bytes(&e.event_name))
+            .unwrap_or_default();
 
         let mut estimated_size = 8 + 4 + meta_utf16.len();
         estimated_size += self
@@ -175,18 +179,7 @@ impl CentralBlob {
             .iter()
             .map(|e| {
                 let row_len = 4 + e.row.len(); // SP header (4), row_bytes
-                // Use cached UTF-16 length if same Arc, otherwise compute and cache
-                let ptr = Arc::as_ptr(&e.event_name) as usize;
-                let evname_len = match &evname_cache {
-                    Some((cached_ptr, cached_bytes)) if *cached_ptr == ptr => cached_bytes.len(),
-                    _ => {
-                        let utf16 = utf8_to_utf16le_bytes(&e.event_name);
-                        let len = utf16.len();
-                        evname_cache = Some((ptr, utf16));
-                        len
-                    }
-                };
-                2 + 8 + 1 + 2 + 4 + evname_len + row_len + 8
+                2 + 8 + 1 + 2 + 4 + evname_utf16.len() + row_len + 8
             })
             .sum::<usize>();
 
@@ -213,16 +206,10 @@ impl CentralBlob {
 
         // EVENTS (type 2)
         for event in &self.events {
-            // Reuse cached UTF-16 event name if same Arc pointer, otherwise convert and cache
-            let ptr = Arc::as_ptr(&event.event_name) as usize;
-            let needs_update = match &evname_cache {
-                Some((cached_ptr, _)) => *cached_ptr != ptr,
-                None => true,
-            };
-            if needs_update {
-                evname_cache = Some((ptr, utf8_to_utf16le_bytes(&event.event_name)));
-            }
-            let evname_utf16 = &evname_cache.as_ref().unwrap().1;
+            debug_assert!(
+                self.events.first().map_or(true, |first| Arc::ptr_eq(&first.event_name, &event.event_name)),
+                "CentralBlob invariant violated: all events must share the same event name"
+            );
 
             buf.extend_from_slice(&2u16.to_le_bytes()); // entity type 2
             buf.extend_from_slice(&event.schema_id.to_le_bytes());
@@ -230,7 +217,7 @@ impl CentralBlob {
 
             // event name (UTF-16LE, prefixed with u16 len in bytes)
             buf.extend_from_slice(&(evname_utf16.len() as u16).to_le_bytes()); // TODO - check for overflow
-            buf.extend_from_slice(evname_utf16);
+            buf.extend_from_slice(&evname_utf16);
 
             let total_len = 4 + event.row.len(); // SP header + data
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
@@ -207,7 +207,7 @@ impl CentralBlob {
         // EVENTS (type 2)
         for event in &self.events {
             debug_assert!(
-                self.events.first().map_or(true, |first| Arc::ptr_eq(
+                self.events.first().is_none_or(|first| Arc::ptr_eq(
                     &first.event_name,
                     &event.event_name
                 )),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
@@ -207,10 +207,9 @@ impl CentralBlob {
         // EVENTS (type 2)
         for event in &self.events {
             debug_assert!(
-                self.events.first().is_none_or(|first| Arc::ptr_eq(
-                    &first.event_name,
-                    &event.event_name
-                )),
+                self.events
+                    .first()
+                    .is_none_or(|first| Arc::ptr_eq(&first.event_name, &event.event_name)),
                 "CentralBlob invariant violated: all events must share the same event name"
             );
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -112,7 +112,7 @@ impl OtlpEncoder {
             schemas: Vec<CentralSchemaEntry>,
             events: Vec<CentralEventEntry>,
             metadata: BatchMetadata,
-            event_name_arc: Arc<String>,
+            event_name: Arc<String>,
         }
 
         impl BatchData {
@@ -171,7 +171,7 @@ impl OtlpEncoder {
                     end_time: timestamp,
                     schema_ids: String::new(),
                 },
-                event_name_arc: Arc::new(event_name_str.to_string()),
+                event_name: Arc::new(event_name_str.to_string()),
             });
 
             // Update timestamp range
@@ -210,7 +210,7 @@ impl OtlpEncoder {
             let central_event = CentralEventEntry {
                 schema_id,
                 level,
-                event_name: Arc::clone(&entry.event_name_arc),
+                event_name: Arc::clone(&entry.event_name),
                 row: row_buffer,
             };
             entry.events.push(central_event);
@@ -279,7 +279,7 @@ impl OtlpEncoder {
     {
         // All spans use "Span" as event name for routing - no grouping by span name
         const EVENT_NAME: &str = "Span";
-        let event_name_arc = Arc::new(EVENT_NAME.to_string());
+        let event_name = Arc::new(EVENT_NAME.to_string());
 
         let mut schemas = Vec::new();
         let mut events = Vec::new();
@@ -328,7 +328,7 @@ impl OtlpEncoder {
             let central_event = CentralEventEntry {
                 schema_id,
                 level,
-                event_name: Arc::clone(&event_name_arc),
+                event_name: Arc::clone(&event_name),
                 row: row_buffer,
             };
             events.push(central_event);


### PR DESCRIPTION
**Description:**

This PR reduces per-record overhead in `encode_log_batch` and `encode_span_batch` by addressing three bottlenecks:

**1. Fixed O(F×A) attribute lookup**

The old code called `attributes.iter().find(|a| a.key == field.name)` for every dynamic attribute field, which meant we were doing O(fields × attributes) string comparisons per record. 

I replaced this with a sequential filter iterator that advances alongside the schema fields from `determine_fields()`. Since both functions iterate the same `log.attributes` or `span.attributes` slice in the same order with the same type filter, we can rely on positional correspondence within a single encode call. No heap allocations needed—no intermediate `Vec` or `HashMap`.

**2. Arc<String> event name reuse**

Instead of calling `Arc::new(event_name.to_string())` for every record, we now create one `Arc::new()` per batch (logs) or per call (spans), then just `Arc::clone()` for each record.

**3. Precompute UTF-16 event name once**

A `CentralBlob` always has the same event name (logs are grouped by event name in `encode_log_batch`, spans always use "Span"). We now compute the UTF-16LE bytes once from the first event and reuse them for all events, instead of calling `utf8_to_utf16le_bytes()` every time. Added a `debug_assert!` with `Arc::ptr_eq` to guard the homogeneity invariant.

**Benchmarks:**

Benchmarks (from `opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs`):

   | Benchmark                          | Test                                           |   main   | this PR  | Improvement |
   |------------------------------------|-------------------------------------------------|----------|----------|-------------|
   | encode_log_batch_attributes        | attributes/0 (10 logs)                          | 10.80 µs | 10.18 µs |       +5.7% |
   | encode_log_batch_attributes        | attributes/4 (10 logs)                          | 14.08 µs | 13.01 µs |       +7.6% |
   | encode_log_batch_attributes        | attributes/8 (10 logs)                          | 17.59 µs | 15.75 µs |      +10.5% |
   | encode_log_batch_attributes        | attributes/16 (10 logs)                         | 25.37 µs | 20.92 µs |      +17.5% |
   | encode_log_batch_sizes             | batch_size/1 (4 attrs)                          |  7.28 µs |  7.25 µs |        ~0%  |
   | encode_log_batch_sizes             | batch_size/10 (4 attrs)                         | 13.93 µs | 12.86 µs |       +7.7% |
   | encode_log_batch_sizes             | batch_size/100 (4 attrs)                        | 77.69 µs | 65.65 µs |      +15.5% |
   | encode_log_batch_sizes             | batch_size/1000 (4 attrs)                       |  735 µs  |  622 µs  |      +15.4% |
   | encode_log_batch_mixed_event_names | mixed_event_names (100 logs, 3 names, 4 attrs)  | 90.42 µs | 79.63 µs |      +11.9% |


The `batch/1` case is flat because with only 1 record × 4 attributes, we're only eliminating 4 `find()` calls. Gains scale nicely with both record count and attribute count.

No API changes. All existing tests pass.

  Also extracted a shared `is_supported_attr filter` and `push_dynamic_attr_fields` helper to deduplicate the attribute type-checking logic across log and span paths.
