### PR TITLE
fix: Switch from md5 crate to RustCrypto/md-5 crate in geneva-uploader

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Replaced `md5` crate with RustCrypto `md-5` crate
+
 ## [0.4.0] - 2025-11-12
 
 ### Changed

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -52,3 +52,6 @@ rand = {version = "0.9"}
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["md-5"] # cargo machete is incorrectly detecting this as an unused crate

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -23,7 +23,7 @@ native-tls = "0.2"
 thiserror = "2.0"
 chrono = "0.4"
 url = "2.2"
-md5 = "0.8.0"
+md-5 = "0.11.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
 # Azure Identity dependencies - using public crates.io versions

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
@@ -1,5 +1,3 @@
-//use md5;
-
 use crate::payload_encoder::bond_encoder::{BondEncodedSchema, FieldDef};
 use chrono::{DateTime, Datelike, Timelike, Utc};
 use std::sync::Arc;
@@ -232,11 +230,12 @@ impl CentralBlob {
 mod tests {
     use super::*;
     use crate::payload_encoder::bond_encoder::{BondEncodedSchema, FieldDef};
+    use md5::{Md5, Digest as _};
     use std::borrow::Cow;
 
     //Helper to calculate MD5 hash, returns [u8;16]
     fn md5_bytes(data: &[u8]) -> [u8; 16] {
-        md5::compute(data).0
+        Md5::digest(data).into()
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/central_blob.rs
@@ -230,7 +230,7 @@ impl CentralBlob {
 mod tests {
     use super::*;
     use crate::payload_encoder::bond_encoder::{BondEncodedSchema, FieldDef};
-    use md5::{Md5, Digest as _};
+    use md5::{Digest as _, Md5};
     use std::borrow::Cow;
 
     //Helper to calculate MD5 hash, returns [u8;16]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/mod.rs
@@ -11,11 +11,12 @@ mod tests {
     };
 
     use crate::payload_encoder::bond_encoder::FieldDef;
+    use md5::{Md5, Digest as _};
 
     fn create_payload(fields: Vec<FieldDef>, row_data: Vec<u8>) -> Vec<u8> {
         let schema_obj = BondEncodedSchema::from_fields("MdsContainer", "testNamespace", &fields);
         let schema_bytes = schema_obj.as_bytes();
-        let schema_md5 = md5::compute(schema_bytes).0;
+        let schema_md5: [u8; 16] = Md5::digest(schema_bytes).into();
         let schema_id = 1u64;
 
         let schema_entry = CentralSchemaEntry {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/mod.rs
@@ -11,7 +11,7 @@ mod tests {
     };
 
     use crate::payload_encoder::bond_encoder::FieldDef;
-    use md5::{Md5, Digest as _};
+    use md5::{Digest as _, Md5};
 
     fn create_payload(fields: Vec<FieldDef>, row_data: Vec<u8>) -> Vec<u8> {
         let schema_obj = BondEncodedSchema::from_fields("MdsContainer", "testNamespace", &fields);

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -129,6 +129,8 @@ struct BatchData {
 
 impl BatchData {
     fn format_schema_ids(&self) -> String {
+        use std::fmt::Write;
+
         if self.schemas.is_empty() {
             return String::new();
         }
@@ -140,7 +142,9 @@ impl BatchData {
                 if i > 0 {
                     acc.push(';');
                 }
-                acc.push_str(&hex::encode(s.md5));
+                for byte in s.md5 {
+                    let _ = write!(acc, "{byte:02x}");
+                }
                 acc
             },
         )
@@ -394,6 +398,7 @@ impl OtlpEncoder {
         // Format schema IDs
         // TODO: This can be shared code with log batch
         let schema_ids_string = {
+            use std::fmt::Write;
             if schemas.is_empty() {
                 String::new()
             } else {
@@ -407,7 +412,9 @@ impl OtlpEncoder {
                             acc.push(';');
                         }
                         // Use stored MD5 hash (already computed when schema was created)
-                        acc.push_str(&hex::encode(s.md5));
+                        for byte in s.md5 {
+                            let _ = write!(acc, "{byte:02x}");
+                        }
                         acc
                     },
                 )

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -8,6 +8,7 @@ use crate::payload_encoder::central_blob::{
 };
 use crate::payload_encoder::lz4_chunked_compression::lz4_chunked_compression;
 use chrono::{TimeZone, Utc};
+use md5::{Md5, Digest as _};
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::trace::v1::Span;
 use otap_df_pdata_views::views::common::{AnyValueView, AttributeView, ValueType};
@@ -128,8 +129,6 @@ struct BatchData {
 
 impl BatchData {
     fn format_schema_ids(&self) -> String {
-        use std::fmt::Write;
-
         if self.schemas.is_empty() {
             return String::new();
         }
@@ -141,7 +140,7 @@ impl BatchData {
                 if i > 0 {
                     acc.push(';');
                 }
-                let _ = write!(&mut acc, "{:x}", md5::Digest(s.md5));
+                acc.push_str(&hex::encode(s.md5));
                 acc
             },
         )
@@ -395,7 +394,6 @@ impl OtlpEncoder {
         // Format schema IDs
         // TODO: This can be shared code with log batch
         let schema_ids_string = {
-            use std::fmt::Write;
             if schemas.is_empty() {
                 String::new()
             } else {
@@ -409,7 +407,7 @@ impl OtlpEncoder {
                             acc.push(';');
                         }
                         // Use stored MD5 hash (already computed when schema was created)
-                        let _ = write!(&mut acc, "{:x}", md5::Digest(s.md5));
+                        acc.push_str(&hex::encode(s.md5));
                         acc
                     },
                 )
@@ -820,7 +818,7 @@ impl OtlpEncoder {
         let schema = BondEncodedSchema::from_fields("OtlpLogRecord", "telemetry", field_info); //TODO - use actual struct name and namespace
 
         let schema_bytes = schema.as_bytes();
-        let schema_md5 = md5::compute(schema_bytes).0;
+        let schema_md5: [u8; 16] = Md5::digest(schema_bytes).into();
 
         CentralSchemaEntry {
             id: schema_id,
@@ -835,7 +833,7 @@ impl OtlpEncoder {
         let schema = BondEncodedSchema::from_fields("OtlpSpanRecord", "telemetry", field_info);
 
         let schema_bytes = schema.as_bytes();
-        let schema_md5 = md5::compute(schema_bytes).0;
+        let schema_md5: [u8; 16] = Md5::digest(schema_bytes).into();
 
         CentralSchemaEntry {
             id: schema_id,

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -8,7 +8,7 @@ use crate::payload_encoder::central_blob::{
 };
 use crate::payload_encoder::lz4_chunked_compression::lz4_chunked_compression;
 use chrono::{TimeZone, Utc};
-use md5::{Md5, Digest as _};
+use md5::{Digest as _, Md5};
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::trace::v1::Span;
 use otap_df_pdata_views::views::common::{AnyValueView, AttributeView, ValueType};


### PR DESCRIPTION
## Changes

This pull request updates the usage of the MD5 hashing library throughout the Geneva uploader codebase, migrating from the `md5` crate to the [RustCrypto](https://github.com/RustCrypto) `md-5` crate.

* Updated the dependency in `Cargo.toml` from `md5 = "0.8.0"` to `md-5 = "0.11.0"`
* Updated formatting of MD5 hashes from using `write!` with `md5::Digest` to using `hex::encode`, simplifying and clarifying the code in `otlp_encoder.rs`.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] ~~Changes in public API reviewed (if applicable)~~ N/A
