### PR TITLE
Add ETW integration tests with live event validation for opentelemetry-etw-logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,21 @@ jobs:
       run: sudo -E $HOME/.cargo/bin/cargo test --manifest-path opentelemetry-user-events-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
     - name: Run user_events integration tests (metrics)
       run: sudo -E $HOME/.cargo/bin/cargo test --manifest-path opentelemetry-user-events-metrics/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+  etw-integration-test:
+    runs-on: windows-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: stable
+    - name: Run ETW integration tests (logs)
+      run: cargo test --manifest-path opentelemetry-etw-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
   lint:
     strategy:
       matrix:

--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -22,6 +22,7 @@ tracelogging_dynamic = "1.2.4"
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
+ferrisetw = "1.2"
 futures-executor = "0.3.31"
 opentelemetry-appender-tracing = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["logs", "trace"] }
@@ -33,6 +34,10 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
     "std",
 ] }
 criterion = "0.8"
+
+[dev-dependencies.windows]
+version = "0.57"
+features = ["Win32_System_Diagnostics_Etw"]
 
 [features]
 spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]

--- a/opentelemetry-etw-logs/src/lib.rs
+++ b/opentelemetry-etw-logs/src/lib.rs
@@ -69,3 +69,470 @@ mod processor;
 
 pub use processor::Processor;
 pub use processor::ProcessorBuilder;
