### PR TITLE
chore: Add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ permissions:
   
 on:
   pull_request:
+  merge_group:
   push:
     branches:
     - main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,7 @@ permissions:
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/pr_naming.yml
+++ b/.github/workflows/pr_naming.yml
@@ -6,9 +6,11 @@ permissions:
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  merge_group:
 
 jobs:
   validate-pr-title:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
Add `merge_group` trigger to CI workflows to support GitHub Merge Queue.

Changes:
- **ci.yml**: Add `merge_group` trigger
- **codeql-analysis.yml**: Add `merge_group` trigger
- **pr_naming.yml**: Add `merge_group` trigger with `if: github.event_name == 'pull_request'` condition so it passes as skipped on merge queue events