### PR TITLE
fix: wrap role/roleInstance in ext_cloud struct in PartA (fixes #584)

### DIFF
--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## vNext
 
 - Fixed a panic that would trigger if logging from inside a blocked on async block due to nested `block_on()`s.
+- **Bug fix**: `service.name` and `service.instance.id` resource attributes are
+  now correctly wrapped in an `ext_cloud` struct in PartA
+  (`PartA.ext_cloud.role`, `PartA.ext_cloud.roleInstance`), matching the Common
+  Schema convention used by the user-events exporters. Previously these were
+  emitted as flat fields directly in PartA (`PartA.role`,
+  `PartA.roleInstance`). **Note**: if you have downstream consumers that relied
+  on the previous flat field layout, this is a breaking change for those
+  consumers.
+- Added integration tests that validate the ETW event payload end-to-end using
+  a live ETW listener.
 
 ## v0.10.1
 

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -11,8 +11,6 @@
   `PartA.roleInstance`). **Note**: if you have downstream consumers that relied
   on the previous flat field layout, this is a breaking change for those
   consumers.
-- Added integration tests that validate the ETW event payload end-to-end using
-  a live ETW listener.
 
 ## v0.10.1
 

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## vNext
 
 - Fixed a panic that would trigger if logging from inside a blocked on async block due to nested `block_on()`s.
-- **Bug fix**: `service.name` and `service.instance.id` resource attributes are
-  now correctly wrapped in an `ext_cloud` struct in PartA
-  (`PartA.ext_cloud.role`, `PartA.ext_cloud.roleInstance`), matching the Common
-  Schema convention used by the user-events exporters. Previously these were
-  emitted as flat fields directly in PartA (`PartA.role`,
-  `PartA.roleInstance`). **Note**: if you have downstream consumers that relied
-  on the previous flat field layout, this is a breaking change for those
-  consumers.
+- **Bug fix**: `service.name` and `service.instance.id` resource attributes
+  were previously emitted as bare fields in PartA (`PartA.role`,
+  `PartA.roleInstance`) without the required `ext_cloud` namespace. They are
+  now emitted inside a nested `ext_cloud` struct (`PartA.ext_cloud.role`,
+  `PartA.ext_cloud.roleInstance`), consistent with how `ext_dt` is already
+  structured in this crate and following the Common Schema TLD mapping spec's
+  preferred nested struct convention. **Note**: downstream consumers that
+  looked for the bare field names (`role`, `roleInstance`) in PartA will need
+  to be updated.
 
 ## v0.10.1
 

