### PR TITLE
fix: remove block_on from user-events-logs processor (fixes #515)

### DIFF
--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- Removed `futures-executor` dependency and `LogExporter` trait implementation.
+  The processor now calls the exporter synchronously, avoiding potential panics
+  from nested `block_on()` calls (e.g. when logging from inside an async
+  runtime).
+
 ## v0.16.0
 
 Released 2026-May-13

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -16,7 +16,6 @@ eventheader_dynamic = "0.5.0"
 opentelemetry = { workspace = true, features = ["logs"] }
 opentelemetry_sdk = { workspace = true, features = ["logs"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-futures-executor = "0.3"
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { workspace = true }

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -423,21 +423,11 @@ where
     }
 }
 
-impl<C> opentelemetry_sdk::logs::LogExporter for UserEventsExporter<C>
+impl<C> UserEventsExporter<C>
 where
     C: EventNameCallback,
 {
-    async fn export(&self, batch: opentelemetry_sdk::logs::LogBatch<'_>) -> OTelSdkResult {
-        if let Some((record, instrumentation)) = batch.iter().next() {
-            self.export_log_data(record, instrumentation)
-        } else {
-            Err(OTelSdkError::InternalFailure(
-                "Batch is expected to have one and only one record, but none was found".to_string(),
-            ))
-        }
-    }
-
-    fn shutdown(&self) -> OTelSdkResult {
+    pub(crate) fn shutdown(&self) -> OTelSdkResult {
         // The explicit unregister() is done in shutdown()
         // as it may not be possible to unregister during Drop
         // as Loggers are typically *not* dropped.
@@ -451,7 +441,12 @@ where
         }
     }
 
-    fn event_enabled(&self, level: Severity, _target: &str, _name: Option<&str>) -> bool {
+    pub(crate) fn event_enabled(
+        &self,
+        level: Severity,
+        _target: &str,
+        _name: Option<&str>,
+    ) -> bool {
         // EventSets are stored in the same order as their int representation,
         // so we can use the level as index to the Vec.
         let level = get_severity_level(level);
@@ -461,7 +456,7 @@ where
         }
     }
 
-    fn set_resource(&mut self, resource: &Resource) {
+    pub(crate) fn set_resource(&mut self, resource: &Resource) {
         // add attributes from resource to the attributes_from_resource
         for (key, value) in resource.iter() {
             // special handling for cloud role and instance

--- a/opentelemetry-user-events-logs/src/logs/processor.rs
+++ b/opentelemetry-user-events-logs/src/logs/processor.rs
@@ -1,10 +1,6 @@
 use opentelemetry::InstrumentationScope;
-use opentelemetry_sdk::logs::LogExporter;
 use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::{
-    error::OTelSdkResult,
-    logs::{LogBatch, SdkLogRecord},
-};
+use opentelemetry_sdk::{error::OTelSdkResult, logs::SdkLogRecord};
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::error::Error;
@@ -46,13 +42,7 @@ where
     C: EventNameCallback,
 {
     fn emit(&self, record: &mut SdkLogRecord, scope: &InstrumentationScope) {
-        let log_tuple = &[(record as &SdkLogRecord, scope)];
-        // TODO: Using futures_executor::block_on can make the code non reentrant safe
-        // if that crate starts emitting logs that are bridged to OTel.
-        // TODO: How to log if export() returns Err? Maybe a metric?
-        // Alternately, we can enter a SuppressionContext and log the error
-        // if the result is an error (once upstream ships SuppressionContext).
-        let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
+        let _ = self.exporter.export_log_data(record, scope);
     }
 
     // Nothing to flush as this processor does not buffer


### PR DESCRIPTION
Fixes #515

## Summary

Remove `futures_executor::block_on` from the user-events-logs processor, making it fully synchronous. This is the same change that PR #514 applied to `opentelemetry-etw-logs`.

## Motivation

The `Processor::emit()` was calling `futures_executor::block_on(self.exporter.export(...))` to invoke the async `LogExporter` trait. This can panic if called from inside another `block_on()` (nested runtime), e.g. when logging from within an async runtime context.

Since the exporter is inherently synchronous (writes directly to a user_events tracepoint with no I/O), the async wrapper was unnecessary.

## Changes

### `opentelemetry-user-events-logs/src/logs/exporter.rs`
- Removed `impl LogExporter for UserEventsExporter` block
- Moved `shutdown()`, `event_enabled()`, and `set_resource()` to direct `pub(crate)` methods on `UserEventsExporter` (alongside the existing `export_log_data()`)

### `opentelemetry-user-events-logs/src/logs/processor.rs`
- `emit()` now calls `self.exporter.export_log_data(record, scope)` directly instead of `block_on(self.exporter.export(...))`
- Removed `LogExporter`, `LogBatch`, and `futures_executor` imports

### `opentelemetry-user-events-logs/Cargo.toml`
- Removed `futures-executor` from dependencies

### `opentelemetry-user-events-logs/CHANGELOG.md`
- Added entry documenting the change
