### PR TITLE
fix: [Geneva uploader] fix CodeQL finding by validating TLS with a generated CA

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -32,9 +32,8 @@ azure_core = "0.29"
 tracing = "0.1"
 
 [features]
-self_signed_certs = [] # Empty by default for security
 mock_auth = [] # Disabled by default. Not to be enabled in the prod release. 
-default = ["self_signed_certs"] # TODO - remove this feature before release
+default = []
 
 [dev-dependencies]
 otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -87,6 +87,8 @@ impl GenevaClient {
             config_major_version: cfg.config_major_version,
             auth_method: cfg.auth_method,
             msi_resource: cfg.msi_resource,
+            #[cfg(test)]
+            test_root_ca_pem: None,
         };
         let config_client =
             Arc::new(GenevaConfigClient::new(config_client_config).map_err(|e| {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -938,7 +938,7 @@ fn extract_endpoint_from_token(token: &str) -> Result<String> {
 fn configure_tls_connector(
     mut builder: native_tls::TlsConnectorBuilder,
     identity: native_tls::Identity,
-    test_root_ca_pem: Option<&[u8]>,
+    _test_root_ca_pem: Option<&[u8]>,
 ) -> Result<native_tls::TlsConnectorBuilder> {
     builder
         .identity(identity)
@@ -946,7 +946,7 @@ fn configure_tls_connector(
         .max_protocol_version(Some(Protocol::Tlsv12));
 
     #[cfg(test)]
-    if let Some(root_ca_pem) = test_root_ca_pem {
+    if let Some(root_ca_pem) = _test_root_ca_pem {
         let root_ca = native_tls::Certificate::from_pem(root_ca_pem)
             .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
         builder.add_root_certificate(root_ca);

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -159,6 +159,8 @@ pub(crate) struct GenevaConfigClientConfig {
     pub(crate) config_major_version: u32,
     pub(crate) auth_method: AuthMethod, // agent_identity and agent_version are hardcoded for now
     pub(crate) msi_resource: Option<String>, // Required when using any Managed Identity variant
+    #[cfg(test)]
+    pub(crate) test_root_ca_pem: Option<Vec<u8>>,
 }
 
 #[allow(dead_code)]
@@ -298,20 +300,26 @@ impl GenevaConfigClient {
                     );
                     GenevaConfigClientError::Certificate(e.to_string())
                 })?;
-                //TODO - use use_native_tls instead of preconfigured_tls once we no longer need self-signed certs
-                // and TLS 1.2 as the exclusive protocol.
-                let tls_connector =
-                    configure_tls_connector(native_tls::TlsConnector::builder(), identity)
-                        .build()
-                        .map_err(|e| {
-                            debug!(
-                                name: "config_client.new.tls_connector_error",
-                                target: "geneva-uploader",
-                                error = %e,
-                                "Failed to build TLS connector"
-                            );
-                            GenevaConfigClientError::Certificate(e.to_string())
-                        })?;
+                // TODO - use use_native_tls instead of preconfigured_tls once we no longer need
+                // TLS 1.2 as the exclusive protocol.
+                let tls_connector = configure_tls_connector(
+                    native_tls::TlsConnector::builder(),
+                    identity,
+                    #[cfg(test)]
+                    config.test_root_ca_pem.as_deref(),
+                    #[cfg(not(test))]
+                    None,
+                )?
+                .build()
+                .map_err(|e| {
+                    debug!(
+                        name: "config_client.new.tls_connector_error",
+                        target: "geneva-uploader",
+                        error = %e,
+                        "Failed to build TLS connector"
+                    );
+                    GenevaConfigClientError::Certificate(e.to_string())
+                })?;
                 client_builder = client_builder.use_preconfigured_tls(tls_connector);
             }
             AuthMethod::WorkloadIdentity { .. } => {
@@ -927,28 +935,22 @@ fn extract_endpoint_from_token(token: &str) -> Result<String> {
     ))
 }
 
-#[cfg(feature = "self_signed_certs")]
 fn configure_tls_connector(
     mut builder: native_tls::TlsConnectorBuilder,
     identity: native_tls::Identity,
-) -> native_tls::TlsConnectorBuilder {
-    eprintln!("WARNING: Self-signed certificates will be accepted. This should only be used in development!");
-    builder
-        .identity(identity)
-        .min_protocol_version(Some(Protocol::Tlsv12))
-        .max_protocol_version(Some(Protocol::Tlsv12))
-        .danger_accept_invalid_certs(true);
-    builder
-}
-
-#[cfg(not(feature = "self_signed_certs"))]
-fn configure_tls_connector(
-    mut builder: native_tls::TlsConnectorBuilder,
-    identity: native_tls::Identity,
-) -> native_tls::TlsConnectorBuilder {
+    test_root_ca_pem: Option<&[u8]>,
+) -> Result<native_tls::TlsConnectorBuilder> {
     builder
         .identity(identity)
         .min_protocol_version(Some(Protocol::Tlsv12))
         .max_protocol_version(Some(Protocol::Tlsv12));
-    builder
+
+    #[cfg(test)]
+    if let Some(root_ca_pem) = test_root_ca_pem {
+        let root_ca = native_tls::Certificate::from_pem(root_ca_pem)
+            .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
+        builder.add_root_certificate(root_ca);
+    }
+
+    Ok(builder)
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -3,10 +3,27 @@ pub(crate) mod client;
 #[cfg(test)]
 mod tests {
     use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfigClientConfig};
-    use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
+    use openssl::{
+        asn1::Asn1Time,
+        bn::{BigNum, MsbOption},
+        hash::MessageDigest,
+        pkcs12::Pkcs12,
+        pkey::{PKey, Private},
+        rsa::Rsa,
+        ssl::{SslAcceptor, SslMethod, SslVersion},
+        x509::{
+            extension::{
+                AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage,
+                SubjectAlternativeName, SubjectKeyIdentifier,
+            },
+            X509NameBuilder, X509,
+        },
+    };
     use rcgen::generate_simple_self_signed;
-    use std::io::Write;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::path::PathBuf;
+    use std::thread;
     use tempfile::NamedTempFile;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -24,6 +41,7 @@ mod tests {
                 resource: "https://monitor.azure.com".to_string(),
             },
             msi_resource: None,
+            test_root_ca_pem: None,
         };
 
         assert_eq!(config.environment, "env");
@@ -70,14 +88,236 @@ mod tests {
         (file, password)
     }
 
-    #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
-    #[tokio::test]
-    async fn test_get_ingestion_info_mocked() {
-        let mock_server = MockServer::start().await;
-        let jwt_endpoint = "https://test.endpoint";
-        let valid_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJFbmRwb2ludCI6Imh0dHBzOi8vdGVzdC5lbmRwb2ludCJ9.signature";
+    struct GeneratedTlsMaterial {
+        client_p12_file: NamedTempFile,
+        client_password: String,
+        root_ca_pem: Vec<u8>,
+        server_cert: X509,
+        server_key: PKey<Private>,
+    }
 
-        let mock_response = serde_json::json!({
+    struct LocalTlsConfigService {
+        endpoint: String,
+        handle: thread::JoinHandle<()>,
+    }
+
+    fn build_pkcs12_der(cert: &X509, key: &PKey<Private>, password: &str) -> Vec<u8> {
+        Pkcs12::builder()
+            .name("alias")
+            .pkey(key)
+            .cert(cert)
+            .build2(password)
+            .unwrap()
+            .to_der()
+            .unwrap()
+    }
+
+    fn build_pkcs12(cert: &X509, key: &PKey<Private>, password: &str) -> NamedTempFile {
+        let pkcs12 = build_pkcs12_der(cert, key, password);
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&pkcs12).unwrap();
+        file
+    }
+
+    fn build_serial_number() -> openssl::asn1::Asn1Integer {
+        let mut serial = BigNum::new().unwrap();
+        serial.rand(159, MsbOption::MAYBE_ZERO, false).unwrap();
+        serial.to_asn1_integer().unwrap()
+    }
+
+    fn build_subject_name(common_name: &str) -> openssl::x509::X509Name {
+        let mut name_builder = X509NameBuilder::new().unwrap();
+        name_builder
+            .append_entry_by_text("CN", common_name)
+            .unwrap();
+        name_builder.build()
+    }
+
+    fn generate_ca() -> (X509, PKey<Private>) {
+        let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let subject_name = build_subject_name("GenevaUploader Test CA");
+
+        let mut builder = X509::builder().unwrap();
+        builder.set_version(2).unwrap();
+        let serial_number = build_serial_number();
+        builder.set_serial_number(&serial_number).unwrap();
+        builder.set_subject_name(&subject_name).unwrap();
+        builder.set_issuer_name(&subject_name).unwrap();
+        builder.set_pubkey(&key).unwrap();
+        let not_before = Asn1Time::days_from_now(0).unwrap();
+        builder.set_not_before(&not_before).unwrap();
+        let not_after = Asn1Time::days_from_now(365).unwrap();
+        builder.set_not_after(&not_after).unwrap();
+        builder
+            .append_extension(BasicConstraints::new().critical().ca().build().unwrap())
+            .unwrap();
+        builder
+            .append_extension(
+                KeyUsage::new()
+                    .critical()
+                    .key_cert_sign()
+                    .crl_sign()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        let subject_key_identifier = SubjectKeyIdentifier::new()
+            .build(&builder.x509v3_context(None, None))
+            .unwrap();
+        builder.append_extension(subject_key_identifier).unwrap();
+        builder.sign(&key, MessageDigest::sha256()).unwrap();
+
+        (builder.build(), key)
+    }
+
+    fn generate_signed_leaf(
+        ca_cert: &X509,
+        ca_key: &PKey<Private>,
+        common_name: &str,
+        subject_alt_name: Option<&str>,
+        for_server: bool,
+    ) -> (X509, PKey<Private>) {
+        let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let subject_name = build_subject_name(common_name);
+
+        let mut builder = X509::builder().unwrap();
+        builder.set_version(2).unwrap();
+        let serial_number = build_serial_number();
+        builder.set_serial_number(&serial_number).unwrap();
+        builder.set_subject_name(&subject_name).unwrap();
+        builder.set_issuer_name(ca_cert.subject_name()).unwrap();
+        builder.set_pubkey(&key).unwrap();
+        let not_before = Asn1Time::days_from_now(0).unwrap();
+        builder.set_not_before(&not_before).unwrap();
+        let not_after = Asn1Time::days_from_now(365).unwrap();
+        builder.set_not_after(&not_after).unwrap();
+        builder
+            .append_extension(BasicConstraints::new().critical().build().unwrap())
+            .unwrap();
+        builder
+            .append_extension(
+                KeyUsage::new()
+                    .critical()
+                    .digital_signature()
+                    .key_encipherment()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        let mut extended_key_usage = ExtendedKeyUsage::new();
+        if for_server {
+            extended_key_usage.server_auth();
+        } else {
+            extended_key_usage.client_auth();
+        }
+        builder
+            .append_extension(extended_key_usage.build().unwrap())
+            .unwrap();
+        let subject_key_identifier = SubjectKeyIdentifier::new()
+            .build(&builder.x509v3_context(Some(ca_cert), None))
+            .unwrap();
+        builder.append_extension(subject_key_identifier).unwrap();
+        let authority_key_identifier = AuthorityKeyIdentifier::new()
+            .keyid(true)
+            .issuer(true)
+            .build(&builder.x509v3_context(Some(ca_cert), None))
+            .unwrap();
+        builder.append_extension(authority_key_identifier).unwrap();
+        if let Some(dns_name) = subject_alt_name {
+            let subject_alt_name = SubjectAlternativeName::new()
+                .dns(dns_name)
+                .build(&builder.x509v3_context(Some(ca_cert), None))
+                .unwrap();
+            builder.append_extension(subject_alt_name).unwrap();
+        }
+        builder.sign(ca_key, MessageDigest::sha256()).unwrap();
+
+        (builder.build(), key)
+    }
+
+    fn generate_ca_signed_tls_material() -> GeneratedTlsMaterial {
+        let (ca_cert, ca_key) = generate_ca();
+        let (server_cert, server_signing_key) =
+            generate_signed_leaf(&ca_cert, &ca_key, "localhost", Some("localhost"), true);
+
+        let (client_cert, client_signing_key) =
+            generate_signed_leaf(&ca_cert, &ca_key, "GenevaUploader Test Client", None, false);
+        let client_password = "test".to_string();
+        let client_p12_file = build_pkcs12(&client_cert, &client_signing_key, &client_password);
+
+        GeneratedTlsMaterial {
+            client_p12_file,
+            client_password,
+            root_ca_pem: ca_cert.to_pem().unwrap(),
+            server_cert,
+            server_key: server_signing_key,
+        }
+    }
+
+    fn spawn_tls_config_service(
+        response_body: String,
+        server_cert: X509,
+        server_key: PKey<Private>,
+    ) -> LocalTlsConfigService {
+        let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls()).unwrap();
+        builder.set_certificate(&server_cert).unwrap();
+        builder.set_private_key(&server_key).unwrap();
+        builder.check_private_key().unwrap();
+        builder
+            .set_min_proto_version(Some(SslVersion::TLS1_2))
+            .unwrap();
+        builder
+            .set_max_proto_version(Some(SslVersion::TLS1_2))
+            .unwrap();
+        let acceptor = builder.build();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!(
+            "https://localhost:{}",
+            listener.local_addr().unwrap().port()
+        );
+        let handle = thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            let Ok(mut tls_stream) = acceptor.accept(socket) else {
+                return;
+            };
+
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let bytes_read = tls_stream.read(&mut buffer).unwrap();
+                if bytes_read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let request = String::from_utf8_lossy(&request);
+            assert!(
+                request.starts_with("GET /api/agent/v3/mockenv/mockacct/MonitoringStorageKeys/?"),
+                "unexpected request: {request}",
+            );
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body,
+            );
+            tls_stream.write_all(response.as_bytes()).unwrap();
+            tls_stream.flush().unwrap();
+        });
+
+        LocalTlsConfigService { endpoint, handle }
+    }
+
+    fn config_service_response() -> (String, &'static str, &'static str) {
+        let jwt_endpoint = "https://test.endpoint";
+        let valid_token =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJFbmRwb2ludCI6Imh0dHBzOi8vdGVzdC5lbmRwb2ludCJ9.signature";
+        let response = serde_json::json!({
             "IngestionGatewayInfo": {
                 "Endpoint": "https://mock.ingestion.endpoint",
                 "AuthToken": valid_token,
@@ -93,11 +333,20 @@ mod tests {
             "TagId": "mock-tag-id"
         });
 
+        (response.to_string(), jwt_endpoint, valid_token)
+    }
+
+    #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
+    #[tokio::test]
+    async fn test_get_ingestion_info_mocked() {
+        let mock_server = MockServer::start().await;
+        let (mock_response, jwt_endpoint, valid_token) = config_service_response();
+
         Mock::given(method("GET"))
             .and(path(
                 "/api/agent/v3/mockenv/mockacct/MonitoringStorageKeys/",
             ))
-            .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
+            .respond_with(ResponseTemplate::new(200).set_body_string(mock_response))
             .mount(&mock_server)
             .await;
 
@@ -115,6 +364,7 @@ mod tests {
                 password,
             },
             msi_resource: None,
+            test_root_ca_pem: None,
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -132,6 +382,94 @@ mod tests {
         assert_eq!(moniker_info.name, "mock-diag-moniker");
         assert_eq!(moniker_info.account_group, "mock-diag-group");
         assert_eq!(token_endpoint, jwt_endpoint);
+    }
+
+    #[tokio::test]
+    async fn test_tls_rejects_untrusted_runtime_generated_ca() {
+        let tls_material = generate_ca_signed_tls_material();
+        let (response_body, _, _) = config_service_response();
+        let tls_server = spawn_tls_config_service(
+            response_body,
+            tls_material.server_cert,
+            tls_material.server_key,
+        );
+
+        let config = GenevaConfigClientConfig {
+            endpoint: tls_server.endpoint,
+            environment: "mockenv".into(),
+            account: "mockacct".into(),
+            namespace: "mockns".into(),
+            region: "mockregion".into(),
+            config_major_version: 1,
+            auth_method: AuthMethod::Certificate {
+                path: PathBuf::from(
+                    tls_material
+                        .client_p12_file
+                        .path()
+                        .to_string_lossy()
+                        .to_string(),
+                ),
+                password: tls_material.client_password,
+            },
+            msi_resource: None,
+            test_root_ca_pem: None,
+        };
+
+        let client = GenevaConfigClient::new(config).unwrap();
+        let result = client.get_ingestion_info().await;
+
+        assert!(matches!(
+            result,
+            Err(crate::config_service::client::GenevaConfigClientError::Http(_))
+        ));
+        tls_server.handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_tls_accepts_runtime_generated_ca() {
+        let tls_material = generate_ca_signed_tls_material();
+        let (response_body, jwt_endpoint, valid_token) = config_service_response();
+        let tls_server = spawn_tls_config_service(
+            response_body,
+            tls_material.server_cert,
+            tls_material.server_key,
+        );
+
+        let config = GenevaConfigClientConfig {
+            endpoint: tls_server.endpoint,
+            environment: "mockenv".into(),
+            account: "mockacct".into(),
+            namespace: "mockns".into(),
+            region: "mockregion".into(),
+            config_major_version: 1,
+            auth_method: AuthMethod::Certificate {
+                path: PathBuf::from(
+                    tls_material
+                        .client_p12_file
+                        .path()
+                        .to_string_lossy()
+                        .to_string(),
+                ),
+                password: tls_material.client_password,
+            },
+            msi_resource: None,
+            test_root_ca_pem: Some(tls_material.root_ca_pem),
+        };
+
+        let client = GenevaConfigClient::new(config).unwrap();
+        let (ingestion_info, moniker_info, token_endpoint) =
+            client.get_ingestion_info().await.unwrap();
+
+        assert_eq!(ingestion_info.endpoint, "https://mock.ingestion.endpoint");
+        assert_eq!(ingestion_info.auth_token, valid_token);
+        assert_eq!(
+            ingestion_info.auth_token_expiry_time,
+            "2030-01-01T00:00:00Z"
+        );
+        assert_eq!(moniker_info.name, "mock-diag-moniker");
+        assert_eq!(moniker_info.account_group, "mock-diag-group");
+        assert_eq!(token_endpoint, jwt_endpoint);
+        tls_server.handle.join().unwrap();
     }
 
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
@@ -161,6 +499,7 @@ mod tests {
                 password,
             },
             msi_resource: None,
+            test_root_ca_pem: None,
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -210,6 +549,7 @@ mod tests {
                 password,
             },
             msi_resource: None,
+            test_root_ca_pem: None,
         };
 
         let client = GenevaConfigClient::new(config).unwrap();
@@ -242,6 +582,7 @@ mod tests {
                 password: "test".to_string(),
             },
             msi_resource: None,
+            test_root_ca_pem: None,
         };
 
         let result = GenevaConfigClient::new(config);
@@ -306,6 +647,7 @@ mod tests {
                 password: cert_password,
             },
             msi_resource: None,
+            test_root_ca_pem: None,
         };
 
         println!("Connecting to real Geneva Config service...");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -34,7 +34,7 @@ mod tests {
     }
 
     #[test]
-    fn test_config_fields() {
+    fn config_fields() {
         let config = GenevaConfigClientConfig {
             endpoint: "https://example.com".to_string(),
             environment: "env".to_string(),
@@ -343,7 +343,7 @@ mod tests {
 
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
-    async fn test_get_ingestion_info_mocked() {
+    async fn get_ingestion_info_mocked() {
         let mock_server = MockServer::start().await;
         let (mock_response, jwt_endpoint, valid_token) = config_service_response();
 
@@ -390,7 +390,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tls_rejects_untrusted_runtime_generated_ca() {
+    async fn tls_rejects_untrusted_runtime_generated_ca() {
         let tls_material = generate_ca_signed_tls_material();
         let (response_body, _, _) = config_service_response();
         let tls_server = spawn_tls_config_service(
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tls_accepts_runtime_generated_ca() {
+    async fn tls_accepts_runtime_generated_ca() {
         let tls_material = generate_ca_signed_tls_material();
         let (response_body, jwt_endpoint, valid_token) = config_service_response();
         let tls_server = spawn_tls_config_service(
@@ -479,7 +479,7 @@ mod tests {
 
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
-    async fn test_error_handling_with_non_success_status() {
+    async fn error_handling_with_non_success_status() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -524,7 +524,7 @@ mod tests {
 
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
-    async fn test_missing_ingestion_gateway_info() {
+    async fn missing_ingestion_gateway_info() {
         let mock_server = MockServer::start().await;
 
         // Response without IngestionGatewayInfo
@@ -574,7 +574,7 @@ mod tests {
 
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
-    async fn test_invalid_certificate_path() {
+    async fn invalid_certificate_path() {
         let config = GenevaConfigClientConfig {
             endpoint: "https://example.com".to_string(),
             environment: "env".to_string(),
@@ -614,12 +614,12 @@ mod tests {
     // export GENEVA_CONFIG_MAJOR_VERSION="config-version"
     // export GENEVA_CERT_PATH="/path/to/your/certificate.p12"
     // export GENEVA_CERT_PASSWORD="your-certificate-password" // Empty string if no password
-    // cargo test test_get_ingestion_info_real_server -- --ignored
+    // cargo test get_ingestion_info_real_server -- --ignored
     // ```
     use std::env;
     #[tokio::test]
     #[ignore] // This test is ignored by default to prevent running in CI pipelines
-    async fn test_get_ingestion_info_real_server() {
+    async fn get_ingestion_info_real_server() {
         // Read configuration from environment variables
         let endpoint =
             env::var("GENEVA_ENDPOINT").expect("GENEVA_ENDPOINT environment variable must be set");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -25,8 +25,13 @@ mod tests {
     use std::path::PathBuf;
     use std::thread;
     use tempfile::NamedTempFile;
+    use uuid::Uuid;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn generate_test_password() -> String {
+        Uuid::new_v4().to_string()
+    }
 
     #[test]
     fn test_config_fields() {
@@ -54,7 +59,7 @@ mod tests {
     }
 
     fn generate_self_signed_p12() -> (NamedTempFile, String) {
-        let password = "test".to_string();
+        let password = generate_test_password();
 
         // This returns a CertifiedKey, not a Certificate
         let cert = generate_simple_self_signed(vec!["localhost".into()]).unwrap();
@@ -242,7 +247,7 @@ mod tests {
 
         let (client_cert, client_signing_key) =
             generate_signed_leaf(&ca_cert, &ca_key, "GenevaUploader Test Client", None, false);
-        let client_password = "test".to_string();
+        let client_password = generate_test_password();
         let client_p12_file = build_pkcs12(&client_cert, &client_signing_key, &client_password);
 
         GeneratedTlsMaterial {
@@ -579,7 +584,7 @@ mod tests {
             config_major_version: 1,
             auth_method: AuthMethod::Certificate {
                 path: PathBuf::from("/nonexistent/path.p12".to_string()),
-                password: "test".to_string(),
+                password: generate_test_password(),
             },
             msi_resource: None,
             test_root_ca_pem: None,

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -65,6 +65,8 @@ mod tests {
                     password: cert_password,
                 },
                 msi_resource: None,
+                #[cfg(test)]
+                test_root_ca_pem: None,
             };
 
             // Build client and uploader


### PR DESCRIPTION
## Summary

This change removes the insecure TLS certificate-validation bypass from the Geneva config client and replaces it with real regression coverage that exercises certificate verification correctly.

## What changed

- removed `danger_accept_invalid_certs(true)` from the config-service client
- removed the `self_signed_certs` default/insecure feature path
- kept the production path on normal certificate validation
- added active tests that:
  - generate a CA at runtime
  - generate CA-signed server and client certificates at runtime
  - verify the handshake succeeds when the generated CA is trusted
  - verify the handshake fails when the generated CA is not trusted

## Why

CodeQL correctly flagged the previous implementation because it disabled TLS certificate validation, which could allow man-in-the-middle attacks. The new approach preserves secure verification and proves the behavior with targeted TLS tests instead of relying on an insecure bypass.

## Verification

- `cargo fmt --all`
- `cargo test -p geneva-uploader test_tls_ -- --nocapture`


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
