### PR TITLE
Update time crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ opentelemetry-semantic-conventions = { version = "0.31", features = [
     "semconv_experimental",
 ] }
 criterion = "0.7"
+# https://rustsec.org/advisories/RUSTSEC-2026-0009
+time = ">=0.3.47"
 
 [workspace.lints.rust]
 rust_2024_compatibility = { level = "warn", priority = -1 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -29,6 +29,8 @@ lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = fa
 azure_identity = "0.29"
 azure_core = "0.29"
 tracing = "0.1"
+# https://rustsec.org/advisories/RUSTSEC-2026-0009
+time = { workspace = true }
 
 [features]
 self_signed_certs = [] # Empty by default for security

--- a/opentelemetry-instrumentation-actix-web/Cargo.toml
+++ b/opentelemetry-instrumentation-actix-web/Cargo.toml
@@ -34,6 +34,8 @@ opentelemetry-semantic-conventions = { workspace = true, features = [
   "semconv_experimental",
 ] }
 serde = "1.0"
+# https://rustsec.org/advisories/RUSTSEC-2026-0009
+time = { workspace = true }
 
 [dev-dependencies]
 actix-rt = "2"


### PR DESCRIPTION
## Changes
- `cargo deny` CI check is failing
- Update the `time` crate version to fix it

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
