### PR TITLE
feat: Update GenevaUploader to surface HTTP status code and Retry-After header from upload error

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `geneva_upload_batch_sync` now takes two additional optional out-parameters: `out_http_status` (`uint16_t*`) and `out_retry_after_secs` (`int64_t*`). Callers should use these to implement retry logic based on the HTTP status code and server-requested backoff delay.
+
 ## [0.4.0] - 2025-11-12
 
 ### Changed

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/log_records_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/log_records_example.c
@@ -240,12 +240,19 @@ int main(void) {
 
     GenevaError first_err = GENEVA_SUCCESS;
     for (size_t i = 0; i < n; i++) {
+        uint16_t http_status = 0;
+        int64_t retry_after_secs = -1;
         GenevaError up_rc = geneva_upload_batch_sync(
-            client, batches, i, err_buf, sizeof(err_buf));
+            client, batches, i, err_buf, sizeof(err_buf),
+            &http_status, &retry_after_secs);
         if (up_rc != GENEVA_SUCCESS) {
             first_err = up_rc;
-            fprintf(stderr, "Batch %zu upload failed (code=%d): %s\n",
-                    i, up_rc, err_buf);
+            fprintf(stderr, "Batch %zu upload failed (code=%d, http_status=%u): %s\n",
+                    i, up_rc, (unsigned)http_status, err_buf);
+            if (retry_after_secs >= 0) {
+                fprintf(stderr, "  Server requested retry after %lld seconds\n",
+                        (long long)retry_after_secs);
+            }
             break;
         }
         printf("  batch %zu uploaded.\n", i);

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/logs_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/logs_example.c
@@ -142,7 +142,7 @@ int main(void) {
     /* Upload synchronously, batch by batch */
     GenevaError first_err = GENEVA_SUCCESS;
     for (size_t i = 0; i < n; i++) {
-        GenevaError r = geneva_upload_batch_sync(client, batches, i, err_buf, sizeof(err_buf));
+        GenevaError r = geneva_upload_batch_sync(client, batches, i, err_buf, sizeof(err_buf), NULL, NULL);
         if (r != GENEVA_SUCCESS) {
             first_err = r;
             printf("Batch %zu upload failed with error %d: %s\n", i, r, err_buf);

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/spans_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/spans_example.c
@@ -142,7 +142,7 @@ int main(void) {
     /* Upload spans synchronously, batch by batch */
     GenevaError first_err = GENEVA_SUCCESS;
     for (size_t i = 0; i < n; i++) {
-        GenevaError r = geneva_upload_batch_sync(client, batches, i, err_buf, sizeof(err_buf));
+        GenevaError r = geneva_upload_batch_sync(client, batches, i, err_buf, sizeof(err_buf), NULL, NULL);
         if (r != GENEVA_SUCCESS) {
             first_err = r;
             printf("Span batch %zu upload failed with error %d: %s\n", i, r, err_buf);

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/include/geneva_ffi.h
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/include/geneva_ffi.h
@@ -178,12 +178,18 @@ size_t geneva_batches_len(const EncodedBatchesHandle* batches);
       - err_msg_out: Optional buffer to receive error message (can be NULL).
                      Message will be NUL-terminated and truncated if buffer too small.
                      Recommended size: >= 256 bytes.
-      - err_msg_len: Size of err_msg_out buffer in bytes (ignored if err_msg_out is NULL) */
+      - err_msg_len: Size of err_msg_out buffer in bytes (ignored if err_msg_out is NULL)
+      - out_http_status: Optional pointer to receive the HTTP status code on failure (can be NULL).
+                         Set to 0 if the failure was not an HTTP status error.
+      - out_retry_after_secs: Optional pointer to receive the Retry-After delay in seconds (can be NULL).
+                              Set to -1 if the server did not send a Retry-After header. */
 GenevaError geneva_upload_batch_sync(GenevaClientHandle* handle,
                                      const EncodedBatchesHandle* batches,
                                      size_t index,
                                      char* err_msg_out,
-                                     size_t err_msg_len);
+                                     size_t err_msg_len,
+                                     uint16_t* out_http_status,
+                                     int64_t* out_retry_after_secs);
 
 
 /* 5) Free the batches handle. */

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -10,7 +10,7 @@ use std::ptr;
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
-use geneva_uploader::client::{EncodedBatch, GenevaClient, GenevaClientConfig};
+use geneva_uploader::client::{EncodedBatch, GenevaClient, GenevaClientConfig, UploadError};
 use geneva_uploader::AuthMethod;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
@@ -686,6 +686,10 @@ pub unsafe extern "C" fn geneva_batches_len(batches: *const EncodedBatchesHandle
 /// - index must be less than the value returned by geneva_batches_len
 /// - err_msg_out: optional buffer to receive error message (can be NULL)
 /// - err_msg_len: size of err_msg_out buffer
+/// - out_http_status: optional pointer to receive the HTTP status code on failure (can be NULL).
+///   Set to 0 if the failure was not an HTTP status error.
+/// - out_retry_after_secs: optional pointer to receive the Retry-After delay in seconds (can be NULL).
+///   Set to -1 if the server did not send a Retry-After header.
 #[no_mangle]
 pub unsafe extern "C" fn geneva_upload_batch_sync(
     handle: *mut GenevaClientHandle,
@@ -693,7 +697,17 @@ pub unsafe extern "C" fn geneva_upload_batch_sync(
     index: usize,
     err_msg_out: *mut c_char,
     err_msg_len: usize,
+    out_http_status: *mut u16,
+    out_retry_after_secs: *mut i64,
 ) -> GenevaError {
+    // Zero out optional output fields
+    if !out_http_status.is_null() {
+        unsafe { *out_http_status = 0 };
+    }
+    if !out_retry_after_secs.is_null() {
+        unsafe { *out_retry_after_secs = -1 };
+    }
+
     // Validate client handle
     match unsafe { validate_handle(handle) } {
         GenevaError::Success => {}
@@ -718,8 +732,26 @@ pub unsafe extern "C" fn geneva_upload_batch_sync(
     let res = runtime().block_on(async move { client.upload_batch(batch).await });
     match res {
         Ok(_) => GenevaError::Success,
-        Err(e) => {
-            unsafe { write_error_if_provided(err_msg_out, err_msg_len, &e) };
+        Err(
+            ref e @ UploadError::HttpStatus {
+                status,
+                ref retry_after,
+                ..
+            },
+        ) => {
+            if !out_http_status.is_null() {
+                unsafe { *out_http_status = status };
+            }
+            if !out_retry_after_secs.is_null() {
+                if let Some(d) = retry_after {
+                    unsafe { *out_retry_after_secs = d.as_secs() as i64 };
+                }
+            }
+            unsafe { write_error_if_provided(err_msg_out, err_msg_len, e) };
+            GenevaError::UploadFailed
+        }
+        Err(ref e) => {
+            unsafe { write_error_if_provided(err_msg_out, err_msg_len, e) };
             GenevaError::UploadFailed
         }
     }
@@ -1542,8 +1574,15 @@ mod tests {
     #[test]
     fn test_upload_batch_sync_with_nulls() {
         unsafe {
-            let result =
-                geneva_upload_batch_sync(ptr::null_mut(), ptr::null(), 0, ptr::null_mut(), 0);
+            let result = geneva_upload_batch_sync(
+                ptr::null_mut(),
+                ptr::null(),
+                0,
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
             assert_eq!(result as u32, GenevaError::NullPointer as u32);
         }
     }
@@ -2070,7 +2109,15 @@ mod tests {
 
         // Attempt upload (ignore return code; we will assert via recorded requests)
         let _ = unsafe {
-            geneva_upload_batch_sync(handle_ptr, batches_ptr as *const _, 0, ptr::null_mut(), 0)
+            geneva_upload_batch_sync(
+                handle_ptr,
+                batches_ptr as *const _,
+                0,
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
         };
 
         // Cleanup: free batches and client
@@ -2203,7 +2250,15 @@ mod tests {
         // Upload all batches
         for i in 0..len {
             let _ = unsafe {
-                geneva_upload_batch_sync(handle_ptr, batches_ptr as *const _, i, ptr::null_mut(), 0)
+                geneva_upload_batch_sync(
+                    handle_ptr,
+                    batches_ptr as *const _,
+                    i,
+                    ptr::null_mut(),
+                    0,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                )
             };
         }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- `GenevaClient::upload_batch` now returns `Result<(), UploadError>` instead of `Result<(), String>`. The new `UploadError` enum exposes the HTTP status code, parsed `Retry-After` duration, and error category so callers can implement retry strategies without string parsing.
 - Replaced `md5` crate with RustCrypto `md-5` crate
 
 ## [0.4.0] - 2025-11-12

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -2,12 +2,16 @@
 
 use crate::config_service::client::{AuthMethod, GenevaConfigClient, GenevaConfigClientConfig};
 // ManagedIdentitySelector removed; no re-export needed.
-use crate::ingestion_service::uploader::{GenevaUploader, GenevaUploaderConfig};
+use crate::ingestion_service::uploader::{
+    GenevaUploader, GenevaUploaderConfig, GenevaUploaderError,
+};
 use crate::payload_encoder::otlp_encoder::MetadataFields;
 use crate::payload_encoder::otlp_encoder::OtlpEncoder;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use otap_df_pdata_views::views::logs::LogsDataView;
+use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, info};
 
 /// Public batch type (already LZ4 chunked compressed).
@@ -36,6 +40,45 @@ pub struct GenevaClientConfig {
     pub msi_resource: Option<String>, // Required for Managed Identity variants
                                       // Add event name/version here if constant, or per-upload if you want them per call.
 }
+
+/// Error type returned by [`GenevaClient::upload_batch`].
+///
+/// Provides enough information for callers to implement retry strategies:
+/// - [`HttpStatus`](UploadError::HttpStatus) carries the HTTP status code and
+///   an optional `Retry-After` duration so callers can distinguish retriable
+///   server errors (429, 5xx) from permanent client errors (4xx).
+/// - [`Transport`](UploadError::Transport) indicates a network-level failure
+///   (timeout, connection refused, DNS) that is typically retriable.
+/// - [`Other`](UploadError::Other) covers config-service or internal errors.
+#[derive(Debug)]
+pub enum UploadError {
+    /// Server returned a non-202 HTTP status.
+    HttpStatus {
+        status: u16,
+        retry_after: Option<Duration>,
+        message: String,
+    },
+    /// Network/transport failure (timeout, connection refused, DNS, etc.)
+    Transport(String),
+    /// Config service or other internal error.
+    Other(String),
+}
+
+impl fmt::Display for UploadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HttpStatus {
+                status, message, ..
+            } => {
+                write!(f, "upload failed with status {status}: {message}")
+            }
+            Self::Transport(msg) => write!(f, "transport error: {msg}"),
+            Self::Other(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for UploadError {}
 
 /// Main user-facing client for Geneva ingestion.
 #[derive(Clone)]
@@ -237,7 +280,7 @@ impl GenevaClient {
 
     /// Upload a single compressed batch.
     /// This allows for granular control over uploads, including custom retry logic for individual batches.
-    pub async fn upload_batch(&self, batch: &EncodedBatch) -> Result<(), String> {
+    pub async fn upload_batch(&self, batch: &EncodedBatch) -> Result<(), UploadError> {
         debug!(
             name: "client.upload_batch",
             target: "geneva-uploader",
@@ -270,7 +313,19 @@ impl GenevaClient {
                     error = %e,
                     "Geneva upload failed"
                 );
-                format!("Geneva upload failed: {e} Event: {}", batch.event_name)
+                match e {
+                    GenevaUploaderError::UploadFailed {
+                        status,
+                        retry_after,
+                        message,
+                    } => UploadError::HttpStatus {
+                        status,
+                        retry_after,
+                        message,
+                    },
+                    GenevaUploaderError::Http(msg) => UploadError::Transport(msg),
+                    other => UploadError::Other(other.to_string()),
+                }
             })
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -24,7 +24,11 @@ pub(crate) enum GenevaUploaderError {
     ConfigClient(String),
     #[allow(dead_code)]
     #[error("Upload failed with status {status}: {message}")]
-    UploadFailed { status: u16, message: String },
+    UploadFailed {
+        status: u16,
+        retry_after: Option<Duration>,
+        message: String,
+    },
     #[allow(dead_code)]
     #[error("Internal error: {0}")]
     InternalError(String),
@@ -265,6 +269,12 @@ impl GenevaUploader {
             .send()
             .await?;
         let status = response.status();
+        let retry_after = response
+            .headers()
+            .get(header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(Duration::from_secs);
         let body = response.text().await?;
 
         if status == reqwest::StatusCode::ACCEPTED {
@@ -298,6 +308,7 @@ impl GenevaUploader {
             );
             Err(GenevaUploaderError::UploadFailed {
                 status: status.as_u16(),
+                retry_after,
                 message: body,
             })
         }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -269,6 +269,10 @@ impl GenevaUploader {
             .send()
             .await?;
         let status = response.status();
+        // TODO: Only the delay-seconds form of Retry-After is parsed here.
+        // The HTTP-date form (e.g., "Fri, 31 Dec 2027 23:59:59 GMT") is
+        // silently ignored and results in None. Add support if the ingestion
+        // backend ever uses that form.
         let retry_after = response
             .headers()
             .get(header::RETRY_AFTER)

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -18,5 +18,5 @@ pub(crate) use ingestion_service::uploader::{
 };
 
 pub use client::EncodedBatch;
-pub use client::{GenevaClient, GenevaClientConfig};
+pub use client::{GenevaClient, GenevaClientConfig, UploadError};
 pub use config_service::client::AuthMethod;

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/logs/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/logs/exporter.rs
@@ -71,7 +71,7 @@ impl opentelemetry_sdk::logs::LogExporter for GenevaExporter {
                 async move { client.upload_batch(&batch).await }
             })
             .buffer_unordered(self.max_concurrent_uploads)
-            .filter_map(|result| async move { result.err() })
+            .filter_map(|result| async move { result.err().map(|e| e.to_string()) })
             .collect()
             .await;
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
@@ -63,7 +63,7 @@ impl SpanExporter for GenevaTraceExporter {
                 async move { client.upload_batch(&batch).await }
             })
             .buffer_unordered(self.max_concurrent_uploads)
-            .filter_map(|result| async move { result.err() })
+            .filter_map(|result| async move { result.err().map(|e| e.to_string()) })
             .collect()
             .await;
 


### PR DESCRIPTION
Fixes #581

## Summary

`upload_batch()` returned `Result<(), String>`, flattening every failure into an opaque message. Callers who wanted to implement retry logic could not distinguish a 429 from a 500 from a DNS failure without parsing the error string. The `Retry-After` response header was discarded entirely.

This PR replaces the `String` error with a structured `UploadError` enum and surfaces the same information through the FFI layer.

## Changes

### Rust API (`geneva-uploader`)

- New public `UploadError` enum with three variants:
  - `HttpStatus { status, retry_after, message }` — server returned non-202
  - `Transport(String)` — network failure (timeout, connection refused, DNS)
  - `Other(String)` — config service or internal error
- `GenevaClient::upload_batch` returns `Result<(), UploadError>` instead of `Result<(), String>`
- `Retry-After` header is now extracted from the HTTP response before consuming the body

### FFI API (`geneva-uploader-ffi`)

- `geneva_upload_batch_sync` gains two optional out-parameters:
  - `out_http_status: *mut u16` (0 if not an HTTP error)
  - `out_retry_after_secs: *mut i64` (-1 if header not present)
- C header and examples updated

### Callers

- `opentelemetry-exporter-geneva` log and trace exporters adapted (`.to_string()` on the error)

## Motivation

Enables callers to implement correct retry strategies:
- Back off on 429/503 using server-provided `Retry-After` delay
- Retry on transient transport errors
- Skip retry on 4xx client errors

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