--- a/opentelemetry-etw-logs/src/exporter/part_a.rs
+++ b/opentelemetry-etw-logs/src/exporter/part_a.rs
@@ -62,21 +62,25 @@ fn populate_part_a_from_context(
 }
 
 fn get_resource_count(resource: &super::Resource) -> u8 {
-    resource.cloud_role.is_some() as u8 + resource.cloud_role_instance.is_some() as u8
+    (resource.cloud_role.is_some() || resource.cloud_role_instance.is_some()) as u8
 }
 
 fn populate_resource(resource: &super::Resource, event: &mut tld::EventBuilder, field_tag: u32) {
-    if let Some(cloud_role) = &resource.cloud_role {
-        event.add_str8("role", cloud_role, tld::OutType::Default, field_tag);
-    }
-
-    if let Some(cloud_role_instance) = &resource.cloud_role_instance {
-        event.add_str8(
-            "roleInstance",
-            cloud_role_instance,
-            tld::OutType::Default,
-            field_tag,
-        );
+    let ext_cloud_count =
+        resource.cloud_role.is_some() as u8 + resource.cloud_role_instance.is_some() as u8;
+    if ext_cloud_count > 0 {
+        event.add_struct("ext_cloud", ext_cloud_count, field_tag);
+        if let Some(cloud_role) = &resource.cloud_role {
+            event.add_str8("role", cloud_role, tld::OutType::Default, field_tag);
+        }
+        if let Some(cloud_role_instance) = &resource.cloud_role_instance {
+            event.add_str8(
+                "roleInstance",
+                cloud_role_instance,
+                tld::OutType::Default,
+                field_tag,
+            );
+        }
     }
 }
 

--- a/opentelemetry-etw-logs/src/exporter/part_a.rs
+++ b/opentelemetry-etw-logs/src/exporter/part_a.rs
@@ -24,7 +24,7 @@ fn populate_part_a_from_record(
 ) {
     const COUNT_TIME: u8 = 1u8;
 
-    let field_count = COUNT_TIME + get_resource_count(resource);
+    let field_count = COUNT_TIME + has_ext_cloud(resource);
 
     event.add_struct("PartA", field_count, field_tag);
 
@@ -39,7 +39,7 @@ fn populate_part_a_from_context(
 ) {
     const COUNT_TIME: u8 = 1u8;
     const COUNT_EXT_DT: u8 = 1u8;
-    let field_count = COUNT_TIME + COUNT_EXT_DT + get_resource_count(resource);
+    let field_count = COUNT_TIME + COUNT_EXT_DT + has_ext_cloud(resource);
 
     event.add_struct("PartA", field_count, field_tag);
 
@@ -61,7 +61,7 @@ fn populate_part_a_from_context(
     populate_resource(resource, event, field_tag);
 }
 
-fn get_resource_count(resource: &super::Resource) -> u8 {
+fn has_ext_cloud(resource: &super::Resource) -> u8 {
     (resource.cloud_role.is_some() || resource.cloud_role_instance.is_some()) as u8
 }
 

--- a/opentelemetry-etw-logs/src/lib.rs
+++ b/opentelemetry-etw-logs/src/lib.rs
@@ -95,7 +95,7 @@ mod integration_tests {
     // We use TDH APIs directly to enumerate all event properties from the
     // schema (TRACE_EVENT_INFO) and read their values from the raw data
     // buffer, producing a flat HashMap keyed by dotted paths like
-    // "PartA.role" or "PartB.body".
+    // "PartA.ext_cloud.role" or "PartB.body".
     // -----------------------------------------------------------------------
 
     /// Captured event with all properties parsed into named fields.
@@ -103,7 +103,7 @@ mod integration_tests {
         event_name: String,
         level: u8,
         keyword: u64,
-        /// Properties keyed by dotted path: "PartA.role", "PartB.body", etc.
+        /// Properties keyed by dotted path: "PartA.ext_cloud.role", "PartB.body", etc.
         /// Values stored as raw bytes — use typed accessors to decode.
         properties: HashMap<String, Vec<u8>>,
     }
@@ -406,8 +406,11 @@ mod integration_tests {
         assert_eq!(evt.get_u16("__csver__"), Some(1024));
 
         // PartA
-        assert_eq!(evt.get_str("PartA.role"), Some("my_test_service"));
-        assert_eq!(evt.get_str("PartA.roleInstance"), Some("test_instance_1"));
+        assert_eq!(evt.get_str("PartA.ext_cloud.role"), Some("my_test_service"));
+        assert_eq!(
+            evt.get_str("PartA.ext_cloud.roleInstance"),
+            Some("test_instance_1")
+        );
         assert!(evt.has("PartA.time"));
 
         // PartC — resource attributes (opted-in only)
@@ -470,8 +473,8 @@ mod integration_tests {
         assert_eq!(evt.get_u16("__csver__"), Some(1024));
 
         // PartA: only role (no roleInstance)
-        assert_eq!(evt.get_str("PartA.role"), Some("minimal_service"));
-        assert!(!evt.has("PartA.roleInstance"));
+        assert_eq!(evt.get_str("PartA.ext_cloud.role"), Some("minimal_service"));
+        assert!(!evt.has("PartA.ext_cloud.roleInstance"));
         assert!(evt.has("PartA.time"));
 
         // No PartC
@@ -520,8 +523,8 @@ mod integration_tests {
         assert_eq!(evt.get_u16("__csver__"), Some(1024));
 
         // PartA: no role or roleInstance
-        assert!(!evt.has("PartA.role"));
-        assert!(!evt.has("PartA.roleInstance"));
+        assert!(!evt.has("PartA.ext_cloud.role"));
+        assert!(!evt.has("PartA.ext_cloud.roleInstance"));
         assert!(evt.has("PartA.time"));
 
         // No PartC


### PR DESCRIPTION
Fixes #584

## Summary

Wrap `service.name` and `service.instance.id` resource attributes inside an `ext_cloud` struct in PartA, matching the Common Schema convention used by the user-events exporters.

## Before (bug)

```
PartA.role = "my-service"
PartA.roleInstance = "instance-1"
```

## After (fix)

```
PartA.ext_cloud.role = "my-service"
PartA.ext_cloud.roleInstance = "instance-1"
```

## Changes

### `opentelemetry-etw-logs/src/exporter/part_a.rs`
- **`get_resource_count`**: Returns 1 if either `cloud_role` or `cloud_role_instance` is present (the `ext_cloud` struct counts as one field in PartA), 0 otherwise.
- **`populate_resource`**: Wraps `role`/`roleInstance` in an `event.add_struct("ext_cloud", ...)` call, following the same pattern as `ext_dt` for `traceId`/`spanId`.

### `opentelemetry-etw-logs/src/lib.rs`
- Updated integration test assertions from `PartA.role` → `PartA.ext_cloud.role` and `PartA.roleInstance` → `PartA.ext_cloud.roleInstance`.