+
+#[cfg(test)]
+mod integration_tests {
+    use std::collections::HashMap;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use ferrisetw::schema_locator::SchemaLocator;
+    use ferrisetw::trace::UserTrace;
+    use ferrisetw::EventRecord;
+
+    use tracelogging_dynamic as tld;
+
+    use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider};
+    use opentelemetry::KeyValue;
+    use opentelemetry_sdk::logs::SdkLoggerProvider;
+    use opentelemetry_sdk::Resource;
+
+    // -----------------------------------------------------------------------
+    // TDH-based ETW event property parser
+    //
+    // ferrisetw's Parser cannot handle TraceLogging struct properties (PartA,
+    // PartB, ext_dt, etc.) — it returns UnimplementedType("structure").
+    // We use TDH APIs directly to enumerate all event properties from the
+    // schema (TRACE_EVENT_INFO) and read their values from the raw data
+    // buffer, producing a flat HashMap keyed by dotted paths like
+    // "PartA.role" or "PartB.body".
+    // -----------------------------------------------------------------------
+
+    /// Captured event with all properties parsed into named fields.
+    struct CapturedEvent {
+        event_name: String,
+        level: u8,
+        keyword: u64,
+        /// Properties keyed by dotted path: "PartA.role", "PartB.body", etc.
+        /// Values stored as raw bytes — use typed accessors to decode.
+        properties: HashMap<String, Vec<u8>>,
+    }
+
+    impl CapturedEvent {
+        fn get_str(&self, key: &str) -> Option<&str> {
+            self.properties
+                .get(key)
+                .and_then(|v| std::str::from_utf8(v).ok())
+        }
+
+        fn get_u16(&self, key: &str) -> Option<u16> {
+            self.properties
+                .get(key)
+                .filter(|v| v.len() >= 2)
+                .map(|v| u16::from_le_bytes([v[0], v[1]]))
+        }
+
+        fn get_i16(&self, key: &str) -> Option<i16> {
+            self.properties
+                .get(key)
+                .filter(|v| v.len() >= 2)
+                .map(|v| i16::from_le_bytes([v[0], v[1]]))
+        }
+
+        fn get_i64(&self, key: &str) -> Option<i64> {
+            self.properties
+                .get(key)
+                .filter(|v| v.len() >= 8)
+                .map(|v| i64::from_le_bytes(v[..8].try_into().unwrap()))
+        }
+
+        fn get_f64(&self, key: &str) -> Option<f64> {
+            self.properties
+                .get(key)
+                .filter(|v| v.len() >= 8)
+                .map(|v| f64::from_le_bytes(v[..8].try_into().unwrap()))
+        }
+
+        fn get_bool(&self, key: &str) -> Option<bool> {
+            self.properties
+                .get(key)
+                .filter(|v| v.len() >= 4)
+                .map(|v| i32::from_le_bytes(v[..4].try_into().unwrap()) != 0)
+        }
+
+        fn has(&self, key: &str) -> bool {
+            self.properties.contains_key(key)
+        }
+    }
+
+    /// Parse all event properties using Windows TDH APIs.
+    ///
+    /// Walks the TRACE_EVENT_INFO property array (which mirrors the
+    /// TraceLogging metadata) and reads leaf values from the user data
+    /// buffer. Struct entries (PartA, PartB, ext_dt, etc.) occupy 0 bytes
+    /// in the data and are used only to build dotted path names.
+    ///
+    /// # Safety
+    /// `er` must point to a valid EVENT_RECORD for the duration of the call.
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn parse_event_properties(
+        er: *const windows::Win32::System::Diagnostics::Etw::EVENT_RECORD,
+    ) -> HashMap<String, Vec<u8>> {
+        use windows::Win32::System::Diagnostics::Etw::{
+            TdhGetEventInformation, EVENT_PROPERTY_INFO, TRACE_EVENT_INFO,
+        };
+
+        let mut result = HashMap::new();
+
+        // Query required buffer size
+        let mut buf_size = 0u32;
+        let _ = TdhGetEventInformation(er, None, None, &mut buf_size);
+        if buf_size == 0 {
+            return result;
+        }
+
+        // Allocate and retrieve TRACE_EVENT_INFO
+        let mut buf = vec![0u8; buf_size as usize];
+        let tei_ptr = buf.as_mut_ptr() as *mut TRACE_EVENT_INFO;
+        let status = TdhGetEventInformation(er, None, Some(tei_ptr), &mut buf_size);
+        if status != 0 {
+            return result;
+        }
+
+        let tei = &*tei_ptr;
+        let top_level_count = tei.TopLevelPropertyCount as usize;
+        let prop_count = tei.PropertyCount as usize;
+
+        let props = std::slice::from_raw_parts(
+            tei.EventPropertyInfoArray.as_ptr(),
+            prop_count,
+        );
+
+        // User data buffer (leaf values only; struct headers are 0 bytes)
+        let data: &[u8] = if (*er).UserData.is_null() || (*er).UserDataLength == 0 {
+            &[]
+        } else {
+            std::slice::from_raw_parts(
+                (*er).UserData as *const u8,
+                (*er).UserDataLength as usize,
+            )
+        };
+
+        let base = buf.as_ptr();
+        let mut data_pos = 0usize;
+
+        // Recursive DFS: TDH lists top-level properties at [0..TopLevelPropertyCount).
+        // Struct entries use StructStartIndex/NumOfStructMembers to reference their
+        // children elsewhere in the array. The data buffer follows DFS order.
+        fn visit(
+            props: &[EVENT_PROPERTY_INFO],
+            indices: &[usize],
+            prefix: &str,
+            base: *const u8,
+            data: &[u8],
+            data_pos: &mut usize,
+            result: &mut HashMap<String, Vec<u8>>,
+        ) {
+            for &idx in indices {
+                let prop = &props[idx];
+                let name = unsafe { read_wide_string_at(base, prop.NameOffset as usize) };
+                let is_struct = (prop.Flags.0 & 0x1) != 0;
+                let full_path = if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}.{name}")
+                };
+
+                if is_struct {
+                    let start = unsafe { prop.Anonymous1.structType.StructStartIndex } as usize;
+                    let count = unsafe { prop.Anonymous1.structType.NumOfStructMembers } as usize;
+                    let child_indices: Vec<usize> = (start..start + count).collect();
+                    visit(props, &child_indices, &full_path, base, data, data_pos, result);
+                } else {
+                    let in_type = unsafe { prop.Anonymous1.nonStructType.InType };
+                    let (value, size) = read_leaf_value(data, *data_pos, in_type);
+                    result.insert(full_path, value);
+                    *data_pos += size;
+                }
+            }
+        }
+
+        let top_level_indices: Vec<usize> = (0..top_level_count).collect();
+        visit(props, &top_level_indices, "", base, data, &mut data_pos, &mut result);
+
+        result
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn read_wide_string_at(base: *const u8, offset: usize) -> String {
+        let ptr = base.add(offset) as *const u16;
+        let mut len = 0;
+        while *ptr.add(len) != 0 {
+            len += 1;
+        }
+        String::from_utf16_lossy(std::slice::from_raw_parts(ptr, len))
+    }
+
+    /// Read a leaf value from the data buffer based on its TDH InType.
+    ///
+    /// Returns (raw_bytes, total_bytes_consumed_from_buffer).
+    fn read_leaf_value(data: &[u8], pos: usize, in_type: u16) -> (Vec<u8>, usize) {
+        match in_type {
+            // Counted types: u16 byte-length prefix + data bytes
+            // 1=UnicodeString, 2=AnsiString, 14=Binary,
+            // 300=CountedString(UTF-16), 301=CountedAnsiString(UTF-8)
+            1 | 2 | 14 | 300 | 301 => {
+                let byte_len =
+                    u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+                (data[pos + 2..pos + 2 + byte_len].to_vec(), 2 + byte_len)
+            }
+            // Fixed-size types
+            3 | 4 => (data[pos..pos + 1].to_vec(), 1),      // Int8 / UInt8
+            5 | 6 => (data[pos..pos + 2].to_vec(), 2),      // Int16 / UInt16
+            7 | 8 | 13 => (data[pos..pos + 4].to_vec(), 4), // Int32 / UInt32 / Bool32
+            9 | 10 => (data[pos..pos + 8].to_vec(), 8),     // Int64 / UInt64
+            11 => (data[pos..pos + 4].to_vec(), 4),          // Float32
+            12 => (data[pos..pos + 8].to_vec(), 8),          // Float64
+            _ => panic!("Unsupported TDH InType: {in_type}"),
+        }
+    }
+
+    /// Start a ferrisetw UserTrace session for the given provider name.
+    fn start_etw_trace(
+        provider_name: &str,
+    ) -> (ferrisetw::trace::UserTrace, mpsc::Receiver<CapturedEvent>) {
+        use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
+
+        let guid_bytes = tld::Guid::from_name(provider_name).to_utf8_bytes();
+        let guid_str = std::str::from_utf8(&guid_bytes).unwrap();
+
+        let (tx, rx) = mpsc::sync_channel::<CapturedEvent>(16);
+
+        let etw_provider = ferrisetw::provider::Provider::by_guid(guid_str)
+            .add_callback(
+                move |record: &EventRecord, _schema_locator: &SchemaLocator| {
+                    let er_ptr = record as *const EventRecord as *const EVENT_RECORD;
+                    let properties = unsafe { parse_event_properties(er_ptr) };
+
+                    let captured = CapturedEvent {
+                        event_name: record.event_name(),
+                        level: record.level(),
+                        keyword: record.keyword(),
+                        properties,
+                    };
+                    let _ = tx.try_send(captured);
+                },
+            )
+            .build();
+
+        let trace = UserTrace::new()
+            .enable(etw_provider)
+            .start_and_process()
+            .unwrap();
+
+        (trace, rx)
+    }
+
+    /// Receive a captured event with the given event name, within a timeout.
+    fn recv_event(rx: &mpsc::Receiver<CapturedEvent>, expected_name: &str) -> CapturedEvent {
+        let deadline = Duration::from_secs(10);
+        let start = std::time::Instant::now();
+        loop {
+            match rx.recv_timeout(deadline.saturating_sub(start.elapsed())) {
+                Ok(evt) if evt.event_name == expected_name => return evt,
+                Ok(_) => continue,
+                Err(_) => panic!(
+                    "Timed out waiting for ETW event with name '{expected_name}'"
+                ),
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests — require admin privileges to start an ETW session.
+    //
+    // Run with:
+    //   cargo test -p opentelemetry-etw-logs --all-features -- --ignored --test-threads=1
+    //
+    // These tests emit logs via the public OTel Logger API
+    // (SdkLoggerProvider → Logger → Processor → ETW) and capture the
+    // resulting ETW events with ferrisetw for payload validation.
+    // -----------------------------------------------------------------------
+
+    /// Full test: validates PartA, PartB, and PartC with multiple attribute types.
+    #[ignore = "Requires admin privileges to start ETW trace session"]
+    #[test]
+    fn integration_test_full() {
+        let provider_name = "OTelETWLogsIntTest_Full";
+
+        let (trace, rx) = start_etw_trace(provider_name);
+
+        let etw_processor = crate::Processor::builder(provider_name)
+            .with_resource_attributes(["resource_attribute1", "resource_attribute2"])
+            .build()
+            .unwrap();
+
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_resource(
+                Resource::builder()
+                    .with_service_name("my_test_service")
+                    .with_attribute(KeyValue::new("service.instance.id", "test_instance_1"))
+                    .with_attribute(KeyValue::new("resource_attribute1", "v1"))
+                    .with_attribute(KeyValue::new("resource_attribute2", "v2"))
+                    .with_attribute(KeyValue::new("resource_attribute3", "v3"))
+                    .build(),
+            )
+            .with_log_processor(etw_processor)
+            .build();
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let logger = logger_provider.logger("test");
+        let mut record = logger.create_log_record();
+        record.set_severity_number(opentelemetry::logs::Severity::Error);
+        record.set_severity_text("ERROR");
+        record.set_body("This is a test message".into());
+        record.add_attribute("event_id", AnyValue::Int(20));
+        record.add_attribute("user_name", AnyValue::String("otel user".into()));
+        record.add_attribute("bool_field", AnyValue::Boolean(true));
+        record.add_attribute("int_field", AnyValue::Int(42));
+        record.add_attribute("double_field", AnyValue::Double(3.14));
+        logger.emit(record);
+
+        let evt = recv_event(&rx, "Log");
+
+        // Event metadata
+        assert_eq!(evt.level, tld::Level::Error.as_int());
+        assert_eq!(evt.keyword, 1);
+
+        // __csver__
+        assert_eq!(evt.get_u16("__csver__"), Some(1024));
+
+        // PartA
+        assert_eq!(evt.get_str("PartA.role"), Some("my_test_service"));
+        assert_eq!(evt.get_str("PartA.roleInstance"), Some("test_instance_1"));
+        assert!(evt.has("PartA.time"));
+
+        // PartC — resource attributes (opted-in only)
+        assert_eq!(evt.get_str("PartC.resource_attribute1"), Some("v1"));
+        assert_eq!(evt.get_str("PartC.resource_attribute2"), Some("v2"));
+        assert!(!evt.has("PartC.resource_attribute3")); // not opted in
+
+        // PartC — log record attributes (order-independent)
+        assert_eq!(evt.get_str("PartC.user_name"), Some("otel user"));
+        assert_eq!(evt.get_bool("PartC.bool_field"), Some(true));
+        assert_eq!(evt.get_i64("PartC.int_field"), Some(42));
+        assert_eq!(evt.get_f64("PartC.double_field"), Some(3.14));
+
+        // PartB
+        assert_eq!(evt.get_str("PartB._typeName"), Some("Log"));
+        assert_eq!(evt.get_str("PartB.body"), Some("This is a test message"));
+        assert_eq!(
+            evt.get_i16("PartB.severityNumber"),
+            Some(opentelemetry::logs::Severity::Error as i16)
+        );
+        assert_eq!(evt.get_str("PartB.severityText"), Some("ERROR"));
+        assert_eq!(evt.get_i64("PartB.eventId"), Some(20));
+
+        trace.stop().unwrap();
+        let _ = logger_provider.shutdown();
+    }
+
+    /// Minimal test: only service.name, body, and severity — no attributes.
+    #[ignore = "Requires admin privileges to start ETW trace session"]
+    #[test]
+    fn integration_test_minimal() {
+        let provider_name = "OTelETWLogsIntTest_Minimal";
+
+        let (trace, rx) = start_etw_trace(provider_name);
+
+        let etw_processor = crate::Processor::builder(provider_name)
+            .build()
+            .unwrap();
+
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_resource(
+                Resource::builder()
+                    .with_service_name("minimal_service")
+                    .build(),
+            )
+            .with_log_processor(etw_processor)
+            .build();
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let logger = logger_provider.logger("test");
+        let mut record = logger.create_log_record();
+        record.set_severity_number(opentelemetry::logs::Severity::Warn);
+        record.set_severity_text("WARN");
+        record.set_body("warn message".into());
+        logger.emit(record);
+
+        let evt = recv_event(&rx, "Log");
+        assert_eq!(evt.level, tld::Level::Warning.as_int());
+
+        // __csver__
+        assert_eq!(evt.get_u16("__csver__"), Some(1024));
+
+        // PartA: only role (no roleInstance)
+        assert_eq!(evt.get_str("PartA.role"), Some("minimal_service"));
+        assert!(!evt.has("PartA.roleInstance"));
+        assert!(evt.has("PartA.time"));
+
+        // No PartC
+
+        // PartB
+        assert_eq!(evt.get_str("PartB._typeName"), Some("Log"));
+        assert_eq!(evt.get_str("PartB.body"), Some("warn message"));
+        assert_eq!(
+            evt.get_i16("PartB.severityNumber"),
+            Some(opentelemetry::logs::Severity::Warn as i16)
+        );
+        assert_eq!(evt.get_str("PartB.severityText"), Some("WARN"));
+
+        trace.stop().unwrap();
+        let _ = logger_provider.shutdown();
+    }
+
+    /// No-resource test: empty resource — validates no role/roleInstance in PartA.
+    #[ignore = "Requires admin privileges to start ETW trace session"]
+    #[test]
+    fn integration_test_no_resource() {
+        let provider_name = "OTelETWLogsIntTest_NoResource";
+
+        let (trace, rx) = start_etw_trace(provider_name);
+
+        let etw_processor = crate::Processor::builder(provider_name)
+            .build()
+            .unwrap();
+
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_resource(Resource::builder_empty().build())
+            .with_log_processor(etw_processor)
+            .build();
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let logger = logger_provider.logger("test");
+        let mut record = logger.create_log_record();
+        record.set_severity_number(opentelemetry::logs::Severity::Error);
+        record.set_severity_text("ERROR");
+        record.set_body("error without resource".into());
+        logger.emit(record);
+
+        let evt = recv_event(&rx, "Log");
+        assert_eq!(evt.level, tld::Level::Error.as_int());
+
+        // __csver__
+        assert_eq!(evt.get_u16("__csver__"), Some(1024));
+
+        // PartA: no role or roleInstance
+        assert!(!evt.has("PartA.role"));
+        assert!(!evt.has("PartA.roleInstance"));
+        assert!(evt.has("PartA.time"));
+
+        // No PartC
+
+        // PartB
+        assert_eq!(evt.get_str("PartB._typeName"), Some("Log"));
+        assert_eq!(evt.get_str("PartB.body"), Some("error without resource"));
+        assert_eq!(
+            evt.get_i16("PartB.severityNumber"),
+            Some(opentelemetry::logs::Severity::Error as i16)
+        );
+        assert_eq!(evt.get_str("PartB.severityText"), Some("ERROR"));
+
+        trace.stop().unwrap();
+        let _ = logger_provider.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary

Adds integration tests for `opentelemetry-etw-logs` that validate the actual ETW event payload end-to-end: logs are emitted via the public OTel Logger API, flow through the ETW processor, and are captured by a live ETW listener for full payload validation.

This is similar to the existing `user-events-integration-test` CI job that validates `opentelemetry-user-events-logs` and `opentelemetry-user-events-trace` on Linux using `perf` + `perf-decode`.

> **Note:** The current test infrastructure uses `ferrisetw` + raw TDH API parsing as a temporary approach. A more robust ETW listener is planned as part of the OTel Arrow project. Once that ships, we will swap the test infrastructure to use it instead.

## Changes

### `opentelemetry-etw-logs/Cargo.toml`
- Added `ferrisetw = "1.2"` dev-dependency (ETW consumer for capturing events)
- Added `windows = "0.57"` dev-dependency with `Win32_System_Diagnostics_Etw` (TDH APIs for parsing event properties from `TRACE_EVENT_INFO`)

### `opentelemetry-etw-logs/src/lib.rs`
Three integration tests using the public OTel Logger API (`SdkLoggerProvider` -> `Logger` -> `Processor` -> ETW -> ferrisetw listener):

- **`integration_test_full`** — Validates PartA (`role`, `roleInstance`, `time`), PartB (`_typeName`, `body`, `severityNumber`, `severityText`, `eventId`), and PartC (opted-in resource attributes, log record attributes with String/Bool/Int/Double types, event_id extraction)
- **`integration_test_minimal`** — Only `service.name`, body, severity; no attributes
- **`integration_test_no_resource`** — Empty resource; confirms no `role`/`roleInstance` in PartA

Test infrastructure:
- TDH-based property parser (`TdhGetEventInformation`) that walks the `TRACE_EVENT_INFO` property tree using `StructStartIndex`/`NumOfStructMembers` to produce a flat `HashMap<String, Vec<u8>>` keyed by dotted paths (e.g. `PartA.role`, `PartB.body`, `PartC.user_name`)
- Order-independent, type-safe assertions via typed accessors (`get_str`, `get_i16`, `get_i64`, `get_f64`, `get_bool`)

### `.github/workflows/ci.yml`
- Added `etw-integration-test` job on `windows-latest`

## How to run locally

Requires admin privileges (ETW trace sessions need elevation):

```powershell
cargo test -p opentelemetry-etw-logs --all-features -- --ignored --test-threads=1
```
