### PR TITLE
feat(geneva-uploader): Add On Behalf Of (OBO) support

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/include/geneva_ffi.h
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/include/geneva_ffi.h
@@ -60,6 +60,19 @@ typedef union {
     GenevaUserManagedIdentityByResourceIdAuthConfig user_msi_resid;         /* Valid when auth_method == GENEVA_AUTH_USER_MANAGED_IDENTITY_BY_RESOURCE_ID */
 } GenevaAuthConfig;
 
+/* OBO (On-Behalf-Of) event configuration for a single event name. */
+typedef struct {
+    const char* event_name;   /* Event name (null-terminated UTF-8) */
+    const char* identity;     /* OBO identity (null-terminated UTF-8) */
+    const char* annotations;  /* OBO annotations (null-terminated UTF-8, can be NULL) */
+} GenevaOboEventConfig;
+
+/* Array of OBO event configurations. Pass NULL to GenevaConfig.obo_map to disable OBO. */
+typedef struct {
+    const GenevaOboEventConfig* entries; /* Pointer to array of GenevaOboEventConfig */
+    size_t count;                        /* Number of entries */
+} GenevaOboEventMap;
+
 /* Configuration structure for Geneva client (C-compatible, tagged union)
  *
  * IMPORTANT - Resource/Scope Configuration:
@@ -92,6 +105,7 @@ typedef struct {
     const char* role_instance;
     GenevaAuthConfig auth; /* Active member selected by auth_method */
     const char* msi_resource; /* Azure AD resource URI for MSI auth (auth methods 0, 3, 4, 5). Not used for auth methods 1, 2. Nullable. */
+    const GenevaOboEventMap* obo_map; /* Optional OBO event map (can be NULL for no OBO). */
 } GenevaConfig;
 
 /* Create a new Geneva client.

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -185,6 +185,27 @@ pub struct GenevaConfig {
     pub role_instance: *const c_char,
     pub auth: GenevaAuthConfig, // Active member selected by auth_method
     pub msi_resource: *const c_char, // Azure AD resource URI for MSI auth (auth methods 0, 3, 4, 5). Not used for auth methods 1, 2. Nullable.
+    pub obo_map: *const FfiOboEventMap, // Optional OBO event map. Nullable.
+}
+
+/// FFI-safe OBO event configuration
+#[repr(C)]
+pub struct FfiOboEventConfig {
+    /// Event name (null-terminated UTF-8 string)
+    pub event_name: *const c_char,
+    /// OBO identity (null-terminated UTF-8 string)
+    pub identity: *const c_char,
+    /// OBO annotations (null-terminated UTF-8 string, can be null)
+    pub annotations: *const c_char,
+}
+
+/// FFI-safe OBO event map (array of configs)
+#[repr(C)]
+pub struct FfiOboEventMap {
+    /// Pointer to array of FfiOboEventConfig
+    pub entries: *const FfiOboEventConfig,
+    /// Number of entries
+    pub count: usize,
 }
 
 /// Error codes returned by FFI functions
@@ -263,6 +284,65 @@ unsafe fn write_error_if_provided(
         unsafe {
             *err_msg_out.add(bytes_to_copy) = 0;
         }
+    }
+}
+
+/// Converts an FFI OBO event map to the Rust-side `OboEventMap`.
+///
+/// Returns `None` when the pointer is null, the entries pointer is null,
+/// or the count is zero. Individual entries with null event_name or identity
+/// are silently skipped.
+///
+/// # Safety
+/// - `ffi_map` must be null or point to a valid `FfiOboEventMap`
+/// - All non-null string pointers inside entries must be valid null-terminated UTF-8
+unsafe fn convert_obo_event_map(
+    ffi_map: *const FfiOboEventMap,
+) -> Option<geneva_uploader::client::OboEventMap> {
+    if ffi_map.is_null() {
+        return None;
+    }
+    let map_ref = unsafe { &*ffi_map };
+    if map_ref.entries.is_null() || map_ref.count == 0 {
+        return None;
+    }
+
+    let mut obo_map = std::collections::HashMap::new();
+    let entries = unsafe { std::slice::from_raw_parts(map_ref.entries, map_ref.count) };
+
+    for entry in entries {
+        if entry.event_name.is_null() || entry.identity.is_null() {
+            continue;
+        }
+        let event_name = unsafe { CStr::from_ptr(entry.event_name) }
+            .to_string_lossy()
+            .into_owned();
+        let identity = unsafe { CStr::from_ptr(entry.identity) }
+            .to_string_lossy()
+            .into_owned();
+        let annotations = if entry.annotations.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(entry.annotations) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        };
+
+        obo_map.insert(
+            event_name,
+            geneva_uploader::client::OboEventConfig {
+                identity,
+                annotations,
+            },
+        );
+    }
+
+    if obo_map.is_empty() {
+        None
+    } else {
+        Some(obo_map)
     }
 }
 
@@ -511,6 +591,7 @@ pub unsafe extern "C" fn geneva_client_new(
         role_name,
         role_instance,
         msi_resource,
+        obo_event_map: unsafe { convert_obo_event_map(config.obo_map) },
     };
 
     // Create client
@@ -1553,6 +1634,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
         Box::new(GenevaClientHandle {
@@ -1715,6 +1797,7 @@ mod tests {
                 // The union is never accessed for SystemManagedIdentity (auth_method 0).
                 auth: std::mem::zeroed(),
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1749,6 +1832,7 @@ mod tests {
                 role_instance: role_instance.as_ptr(),
                 auth: std::mem::zeroed(), // Union not accessed for invalid auth method
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1788,6 +1872,7 @@ mod tests {
                     },
                 },
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1826,6 +1911,7 @@ mod tests {
                     },
                 },
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1864,6 +1950,7 @@ mod tests {
                     },
                 },
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1902,6 +1989,7 @@ mod tests {
                     },
                 },
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1943,6 +2031,7 @@ mod tests {
                     },
                 },
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -1986,6 +2075,7 @@ mod tests {
                     },
                 },
                 msi_resource: ptr::null(),
+                obo_map: ptr::null(),
             };
 
             let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
@@ -2070,6 +2160,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
 
@@ -2192,6 +2283,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
 
@@ -2359,6 +2451,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
         let mut handle_box = Box::new(GenevaClientHandle {
@@ -2482,6 +2575,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
 
         let ffi_client =
@@ -2659,6 +2753,7 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
 
         let ffi_client =
@@ -2740,5 +2835,162 @@ mod tests {
 
         drop(batches);
         drop(handle_box);
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_valid() {
+        let event_name = CString::new("TestEvent").unwrap();
+        let identity = CString::new("Microsoft.TestService").unwrap();
+        let annotations = CString::new("<Config onBehalfFields=\"resourceId\"/>").unwrap();
+
+        let entry = FfiOboEventConfig {
+            event_name: event_name.as_ptr(),
+            identity: identity.as_ptr(),
+            annotations: annotations.as_ptr(),
+        };
+
+        let map = FfiOboEventMap {
+            entries: &entry as *const FfiOboEventConfig,
+            count: 1,
+        };
+
+        let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_some());
+        let obo_map = result.unwrap();
+        assert_eq!(obo_map.len(), 1);
+        let config = obo_map.get("TestEvent").unwrap();
+        assert_eq!(config.identity, "Microsoft.TestService");
+        assert_eq!(
+            config.annotations.as_deref(),
+            Some("<Config onBehalfFields=\"resourceId\"/>")
+        );
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_null_annotations() {
+        let event_name = CString::new("TestEvent").unwrap();
+        let identity = CString::new("Microsoft.TestService").unwrap();
+
+        let entry = FfiOboEventConfig {
+            event_name: event_name.as_ptr(),
+            identity: identity.as_ptr(),
+            annotations: std::ptr::null(),
+        };
+
+        let map = FfiOboEventMap {
+            entries: &entry as *const FfiOboEventConfig,
+            count: 1,
+        };
+
+        let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_some());
+        let obo_map = result.unwrap();
+        let config = obo_map.get("TestEvent").unwrap();
+        assert_eq!(config.identity, "Microsoft.TestService");
+        assert!(config.annotations.is_none());
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_null() {
+        let result = unsafe { convert_obo_event_map(std::ptr::null()) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_multiple_entries() {
+        let event1 = CString::new("Event1").unwrap();
+        let id1 = CString::new("Microsoft.Service1").unwrap();
+        let event2 = CString::new("Event2").unwrap();
+        let id2 = CString::new("Microsoft.Service2").unwrap();
+        let ann2 = CString::new("<Config/>").unwrap();
+
+        let entries = [
+            FfiOboEventConfig {
+                event_name: event1.as_ptr(),
+                identity: id1.as_ptr(),
+                annotations: std::ptr::null(),
+            },
+            FfiOboEventConfig {
+                event_name: event2.as_ptr(),
+                identity: id2.as_ptr(),
+                annotations: ann2.as_ptr(),
+            },
+        ];
+
+        let map = FfiOboEventMap {
+            entries: entries.as_ptr(),
+            count: entries.len(),
+        };
+
+        let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_some());
+        let obo_map = result.unwrap();
+        assert_eq!(obo_map.len(), 2);
+        assert_eq!(
+            obo_map.get("Event1").unwrap().identity,
+            "Microsoft.Service1"
+        );
+        assert_eq!(
+            obo_map.get("Event2").unwrap().identity,
+            "Microsoft.Service2"
+        );
+    }
+
+    #[test]
+    fn test_client_creation_with_obo_map() {
+        unsafe {
+            let endpoint = CString::new("https://test.geneva.com").unwrap();
+            let environment = CString::new("test").unwrap();
+            let account = CString::new("testaccount").unwrap();
+            let namespace = CString::new("testns").unwrap();
+            let region = CString::new("testregion").unwrap();
+            let tenant = CString::new("testtenant").unwrap();
+            let role_name = CString::new("testrole").unwrap();
+            let role_instance = CString::new("testinstance").unwrap();
+
+            let event_name = CString::new("MyEvent").unwrap();
+            let identity = CString::new("Microsoft.TestService").unwrap();
+            let annotations = CString::new("<Config/>").unwrap();
+
+            let entries = [FfiOboEventConfig {
+                event_name: event_name.as_ptr(),
+                identity: identity.as_ptr(),
+                annotations: annotations.as_ptr(),
+            }];
+
+            let obo_map = FfiOboEventMap {
+                entries: entries.as_ptr(),
+                count: entries.len(),
+            };
+
+            let config = GenevaConfig {
+                endpoint: endpoint.as_ptr(),
+                environment: environment.as_ptr(),
+                account: account.as_ptr(),
+                namespace_name: namespace.as_ptr(),
+                region: region.as_ptr(),
+                config_major_version: 1,
+                auth_method: 0, // SystemManagedIdentity - union not used
+                tenant: tenant.as_ptr(),
+                role_name: role_name.as_ptr(),
+                role_instance: role_instance.as_ptr(),
+                // SAFETY: GenevaAuthConfig only contains raw pointers (*const c_char).
+                // Zero-initializing raw pointers creates null pointers, which is valid.
+                // The union is never accessed for SystemManagedIdentity (auth_method 0).
+                auth: std::mem::zeroed(),
+                msi_resource: ptr::null(),
+                obo_map: &obo_map as *const FfiOboEventMap,
+            };
+
+            let mut out: *mut GenevaClientHandle = std::ptr::null_mut();
+            let rc = geneva_client_new(&config, &mut out, ptr::null_mut(), 0);
+            // Client creation may fail (e.g. MSI token acquisition), but the OBO map
+            // conversion path must not crash. We just verify it doesn't panic.
+            // If it somehow succeeds, clean up.
+            if !out.is_null() {
+                geneva_client_free(out);
+            }
+            let _ = rc;
+        }
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -289,22 +289,26 @@ unsafe fn write_error_if_provided(
 
 /// Converts an FFI OBO event map to the Rust-side `OboEventMap`.
 ///
-/// Returns `None` when the pointer is null, the entries pointer is null,
-/// or the count is zero. Individual entries with null event_name or identity
-/// are silently skipped.
+/// Returns `Ok(None)` when the pointer is null, the entries pointer is null,
+/// or the count is zero. Individual entries with null `event_name` or
+/// `identity` are silently skipped.
+///
+/// Returns `Err` if any non-null string pointer contains invalid UTF-8,
+/// matching the validation behavior used for the other config fields in
+/// `geneva_client_new`.
 ///
 /// # Safety
 /// - `ffi_map` must be null or point to a valid `FfiOboEventMap`
-/// - All non-null string pointers inside entries must be valid null-terminated UTF-8
+/// - All non-null string pointers inside entries must be valid null-terminated C strings
 unsafe fn convert_obo_event_map(
     ffi_map: *const FfiOboEventMap,
-) -> Option<geneva_uploader::client::OboEventMap> {
+) -> Result<Option<geneva_uploader::client::OboEventMap>, String> {
     if ffi_map.is_null() {
-        return None;
+        return Ok(None);
     }
     let map_ref = unsafe { &*ffi_map };
     if map_ref.entries.is_null() || map_ref.count == 0 {
-        return None;
+        return Ok(None);
     }
 
     let mut obo_map = std::collections::HashMap::new();
@@ -314,20 +318,12 @@ unsafe fn convert_obo_event_map(
         if entry.event_name.is_null() || entry.identity.is_null() {
             continue;
         }
-        let event_name = unsafe { CStr::from_ptr(entry.event_name) }
-            .to_string_lossy()
-            .into_owned();
-        let identity = unsafe { CStr::from_ptr(entry.identity) }
-            .to_string_lossy()
-            .into_owned();
+        let event_name = unsafe { c_str_to_string(entry.event_name, "obo_event_map.event_name") }?;
+        let identity = unsafe { c_str_to_string(entry.identity, "obo_event_map.identity") }?;
         let annotations = if entry.annotations.is_null() {
             None
         } else {
-            Some(
-                unsafe { CStr::from_ptr(entry.annotations) }
-                    .to_string_lossy()
-                    .into_owned(),
-            )
+            Some(unsafe { c_str_to_string(entry.annotations, "obo_event_map.annotations") }?)
         };
 
         obo_map.insert(
@@ -340,9 +336,9 @@ unsafe fn convert_obo_event_map(
     }
 
     if obo_map.is_empty() {
-        None
+        Ok(None)
     } else {
-        Some(obo_map)
+        Ok(Some(obo_map))
     }
 }
 
@@ -578,6 +574,15 @@ pub unsafe extern "C" fn geneva_client_new(
         None
     };
 
+    // Validate and convert the optional OBO event map (UTF-8 checked per-field).
+    let obo_event_map = match unsafe { convert_obo_event_map(config.obo_map) } {
+        Ok(map) => map,
+        Err(e) => {
+            unsafe { write_error_if_provided(err_msg_out, err_msg_len, &e) };
+            return GenevaError::InvalidConfig;
+        }
+    };
+
     // Build client config
     let geneva_config = GenevaClientConfig {
         endpoint,
@@ -591,7 +596,7 @@ pub unsafe extern "C" fn geneva_client_new(
         role_name,
         role_instance,
         msi_resource,
-        obo_event_map: unsafe { convert_obo_event_map(config.obo_map) },
+        obo_event_map,
     };
 
     // Create client
@@ -2855,6 +2860,8 @@ mod tests {
         };
 
         let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_ok());
+        let result = result.unwrap();
         assert!(result.is_some());
         let obo_map = result.unwrap();
         assert_eq!(obo_map.len(), 1);
@@ -2883,6 +2890,8 @@ mod tests {
         };
 
         let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_ok());
+        let result = result.unwrap();
         assert!(result.is_some());
         let obo_map = result.unwrap();
         let config = obo_map.get("TestEvent").unwrap();
@@ -2893,7 +2902,8 @@ mod tests {
     #[test]
     fn test_convert_obo_event_map_null() {
         let result = unsafe { convert_obo_event_map(std::ptr::null()) };
-        assert!(result.is_none());
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 
     #[test]
@@ -2923,6 +2933,8 @@ mod tests {
         };
 
         let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_ok());
+        let result = result.unwrap();
         assert!(result.is_some());
         let obo_map = result.unwrap();
         assert_eq!(obo_map.len(), 2);
@@ -2933,6 +2945,84 @@ mod tests {
         assert_eq!(
             obo_map.get("Event2").unwrap().identity,
             "Microsoft.Service2"
+        );
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_invalid_utf8_event_name() {
+        // Build a CString-like buffer with invalid UTF-8 (0xFF) followed by a NUL byte.
+        // CString::new rejects interior NULs but allows non-UTF-8 bytes, so we use it directly.
+        let bad_event_name = CString::new([0xFFu8, 0x65, 0x76, 0x65, 0x6E, 0x74]).unwrap();
+        let identity = CString::new("Microsoft.TestService").unwrap();
+
+        let entry = FfiOboEventConfig {
+            event_name: bad_event_name.as_ptr(),
+            identity: identity.as_ptr(),
+            annotations: std::ptr::null(),
+        };
+
+        let map = FfiOboEventMap {
+            entries: &entry as *const FfiOboEventConfig,
+            count: 1,
+        };
+
+        let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("obo_event_map.event_name"),
+            "expected error to mention field name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_invalid_utf8_identity() {
+        let event_name = CString::new("TestEvent").unwrap();
+        let bad_identity = CString::new([0xFFu8, 0x69, 0x64]).unwrap();
+
+        let entry = FfiOboEventConfig {
+            event_name: event_name.as_ptr(),
+            identity: bad_identity.as_ptr(),
+            annotations: std::ptr::null(),
+        };
+
+        let map = FfiOboEventMap {
+            entries: &entry as *const FfiOboEventConfig,
+            count: 1,
+        };
+
+        let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("obo_event_map.identity"),
+            "expected error to mention field name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_convert_obo_event_map_invalid_utf8_annotations() {
+        let event_name = CString::new("TestEvent").unwrap();
+        let identity = CString::new("Microsoft.TestService").unwrap();
+        let bad_annotations = CString::new([0xFFu8, 0x61, 0x6E, 0x6E]).unwrap();
+
+        let entry = FfiOboEventConfig {
+            event_name: event_name.as_ptr(),
+            identity: identity.as_ptr(),
+            annotations: bad_annotations.as_ptr(),
+        };
+
+        let map = FfiOboEventMap {
+            entries: &entry as *const FfiOboEventConfig,
+            count: 1,
+        };
+
+        let result = unsafe { convert_obo_event_map(&map as *const FfiOboEventMap) };
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("obo_event_map.annotations"),
+            "expected error to mention field name, got: {err}"
         );
     }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
@@ -344,6 +344,7 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        obo_event_map: None,
     })
     .expect("Failed to create GenevaClient");
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
@@ -141,6 +141,7 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        obo_event_map: None,
     })
     .expect("Failed to create GenevaClient");
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -189,7 +189,7 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(black_box(&view), black_box(&metadata))
+                            .encode_logs_from_view(black_box(&view), black_box(&metadata), None)
                             .unwrap();
                         black_box(res);
                     });
@@ -221,7 +221,7 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(black_box(&view), black_box(&metadata))
+                            .encode_logs_from_view(black_box(&view), black_box(&metadata), None)
                             .unwrap();
                         black_box(res);
                     });
@@ -248,7 +248,7 @@ mod benchmarks {
             b.iter(|| {
                 let view = RawLogsData::new(black_box(mixed_request_bytes.as_slice()));
                 let res = encoder
-                    .encode_logs_from_view(black_box(&view), black_box(&metadata))
+                    .encode_logs_from_view(black_box(&view), black_box(&metadata), None)
                     .unwrap();
                 black_box(res);
             });

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -5,8 +5,9 @@ use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfig
 use crate::ingestion_service::uploader::{
     GenevaUploader, GenevaUploaderConfig, GenevaUploaderError,
 };
-use crate::payload_encoder::otlp_encoder::MetadataFields;
 use crate::payload_encoder::otlp_encoder::OtlpEncoder;
+use crate::payload_encoder::otlp_encoder::{lookup_obo_config, MetadataFields};
+pub use crate::payload_encoder::otlp_encoder::{OboEventConfig, OboEventMap};
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use otap_df_pdata_views::views::logs::LogsDataView;
 use std::fmt;
@@ -38,7 +39,7 @@ pub struct GenevaClientConfig {
     pub role_name: String,
     pub role_instance: String,
     pub msi_resource: Option<String>, // Required for Managed Identity variants
-                                      // Add event name/version here if constant, or per-upload if you want them per call.
+    pub obo_event_map: Option<OboEventMap>, // Per-event OBO config (None = no OBO)
 }
 
 /// Error type returned by [`GenevaClient::upload_batch`].
@@ -86,6 +87,7 @@ pub struct GenevaClient {
     uploader: Arc<GenevaUploader>,
     encoder: OtlpEncoder,
     metadata_fields: MetadataFields,
+    obo_event_map: Option<OboEventMap>,
 }
 
 impl GenevaClient {
@@ -190,6 +192,7 @@ impl GenevaClient {
             uploader: Arc::new(uploader),
             encoder: OtlpEncoder::new(),
             metadata_fields,
+            obo_event_map: cfg.obo_event_map,
         })
     }
 
@@ -236,7 +239,7 @@ impl GenevaClient {
         );
 
         self.encoder
-            .encode_logs_from_view(view, &self.metadata_fields)
+            .encode_logs_from_view(view, &self.metadata_fields, self.obo_event_map.as_ref())
             .map_err(|e| {
                 debug!(
                     name: "client.encode_and_compress_logs.error",
@@ -266,7 +269,11 @@ impl GenevaClient {
             .flat_map(|scope_span| scope_span.spans.iter());
 
         self.encoder
-            .encode_span_batch(span_iter, &self.metadata_fields)
+            .encode_span_batch(
+                span_iter,
+                &self.metadata_fields,
+                self.obo_event_map.as_ref(),
+            )
             .map_err(|e| {
                 debug!(
                     name: "client.encode_and_compress_spans.error",
@@ -289,12 +296,17 @@ impl GenevaClient {
             "Uploading batch"
         );
 
+        // Look up per-event OBO config for this batch's event name
+        let obo_config = lookup_obo_config(self.obo_event_map.as_ref(), &batch.event_name)
+            .filter(|c| c.is_active());
+
         self.uploader
             .upload(
                 batch.data.clone(),
                 &batch.event_name,
                 &batch.metadata,
                 batch.row_count,
+                obo_config,
             )
             .await
             .map(|_| {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -130,7 +130,7 @@ mod tests {
 
         let response = ctx
             .uploader
-            .upload(ctx.data, &ctx.event_name, &metadata, 1)
+            .upload(ctx.data, &ctx.event_name, &metadata, 1, None)
             .await
             .expect("Upload failed");
 
@@ -197,7 +197,7 @@ mod tests {
 
         let _ = ctx
             .uploader
-            .upload(ctx.data.clone(), &ctx.event_name, &warmup_metadata, 1)
+            .upload(ctx.data.clone(), &ctx.event_name, &warmup_metadata, 1, None)
             .await
             .expect("Warm-up upload failed");
         let warmup_elapsed = start_warmup.elapsed();
@@ -223,7 +223,7 @@ mod tests {
                 };
 
                 let resp = uploader
-                    .upload(data, &event_name, &metadata, 1)
+                    .upload(data, &event_name, &metadata, 1, None)
                     .await
                     .unwrap_or_else(|_| panic!("Upload {i} failed"));
                 let elapsed = start.elapsed();

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -160,6 +160,7 @@ impl GenevaUploader {
 
     /// Creates the GIG upload URI with required parameters
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     fn create_upload_uri(
         &self,
         monitoring_endpoint: &str,
@@ -168,6 +169,7 @@ impl GenevaUploader {
         event_name: &str,
         metadata: &BatchMetadata,
         row_count: usize,
+        obo_config: Option<&crate::payload_encoder::otlp_encoder::OboEventConfig>,
     ) -> Result<String> {
         // Get already formatted schema IDs and format timestamps using BatchMetadata methods
         let schema_ids = &metadata.schema_ids;
@@ -201,6 +203,24 @@ impl GenevaUploader {
             schema_ids,
             row_count
         ).map_err(|e| GenevaUploaderError::InternalError(format!("Failed to write query string: {e}")))?;
+
+        // Append OBO query parameters if this event has OBO config
+        if let Some(config) = obo_config.filter(|c| c.is_active()) {
+            write!(&mut query, "&onbehalfid={}", config.identity.trim()).map_err(|e| {
+                GenevaUploaderError::InternalError(format!("Failed to write OBO identity: {e}"))
+            })?;
+            if let Some(ann) = config.active_annotations() {
+                let encoded_annotations: String = byte_serialize(ann.as_bytes()).collect();
+                write!(&mut query, "&onbehalfannotations={}", encoded_annotations).map_err(
+                    |e| {
+                        GenevaUploaderError::InternalError(format!(
+                            "Failed to write OBO annotations: {e}"
+                        ))
+                    },
+                )?;
+            }
+        }
+
         Ok(query)
     }
 
@@ -222,6 +242,7 @@ impl GenevaUploader {
         event_name: &str,
         metadata: &BatchMetadata,
         row_count: usize,
+        obo_config: Option<&crate::payload_encoder::otlp_encoder::OboEventConfig>,
     ) -> Result<IngestionResponse> {
         debug!(
             name: "uploader.upload",
@@ -242,6 +263,7 @@ impl GenevaUploader {
             event_name,
             metadata,
             row_count,
+            obo_config,
         )?;
         let full_url = format!(
             "{}/{}",
@@ -316,5 +338,148 @@ impl GenevaUploader {
                 message: body,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload_encoder::otlp_encoder::OboEventConfig;
+
+    fn make_uploader() -> GenevaUploader {
+        let uploader_config = GenevaUploaderConfig {
+            namespace: "TestNamespace".to_string(),
+            source_identity: "Tenant=Test/Role=TestRole/RoleInstance=TestInstance".to_string(),
+            environment: "TestEnv".to_string(),
+            config_version: "Ver1v0".to_string(),
+        };
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::ACCEPT,
+            header::HeaderValue::from_static("application/json"),
+        );
+        let http_client =
+            GenevaUploader::build_h1_client(headers).expect("HTTP client should build");
+        use crate::config_service::client::{AuthMethod, GenevaConfigClientConfig};
+        let config_client_config = GenevaConfigClientConfig {
+            endpoint: "https://test.endpoint.com".to_string(),
+            environment: "TestEnv".to_string(),
+            account: "TestAccount".to_string(),
+            namespace: "TestNamespace".to_string(),
+            region: "westus2".to_string(),
+            config_major_version: 1,
+            auth_method: AuthMethod::SystemManagedIdentity,
+            msi_resource: Some("https://monitor.azure.com".to_string()),
+            test_root_ca_pem: None,
+        };
+        let config_client = Arc::new(
+            crate::config_service::client::GenevaConfigClient::new(config_client_config)
+                .expect("Config client should init"),
+        );
+        GenevaUploader {
+            config_client,
+            config: uploader_config,
+            http_client,
+        }
+    }
+
+    fn make_test_metadata() -> BatchMetadata {
+        BatchMetadata {
+            start_time: 1_700_000_000_000_000_000,
+            end_time: 1_700_000_001_000_000_000,
+            schema_ids: "abc123".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_upload_uri_with_obo_identity() {
+        let uploader = make_uploader();
+        let metadata = make_test_metadata();
+        let obo_config = OboEventConfig {
+            identity: "Microsoft.TestService".to_string(),
+            annotations: None,
+        };
+        let uri = uploader
+            .create_upload_uri(
+                "https://monitor.endpoint",
+                "testmoniker",
+                1024,
+                "TestEvent",
+                &metadata,
+                10,
+                Some(&obo_config),
+            )
+            .expect("URI creation should succeed");
+        assert!(
+            uri.contains("&onbehalfid=Microsoft.TestService"),
+            "URI should contain onbehalfid, got: {}",
+            uri
+        );
+        assert!(
+            !uri.contains("&onbehalfannotations="),
+            "URI should NOT contain onbehalfannotations when not set"
+        );
+    }
+
+    #[test]
+    fn test_upload_uri_with_obo_annotations() {
+        let uploader = make_uploader();
+        let metadata = make_test_metadata();
+        let obo_config = OboEventConfig {
+            identity: "Microsoft.TestService".to_string(),
+            annotations: Some(
+                r#"<Config onBehalfFields="resourceId" priority="Normal"/>"#.to_string(),
+            ),
+        };
+        let uri = uploader
+            .create_upload_uri(
+                "https://monitor.endpoint",
+                "testmoniker",
+                1024,
+                "TestEvent",
+                &metadata,
+                10,
+                Some(&obo_config),
+            )
+            .expect("URI creation should succeed");
+        assert!(
+            uri.contains("&onbehalfid=Microsoft.TestService"),
+            "URI should contain onbehalfid"
+        );
+        assert!(
+            uri.contains("&onbehalfannotations="),
+            "URI should contain onbehalfannotations, got: {}",
+            uri
+        );
+        assert!(
+            !uri.contains("<Config"),
+            "Annotations should be URL-encoded"
+        );
+    }
+
+    #[test]
+    fn test_upload_uri_without_obo() {
+        let uploader = make_uploader();
+        let metadata = make_test_metadata();
+        let uri = uploader
+            .create_upload_uri(
+                "https://monitor.endpoint",
+                "testmoniker",
+                1024,
+                "TestEvent",
+                &metadata,
+                10,
+                None,
+            )
+            .expect("URI creation should succeed");
+        assert!(
+            !uri.contains("onbehalfid"),
+            "URI should NOT contain onbehalfid, got: {}",
+            uri
+        );
+        assert!(
+            !uri.contains("onbehalfannotations"),
+            "URI should NOT contain onbehalfannotations"
+        );
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -46,6 +46,34 @@ const FIELD_PARENT_ID: &str = "parentId";
 const FIELD_LINKS: &str = "links";
 const FIELD_STATUS_MESSAGE: &str = "statusMessage";
 
+// OBO (On Behalf Of) field constants
+const FIELD_OBO_SERVICE_ID: &str = "onbehalfServiceId";
+const FIELD_OBO_ANNOTATIONS: &str = "onbehalfAnnotations";
+
+/// Per-event OBO configuration, matching AMACA's EventStreamingAnnotation model.
+/// The identity field should already contain the resolved identity
+/// (altOnbehalfIdentity > onBehalfIdentity > serviceIdentity).
+#[derive(Clone, Debug)]
+pub struct OboEventConfig {
+    pub identity: String,
+    pub annotations: Option<String>,
+}
+
+impl OboEventConfig {
+    /// Returns true if OBO is meaningfully configured (identity is non-empty)
+    pub fn is_active(&self) -> bool {
+        !self.identity.trim().is_empty()
+    }
+
+    /// Returns annotations only if non-empty
+    pub fn active_annotations(&self) -> Option<&str> {
+        self.annotations.as_deref().filter(|s| !s.trim().is_empty())
+    }
+}
+
+/// Map of event_name → OBO config. Events not in the map don't get OBO.
+pub type OboEventMap = HashMap<String, OboEventConfig>;
+
 fn non_blank_utf8(bytes: &[u8]) -> Option<&str> {
     let s = std::str::from_utf8(bytes).ok()?;
     (!s.trim().is_empty()).then_some(s)
@@ -53,6 +81,28 @@ fn non_blank_utf8(bytes: &[u8]) -> Option<&str> {
 
 fn normalized_event_name(record: &impl LogRecordView) -> Option<&str> {
     record.event_name().and_then(non_blank_utf8)
+}
+
+/// Look up an event in the OBO map, handling .NET-style anchored regex format.
+/// Tries the literal event name first, then checks the simple anchored regex form.
+pub(crate) fn lookup_obo_config<'a>(
+    obo_event_map: Option<&'a OboEventMap>,
+    event_name: &str,
+) -> Option<&'a OboEventConfig> {
+    let map = obo_event_map?;
+    if let Some(config) = map.get(event_name) {
+        return Some(config);
+    }
+    if let Some(stripped) = event_name
+        .strip_prefix('^')
+        .and_then(|name| name.strip_suffix('$'))
+    {
+        if let Some(config) = map.get(stripped) {
+            return Some(config);
+        }
+    }
+    let anchored = format!("^{event_name}$");
+    map.get(&anchored)
 }
 
 /// Metadata fields that should appear as Bond schema fields (queryable in Geneva)
@@ -159,7 +209,12 @@ impl LogBatchAccumulator {
     }
 
     /// Encode a single log record and append it to the appropriate batch.
-    fn push<R: LogRecordView>(&mut self, record: &R, metadata_fields: &MetadataFields) {
+    fn push<R: LogRecordView>(
+        &mut self,
+        record: &R,
+        metadata_fields: &MetadataFields,
+        obo_event_map: Option<&OboEventMap>,
+    ) {
         let timestamp = record
             .time_unix_nano()
             .filter(|&t| t != 0)
@@ -167,7 +222,10 @@ impl LogBatchAccumulator {
             .unwrap_or(0);
         let routing_event_name = normalized_event_name(record).unwrap_or("Log");
 
-        let (field_info, dynamic_fields_start) = OtlpEncoder::determine_fields(record);
+        // Look up per-event OBO config
+        let obo_config = lookup_obo_config(obo_event_map, routing_event_name);
+
+        let (field_info, dynamic_fields_start) = OtlpEncoder::determine_fields(record, obo_config);
 
         // Only allocate Arc<str> when we see a new event name for the first time.
         // Arc<str>: Borrow<str>, so contains_key / get_mut accept a plain &str.
@@ -213,8 +271,13 @@ impl LogBatchAccumulator {
             }
         };
 
-        let row_buffer =
-            OtlpEncoder::write_row_data(record, &field_info, dynamic_fields_start, metadata_fields);
+        let row_buffer = OtlpEncoder::write_row_data(
+            record,
+            &field_info,
+            dynamic_fields_start,
+            metadata_fields,
+            obo_config,
+        );
         let level = record.severity_number().unwrap_or(0) as u8;
         // Reuse the Arc already stored in BatchData — just a refcount increment.
         let event_name = Arc::clone(&entry.routing_name);
@@ -313,12 +376,13 @@ impl OtlpEncoder {
         &self,
         view: &T,
         metadata_fields: &MetadataFields,
+        obo_event_map: Option<&OboEventMap>,
     ) -> Result<Vec<EncodedBatch>, String> {
         let mut acc = LogBatchAccumulator::new();
         for resource_logs in view.resources() {
             for scope_logs in resource_logs.scopes() {
                 for log_record in scope_logs.log_records() {
-                    acc.push(&log_record, metadata_fields);
+                    acc.push(&log_record, metadata_fields, obo_event_map);
                 }
             }
         }
@@ -333,9 +397,13 @@ impl OtlpEncoder {
         &self,
         spans: impl IntoIterator<Item = &'a Span>,
         metadata_fields: &MetadataFields,
+        obo_event_map: Option<&OboEventMap>,
     ) -> Result<Vec<EncodedBatch>, String> {
         // All spans use "Span" as event name for routing - no grouping by span name
         const EVENT_NAME: &str = "Span";
+
+        // Look up OBO for span events
+        let obo_config = lookup_obo_config(obo_event_map, EVENT_NAME);
 
         let mut schemas = Vec::new();
         let mut events = Vec::new();
@@ -344,7 +412,7 @@ impl OtlpEncoder {
 
         for span in spans {
             // 1. Get schema fields
-            let field_info = Self::determine_span_fields(span, EVENT_NAME);
+            let field_info = Self::determine_span_fields(span, EVENT_NAME, obo_config);
 
             // 2. Update timestamp range
             if span.start_time_unix_nano != 0 {
@@ -377,7 +445,8 @@ impl OtlpEncoder {
             };
 
             // 4. Encode row
-            let row_buffer = self.write_span_row_data(span, &field_info, metadata_fields);
+            let row_buffer =
+                self.write_span_row_data(span, &field_info, metadata_fields, obo_config);
             let level = 5; // Default level for spans (INFO equivalent)
 
             // 5. Create CentralEventEntry
@@ -477,7 +546,10 @@ impl OtlpEncoder {
     // ---------------------------------------------------------------------------
 
     /// Determine Bond schema fields for any [`LogRecordView`].
-    fn determine_fields(record: &impl LogRecordView) -> (Vec<FieldDef>, usize) {
+    fn determine_fields(
+        record: &impl LogRecordView,
+        obo_config: Option<&OboEventConfig>,
+    ) -> (Vec<FieldDef>, usize) {
         let estimated_capacity = 14 + 3; // base + conditional; attributes appended below
         let mut fields: Vec<(Cow<'static, str>, BondDataType)> =
             Vec::with_capacity(estimated_capacity);
@@ -522,6 +594,14 @@ impl OtlpEncoder {
                     .is_some()
         }) {
             fields.push((FIELD_BODY.into(), BondDataType::BT_STRING));
+        }
+
+        // OBO fields — only if this event has OBO config with non-empty identity
+        if obo_config.is_some_and(|c| c.is_active()) {
+            fields.push((FIELD_OBO_SERVICE_ID.into(), BondDataType::BT_STRING));
+            if obo_config.unwrap().active_annotations().is_some() {
+                fields.push((FIELD_OBO_ANNOTATIONS.into(), BondDataType::BT_STRING));
+            }
         }
 
         // Part C – dynamic attributes
@@ -591,6 +671,7 @@ impl OtlpEncoder {
         fields: &[FieldDef],
         dynamic_fields_start: usize,
         metadata_fields: &MetadataFields,
+        obo_config: Option<&OboEventConfig>,
     ) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(fields.len() * 50);
         let timestamp_nanos = record
@@ -656,6 +737,16 @@ impl OtlpEncoder {
                                 }
                             }
                         }
+                    }
+                }
+                FIELD_OBO_SERVICE_ID => {
+                    if let Some(config) = obo_config.filter(|c| c.is_active()) {
+                        BondWriter::write_string(&mut buffer, config.identity.trim());
+                    }
+                }
+                FIELD_OBO_ANNOTATIONS => {
+                    if let Some(ann) = obo_config.and_then(|c| c.active_annotations()) {
+                        BondWriter::write_string(&mut buffer, ann);
                     }
                 }
                 _ => {}
@@ -745,7 +836,11 @@ impl OtlpEncoder {
     // ---------------------------------------------------------------------------
 
     /// Determine span fields
-    fn determine_span_fields(span: &Span, _event_name: &str) -> Vec<FieldDef> {
+    fn determine_span_fields(
+        span: &Span,
+        _event_name: &str,
+        obo_config: Option<&OboEventConfig>,
+    ) -> Vec<FieldDef> {
         // Pre-allocate with estimated capacity to avoid reallocations
         let estimated_capacity = 18 + span.attributes.len(); // 7 base + 3 tenant/role + 3 span-specific + 5 max conditional + attributes
         let mut fields = Vec::with_capacity(estimated_capacity);
@@ -791,6 +886,14 @@ impl OtlpEncoder {
         if let Some(status) = &span.status {
             if !status.message.is_empty() {
                 fields.push((FIELD_STATUS_MESSAGE.into(), BondDataType::BT_STRING));
+            }
+        }
+
+        // OBO fields — only if this event has OBO config with non-empty identity
+        if obo_config.is_some_and(|c| c.is_active()) {
+            fields.push((FIELD_OBO_SERVICE_ID.into(), BondDataType::BT_STRING));
+            if obo_config.unwrap().active_annotations().is_some() {
+                fields.push((FIELD_OBO_ANNOTATIONS.into(), BondDataType::BT_STRING));
             }
         }
 
@@ -857,6 +960,7 @@ impl OtlpEncoder {
         span: &Span,
         fields: &[FieldDef],
         metadata_fields: &MetadataFields,
+        obo_config: Option<&OboEventConfig>,
     ) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(fields.len() * 50);
 
@@ -931,6 +1035,16 @@ impl OtlpEncoder {
                 FIELD_STATUS_MESSAGE => {
                     if let Some(status) = &span.status {
                         BondWriter::write_string(&mut buffer, &status.message);
+                    }
+                }
+                FIELD_OBO_SERVICE_ID => {
+                    if let Some(config) = obo_config.filter(|c| c.is_active()) {
+                        BondWriter::write_string(&mut buffer, config.identity.trim());
+                    }
+                }
+                FIELD_OBO_ANNOTATIONS => {
+                    if let Some(ann) = obo_config.and_then(|c| c.active_annotations()) {
+                        BondWriter::write_string(&mut buffer, ann);
                     }
                 }
                 _ => {
@@ -1080,6 +1194,7 @@ mod tests {
         encoder: &OtlpEncoder,
         logs: impl IntoIterator<Item = &'a LogRecord>,
         metadata: &MetadataFields,
+        obo_event_map: Option<&OboEventMap>,
     ) -> Result<Vec<EncodedBatch>, String> {
         use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
         use prost::Message as _;
@@ -1094,7 +1209,7 @@ mod tests {
             }],
         }
         .encode_to_vec();
-        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata)
+        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, obo_event_map)
     }
 
     /// Wraps raw LogRecord proto bytes into a minimal ExportLogsServiceRequest encoding.
@@ -1166,7 +1281,7 @@ mod tests {
         });
 
         let metadata = make_metadata("testNamespace");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
 
         assert!(!result.is_empty());
     }
@@ -1214,7 +1329,8 @@ mod tests {
 
         // Encode multiple log records with different schema structures but same event_name
         let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata, None)
+                .unwrap();
 
         // Should create one batch (same event_name = "user_action")
         assert_eq!(result.len(), 1);
@@ -1264,7 +1380,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "test_event");
@@ -1281,7 +1397,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Log");
@@ -1319,7 +1435,7 @@ mod tests {
         });
 
         let encoded =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
         // Smoke test: a rich proto-backed view encodes to a single non-empty batch.
         assert_eq!(encoded.len(), 1);
         assert_eq!(encoded[0].event_name, "view_event");
@@ -1346,9 +1462,9 @@ mod tests {
         };
 
         let with_empty =
-            encode_log_batch_via_proto(&encoder, [log_with_empty].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log_with_empty].iter(), &metadata, None).unwrap();
         let without =
-            encode_log_batch_via_proto(&encoder, [log_without].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log_without].iter(), &metadata, None).unwrap();
 
         assert_single_batch_equal(&with_empty, &without);
     }
@@ -1372,7 +1488,7 @@ mod tests {
 
         // Expected: encode a log without body
         let expected =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
 
         // Inject invalid UTF-8 into the body field via raw proto wire bytes.
         // body = AnyValue { string_value: [0xFF] }
@@ -1383,7 +1499,7 @@ mod tests {
         let export_bytes = wrap_log_record_bytes(&log_bytes);
 
         let actual = encoder
-            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata)
+            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, None)
             .unwrap();
         assert_single_batch_equal(&expected, &actual);
     }
@@ -1406,7 +1522,7 @@ mod tests {
         };
 
         let expected =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
 
         // Inject severity_text = [0xFF] directly into the LogRecord wire bytes.
         // severity_text field = 3 (LEN) => [0x1A, 0x01, 0xFF]
@@ -1415,7 +1531,7 @@ mod tests {
         let export_bytes = wrap_log_record_bytes(&log_bytes);
 
         let actual = encoder
-            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata)
+            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, None)
             .unwrap();
         assert_single_batch_equal(&expected, &actual);
     }
@@ -1438,7 +1554,7 @@ mod tests {
         };
 
         let expected =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
 
         // Inject attributes = [ KeyValue { key: [0xFF], value: AnyValue { string_value: "a" } } ]
         // KeyValue bytes:
@@ -1450,7 +1566,7 @@ mod tests {
         let export_bytes = wrap_log_record_bytes(&log_bytes);
 
         let actual = encoder
-            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata)
+            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, None)
             .unwrap();
         assert_single_batch_equal(&expected, &actual);
     }
@@ -1484,19 +1600,26 @@ mod tests {
         use prost::Message as _;
         let base_bytes = base_log.encode_to_vec();
         let base_ref = RawLogRecord::new(&base_bytes);
-        let (base_fields, base_dynamic_fields_start) = OtlpEncoder::determine_fields(&base_ref);
+        let (base_fields, base_dynamic_fields_start) =
+            OtlpEncoder::determine_fields(&base_ref, None);
         let base_row = OtlpEncoder::write_row_data(
             &base_ref,
             &base_fields,
             base_dynamic_fields_start,
             &metadata,
+            None,
         );
 
         let dup_bytes = dup_log.encode_to_vec();
         let dup_ref = RawLogRecord::new(&dup_bytes);
-        let (dup_fields, dup_dynamic_fields_start) = OtlpEncoder::determine_fields(&dup_ref);
-        let dup_row =
-            OtlpEncoder::write_row_data(&dup_ref, &dup_fields, dup_dynamic_fields_start, &metadata);
+        let (dup_fields, dup_dynamic_fields_start) = OtlpEncoder::determine_fields(&dup_ref, None);
+        let dup_row = OtlpEncoder::write_row_data(
+            &dup_ref,
+            &dup_fields,
+            dup_dynamic_fields_start,
+            &metadata,
+            None,
+        );
 
         assert_eq!(dup_fields.len() - dup_dynamic_fields_start, 2);
         assert_eq!(dup_row.len() - base_row.len(), 16);
@@ -1536,7 +1659,8 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata, None)
+                .unwrap();
 
         // All should be in one batch with same event_name
         assert_eq!(result.len(), 1);
@@ -1563,7 +1687,8 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log1, log2].iter(), &metadata).unwrap();
+        let result =
+            encode_log_batch_via_proto(&encoder, [log1, log2].iter(), &metadata, None).unwrap();
 
         // Should create 2 separate batches
         assert_eq!(result.len(), 2);
@@ -1586,7 +1711,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Log"); // Should default to "Log"
@@ -1634,7 +1759,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2, log3, log4].iter(), &metadata)
+            encode_log_batch_via_proto(&encoder, [log1, log2, log3, log4].iter(), &metadata, None)
                 .unwrap();
 
         // Should create 3 batches: "user_action", "system_alert", "Log"
@@ -1693,7 +1818,9 @@ mod tests {
         });
 
         let metadata = make_metadata("testNamespace");
-        let result = encoder.encode_span_batch([span].iter(), &metadata).unwrap();
+        let result = encoder
+            .encode_span_batch([span].iter(), &metadata, None)
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Span");
@@ -1729,7 +1856,9 @@ mod tests {
         });
 
         let metadata = make_metadata("test");
-        let result = encoder.encode_span_batch([span].iter(), &metadata).unwrap();
+        let result = encoder
+            .encode_span_batch([span].iter(), &metadata, None)
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Span");
@@ -1758,7 +1887,9 @@ mod tests {
         });
 
         let metadata = make_metadata("test");
-        let result = encoder.encode_span_batch([span].iter(), &metadata).unwrap();
+        let result = encoder
+            .encode_span_batch([span].iter(), &metadata, None)
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Span");
@@ -1789,13 +1920,13 @@ mod tests {
             ..Default::default()
         };
 
-        let fields1 = OtlpEncoder::determine_span_fields(&span1, "Span");
+        let fields1 = OtlpEncoder::determine_span_fields(&span1, "Span", None);
         assert!(
             fields1.iter().any(|f| f.name.as_ref() == FIELD_NAME),
             "Span with non-empty name should include 'name' field in schema"
         );
 
-        let fields2 = OtlpEncoder::determine_span_fields(&span2, "Span");
+        let fields2 = OtlpEncoder::determine_span_fields(&span2, "Span", None);
         assert!(
             fields2.iter().any(|f| f.name.as_ref() == FIELD_NAME),
             "Span with non-empty name should include 'name' field in schema"
@@ -1803,7 +1934,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result = encoder
-            .encode_span_batch([span1, span2].iter(), &metadata)
+            .encode_span_batch([span1, span2].iter(), &metadata, None)
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -1888,7 +2019,7 @@ mod tests {
         ];
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, logs.iter(), &metadata).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, logs.iter(), &metadata, None).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].row_count, 3);
@@ -1906,7 +2037,9 @@ mod tests {
             },
         ];
 
-        let span_result = encoder.encode_span_batch(spans.iter(), &metadata).unwrap();
+        let span_result = encoder
+            .encode_span_batch(spans.iter(), &metadata, None)
+            .unwrap();
 
         assert_eq!(span_result.len(), 1);
         assert_eq!(span_result[0].row_count, 2);
@@ -1928,7 +2061,7 @@ mod tests {
         };
 
         let encoded =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
 
         // Confirm the selected timestamp is time_unix_nano, not observed_time_unix_nano
         assert_eq!(encoded[0].metadata.start_time, 1_000_000_000);
@@ -1966,7 +2099,7 @@ mod tests {
 
         use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
         let encoded = encoder
-            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata)
+            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata, None)
             .unwrap();
 
         assert_eq!(encoded.len(), 1);
@@ -2037,7 +2170,7 @@ mod tests {
         .encode_to_vec();
 
         let result = encoder
-            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata)
+            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata, None)
             .unwrap();
 
         // Two event names → two batches
@@ -2055,5 +2188,397 @@ mod tests {
         assert_eq!(alpha.metadata.end_time, 3_000);
         assert_eq!(beta.metadata.start_time, 2_000);
         assert_eq!(beta.metadata.end_time, 4_000);
+    }
+
+    // ==================== OBO (On Behalf Of) Per-Event Tests ====================
+
+    fn make_obo_event_map(
+        event_name: &str,
+        identity: &str,
+        annotations: Option<&str>,
+    ) -> OboEventMap {
+        let mut map = HashMap::new();
+        map.insert(
+            event_name.to_string(),
+            OboEventConfig {
+                identity: identity.to_string(),
+                annotations: annotations.map(|s| s.to_string()),
+            },
+        );
+        map
+    }
+
+    #[test]
+    fn test_obo_lookup_matches_literal_event_name() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", Some("<Config/>"));
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "MyEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_obo_lookup_matches_anchored_event_name() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("^MyEvent$", "Microsoft.TestService", Some("<Config/>"));
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "MyEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_obo_lookup_no_match_for_different_event() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", None);
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "OtherEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_obo_lookup_strips_anchored_event_name() {
+        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", None);
+        let config = lookup_obo_config(Some(&obo_map), "^MyEvent$");
+        assert!(config.is_some());
+    }
+
+    #[test]
+    fn test_obo_fields_in_log_schema() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "TestEvent",
+            "Microsoft.SomeService",
+            Some(r#"<Config onBehalfFields="resourceId" priority="Normal"/>"#),
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "OBO log batch should encode successfully");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_obo_fields_absent_when_not_configured() {
+        let metadata = make_metadata("TestNamespace");
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(&OtlpEncoder::new(), [log].iter(), &metadata, None);
+        assert!(
+            result.is_ok(),
+            "Log batch without OBO should encode successfully"
+        );
+    }
+
+    #[test]
+    fn test_obo_identity_only_no_annotations() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("TestEvent", "Microsoft.SomeService", None);
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(
+            result.is_ok(),
+            "OBO with identity only should encode successfully"
+        );
+    }
+
+    #[test]
+    fn test_obo_fields_in_span_schema() {
+        let obo_config = OboEventConfig {
+            identity: "Microsoft.SomeService".to_string(),
+            annotations: Some(r#"<Config onBehalfFields="resourceId"/>"#.to_string()),
+        };
+        let span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "test_span".to_string(),
+            kind: 1,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+        let fields = OtlpEncoder::determine_span_fields(&span, "Span", Some(&obo_config));
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.name.as_ref() == FIELD_OBO_SERVICE_ID),
+            "Span schema should include onbehalfServiceId"
+        );
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.name.as_ref() == FIELD_OBO_ANNOTATIONS),
+            "Span schema should include onbehalfAnnotations"
+        );
+    }
+
+    #[test]
+    fn test_encode_log_batch_with_obo() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "TestEvent",
+            "Microsoft.BatchService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "encode with OBO should succeed");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_encode_span_batch_with_obo() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "Span",
+            "Microsoft.SpanBatchService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let encoder = OtlpEncoder::new();
+        let span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "test_span".to_string(),
+            kind: 1,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+        let result = encoder.encode_span_batch([span].iter(), &metadata, Some(&obo_map));
+        assert!(result.is_ok(), "encode_span_batch with OBO should succeed");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_mixed_batch_obo_and_non_obo_events() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "OboEvent",
+            "Microsoft.OboService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let obo_log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "OboEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let regular_log = LogRecord {
+            observed_time_unix_nano: 1_700_000_001_000_000_000,
+            event_name: "RegularEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [obo_log, regular_log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Mixed batch should succeed");
+        let batches = result.unwrap();
+        assert_eq!(
+            batches.len(),
+            2,
+            "Should have separate batches for different event names"
+        );
+    }
+
+    #[test]
+    fn test_no_obo_map_means_no_obo() {
+        let metadata = make_metadata("TestNamespace");
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(&OtlpEncoder::new(), [log].iter(), &metadata, None);
+        assert!(result.is_ok(), "encode without OBO should succeed");
+    }
+
+    #[test]
+    fn test_obo_empty_identity_not_active() {
+        let metadata = make_metadata("TestNamespace");
+        let mut obo_map = HashMap::new();
+        obo_map.insert(
+            "TestEvent".to_string(),
+            OboEventConfig {
+                identity: "".to_string(),
+                annotations: Some("some annotations".to_string()),
+            },
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Should succeed even with empty identity");
+    }
+
+    #[test]
+    fn test_obo_whitespace_identity_not_active() {
+        let metadata = make_metadata("TestNamespace");
+        let mut obo_map = HashMap::new();
+        obo_map.insert(
+            "TestEvent".to_string(),
+            OboEventConfig {
+                identity: "   ".to_string(),
+                annotations: None,
+            },
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Should succeed with whitespace identity");
+    }
+
+    #[test]
+    fn test_obo_blank_annotations_suppressed() {
+        let metadata = make_metadata("TestNamespace");
+        let mut obo_map = HashMap::new();
+        obo_map.insert(
+            "TestEvent".to_string(),
+            OboEventConfig {
+                identity: "Microsoft.TestService".to_string(),
+                annotations: Some("   ".to_string()),
+            },
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Should succeed with blank annotations");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_obo_event_config_helpers() {
+        let active = OboEventConfig {
+            identity: "Microsoft.Service".to_string(),
+            annotations: Some("config".to_string()),
+        };
+        assert!(active.is_active());
+        assert_eq!(active.active_annotations(), Some("config"));
+
+        let empty_id = OboEventConfig {
+            identity: "".to_string(),
+            annotations: Some("config".to_string()),
+        };
+        assert!(!empty_id.is_active());
+
+        let whitespace_id = OboEventConfig {
+            identity: "   ".to_string(),
+            annotations: None,
+        };
+        assert!(!whitespace_id.is_active());
+
+        let blank_ann = OboEventConfig {
+            identity: "Microsoft.Service".to_string(),
+            annotations: Some("  ".to_string()),
+        };
+        assert!(blank_ann.is_active());
+        assert_eq!(blank_ann.active_annotations(), None);
+
+        let none_ann = OboEventConfig {
+            identity: "Microsoft.Service".to_string(),
+            annotations: None,
+        };
+        assert_eq!(none_ann.active_annotations(), None);
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -22,6 +22,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
         role_name: "checkout".to_string(),
         role_instance: "instance-1".to_string(),
         msi_resource: None,
+        obo_event_map: None,
     })
     .expect("client should initialize");
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -89,6 +89,7 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        obo_event_map: None,
     };
 
     let geneva_client = GenevaClient::new(config).expect("Failed to create GenevaClient");

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
@@ -105,6 +105,7 @@ async fn main() {
         role_instance,
         auth_method,
         msi_resource,
+        obo_event_map: None,
     };
 
     // GenevaClient::new is synchronous (returns Result), so no await is needed here.

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
@@ -84,6 +84,7 @@ async fn main() {
         role_instance,
         auth_method,
         msi_resource: None, // Not used for Workload Identity
+        obo_event_map: None,
     };
 
     // GenevaClient::new is synchronous (returns Result), so no await is needed here.

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -57,6 +57,7 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        obo_event_map: None,
     };
 
     let geneva_client = GenevaClient::new(config).expect("Failed to create GenevaClient");

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -128,6 +128,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             msi_resource: None,
+            obo_event_map: None,
         };
 
         let client = GenevaClient::new(config).map_err(std::io::Error::other)?;
@@ -147,6 +148,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
 
         let client = GenevaClient::new(config).map_err(std::io::Error::other)?;
@@ -202,6 +204,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
+            obo_event_map: None,
         };
 
         let client = GenevaClient::new(config).map_err(std::io::Error::other)?;


### PR DESCRIPTION
## Changes
   
Add On Behalf Of (OBO) support to the Geneva Uploader, enabling data to be uploaded on behalf of a different service identity.
   
### What OBO does
When a monitoring agent collects data from multiple services, OBO allows tagging each upload with the originating service's identity so Geneva routes/stores data under the correct service.
   
### Changes made
1. **Config**: Added `obo_identity` and `obo_annotations` optional fields to `GenevaClientConfig`
2. **Upload URI**: Appends `&onbehalfid=` and `&onbehalfannotations=` (URL-encoded) query parameters to the GIG upload URI when OBO is configured
3. **Bond schema**: Adds `onbehalfServiceId` and `onbehalfAnnotations` columns to Bond schema via `determine_fields()` and `determine_span_fields()`
4. **Bond row data**: Writes OBO values into each log/span row via `write_row_data()` and `write_span_row_data()`
5. **Backward compatible**: All changes are behind `Option<String>` — no behavior change when OBO is not configured
   
### Reference
OBO logic ported from the C# PipelineAgent (AMACoreAgent) implementation.
   
## Merge requirement checklist
   
* [x] CONTRIBUTING guidelines followed
* [x] Unit tests added/updated (11 new tests: 8 Bond blob tests + 3 URI tests)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed