### PR TITLE
feat: [Geneva uploader]   Support managed identity auth by resource ID

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -634,10 +634,10 @@ impl GenevaConfigClient {
             return Ok(None);
         }
 
-        // azure_identity 0.29 detects IDENTITY_ENDPOINT + IDENTITY_HEADER as App Service
-        // and rejects UserAssignedId::ResourceId. Local MSI endpoints used by some
-        // environments, such as Azure Arc extensions, support resource ID selection
-        // through msi_res_id.
+        // `azure_identity` 0.29 treats IDENTITY_ENDPOINT + IDENTITY_HEADER as the App Service
+        // local endpoint and does not forward `UserAssignedId::ResourceId` as `msi_res_id`.
+        // Selecting a user-assigned identity by Azure resource ID against this local endpoint
+        // requires sending `msi_res_id` directly, so this branch issues the request explicitly.
         let msi_resource = resource.trim_end_matches("/.default");
         let response = self
             .http_client

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1,4 +1,4 @@
-// Geneva Config Client with TLS (PKCS#12) and Azure Workload Identity support TODO: Azure Arc support
+// Geneva Config Client with TLS (PKCS#12), Azure Workload Identity, and Managed Identity support.
 
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::{
@@ -203,6 +203,11 @@ struct GenevaResponse {
     // Keep tag_id as it might be used for validation
     #[serde(rename = "TagId")]
     tag_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MsiTokenResponse {
+    access_token: String,
 }
 
 #[allow(dead_code)]
@@ -537,6 +542,17 @@ impl GenevaConfigClient {
             scope_candidates.push(format!("{base}/"));
         }
 
+        if let AuthMethod::UserManagedIdentityByResourceId { resource_id } =
+            &self.config.auth_method
+        {
+            if let Some(token) = self
+                .try_get_local_managed_identity_token_by_resource_id(resource, resource_id)
+                .await?
+            {
+                return Ok(token);
+            }
+        }
+
         let user_assigned_id = match &self.config.auth_method {
             AuthMethod::SystemManagedIdentity => None,
             AuthMethod::UserManagedIdentity { client_id } => {
@@ -598,6 +614,91 @@ impl GenevaConfigClient {
             "Managed Identity token acquisition failed. Scopes tried: {scopes}. Last error: {detail}. IMDS fallback intentionally disabled.",
             scopes = scope_candidates.join(", ")
         )))
+    }
+
+    async fn try_get_local_managed_identity_token_by_resource_id(
+        &self,
+        resource: &str,
+        resource_id: &str,
+    ) -> Result<Option<String>> {
+        let Ok(identity_endpoint) = std::env::var("IDENTITY_ENDPOINT") else {
+            return Ok(None);
+        };
+        if identity_endpoint.is_empty() {
+            return Ok(None);
+        }
+        let Ok(identity_header) = std::env::var("IDENTITY_HEADER") else {
+            return Ok(None);
+        };
+        if identity_header.is_empty() {
+            return Ok(None);
+        }
+
+        // azure_identity 0.29 detects IDENTITY_ENDPOINT + IDENTITY_HEADER as App Service
+        // and rejects UserAssignedId::ResourceId. Local MSI endpoints used by some
+        // environments, such as Azure Arc extensions, support resource ID selection
+        // through msi_res_id.
+        let msi_resource = resource.trim_end_matches("/.default");
+        let response = self
+            .http_client
+            .get(identity_endpoint)
+            .header("Metadata", "true")
+            .header("X-IDENTITY-HEADER", identity_header)
+            .query(&[
+                ("api-version", "2018-02-01"),
+                ("resource", msi_resource),
+                ("msi_res_id", resource_id),
+            ])
+            .send()
+            .await
+            .map_err(|e| {
+                debug!(
+                    name: "config_client.get_local_msi_token.http_error",
+                    target: "geneva-uploader",
+                    error = %e,
+                    "Local Managed Identity token request failed"
+                );
+                GenevaConfigClientError::Http(e)
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            debug!(
+                name: "config_client.get_local_msi_token.failed",
+                target: "geneva-uploader",
+                status = %status.as_u16(),
+                "Local Managed Identity token request returned non-success status"
+            );
+            return Err(GenevaConfigClientError::MsiAuth(format!(
+                "Local Managed Identity token request failed with status {status}"
+            )));
+        }
+
+        let body = response.text().await.map_err(|e| {
+            debug!(
+                name: "config_client.get_local_msi_token.read_error",
+                target: "geneva-uploader",
+                error = %e,
+                "Failed to read Local Managed Identity token response"
+            );
+            GenevaConfigClientError::Http(e)
+        })?;
+        let token_response: MsiTokenResponse = serde_json::from_str(&body).map_err(|e| {
+            debug!(
+                name: "config_client.get_local_msi_token.parse_error",
+                target: "geneva-uploader",
+                error = %e,
+                "Failed to parse Local Managed Identity token response"
+            );
+            GenevaConfigClientError::SerdeJson(e)
+        })?;
+
+        info!(
+            name: "config_client.get_local_msi_token.success",
+            target: "geneva-uploader",
+            "Successfully acquired Local Managed Identity token"
+        );
+        Ok(Some(token_response.access_token))
     }
 
     /// Retrieves ingestion gateway information from the Geneva Config Service.

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -634,6 +634,8 @@ impl GenevaConfigClient {
 
         // `azure_identity` 0.29 treats IDENTITY_ENDPOINT + IDENTITY_HEADER as the App Service
         // local endpoint and does not forward `UserAssignedId::ResourceId` as `msi_res_id`.
+        // See https://github.com/Azure/azure-sdk-for-rust/issues/2407.
+        // TODO: Re-evaluate this workaround when upgrading azure_identity beyond 0.29.
         // Selecting a user-assigned identity by Azure resource ID against this local endpoint
         // requires sending `msi_res_id` directly, so this branch issues the request explicitly.
         let msi_resource = resource.trim_end_matches("/.default");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1,9 +1,9 @@
-// Geneva Config Client with TLS (PKCS#12), Azure Workload Identity, and Managed Identity support.
+// Geneva Config Client with TLS (PKCS#12), Azure Workload Identity, and Azure Managed Identity support, including local endpoint resource-ID flow.
 
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::{
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
-    Client,
+    Client, Url,
 };
 use serde::Deserialize;
 use std::time::Duration;
@@ -542,17 +542,6 @@ impl GenevaConfigClient {
             scope_candidates.push(format!("{base}/"));
         }
 
-        if let AuthMethod::UserManagedIdentityByResourceId { resource_id } =
-            &self.config.auth_method
-        {
-            if let Some(token) = self
-                .try_get_local_managed_identity_token_by_resource_id(resource, resource_id)
-                .await?
-            {
-                return Ok(token);
-            }
-        }
-
         let user_assigned_id = match &self.config.auth_method {
             AuthMethod::SystemManagedIdentity => None,
             AuthMethod::UserManagedIdentity { client_id } => {
@@ -562,6 +551,12 @@ impl GenevaConfigClient {
                 Some(UserAssignedId::ObjectId(object_id.clone()))
             }
             AuthMethod::UserManagedIdentityByResourceId { resource_id } => {
+                if let Some(token) = self
+                    .try_get_local_managed_identity_token_by_resource_id(resource, resource_id)
+                    .await?
+                {
+                    return Ok(token);
+                }
                 Some(UserAssignedId::ResourceId(resource_id.clone()))
             }
             _ => {
@@ -633,6 +628,9 @@ impl GenevaConfigClient {
         if identity_header.is_empty() {
             return Ok(None);
         }
+        let identity_endpoint_url = Url::parse(&identity_endpoint).map_err(|e| {
+            GenevaConfigClientError::MsiAuth(format!("IDENTITY_ENDPOINT is not a valid URL: {e}"))
+        })?;
 
         // `azure_identity` 0.29 treats IDENTITY_ENDPOINT + IDENTITY_HEADER as the App Service
         // local endpoint and does not forward `UserAssignedId::ResourceId` as `msi_res_id`.
@@ -641,7 +639,7 @@ impl GenevaConfigClient {
         let msi_resource = resource.trim_end_matches("/.default");
         let response = self
             .http_client
-            .get(identity_endpoint)
+            .get(identity_endpoint_url)
             .header("Metadata", "true")
             .header("X-IDENTITY-HEADER", identity_header)
             .query(&[

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -552,7 +552,7 @@ impl GenevaConfigClient {
             }
             AuthMethod::UserManagedIdentityByResourceId { resource_id } => {
                 if let Some(token) = self
-                    .try_get_local_managed_identity_token_by_resource_id(resource, resource_id)
+                    .try_get_local_managed_identity_token_by_resource_id(base, resource_id)
                     .await?
                 {
                     return Ok(token);
@@ -613,7 +613,7 @@ impl GenevaConfigClient {
 
     async fn try_get_local_managed_identity_token_by_resource_id(
         &self,
-        resource: &str,
+        msi_resource: &str,
         resource_id: &str,
     ) -> Result<Option<String>> {
         let Ok(identity_endpoint) = std::env::var("IDENTITY_ENDPOINT") else {
@@ -638,7 +638,6 @@ impl GenevaConfigClient {
         // TODO: Re-evaluate this workaround when upgrading azure_identity beyond 0.29.
         // Selecting a user-assigned identity by Azure resource ID against this local endpoint
         // requires sending `msi_res_id` directly, so this branch issues the request explicitly.
-        let msi_resource = resource.trim_end_matches("/.default");
         let response = self
             .http_client
             .get(identity_endpoint_url)
@@ -663,14 +662,24 @@ impl GenevaConfigClient {
 
         if !response.status().is_success() {
             let status = response.status();
+            let body = response.text().await.map_err(|e| {
+                debug!(
+                    name: "config_client.get_local_msi_token.read_error",
+                    target: "geneva-uploader",
+                    error = %e,
+                    "Failed to read Local Managed Identity token error response"
+                );
+                GenevaConfigClientError::Http(e)
+            })?;
             debug!(
                 name: "config_client.get_local_msi_token.failed",
                 target: "geneva-uploader",
                 status = %status.as_u16(),
+                body = %body,
                 "Local Managed Identity token request returned non-success status"
             );
             return Err(GenevaConfigClientError::MsiAuth(format!(
-                "Local Managed Identity token request failed with status {status}"
+                "Local Managed Identity token request failed with status {status}: {body}"
             )));
         }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -23,11 +23,47 @@ mod tests {
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::path::PathBuf;
+    use std::sync::Mutex;
     use std::thread;
     use tempfile::NamedTempFile;
     use uuid::Uuid;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Tests that mutate IDENTITY_ENDPOINT / IDENTITY_HEADER must hold this lock.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvVarGuard {
+        fn set(vars: &[(&'static str, String)]) -> Self {
+            let previous = vars
+                .iter()
+                .map(|(name, _)| (*name, std::env::var(name).ok()))
+                .collect();
+            for (name, value) in vars {
+                // Tests serialize environment mutations with ENV_LOCK.
+                unsafe { std::env::set_var(name, value) };
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.previous.drain(..) {
+                if let Some(value) = value {
+                    // Tests serialize environment mutations with ENV_LOCK.
+                    unsafe { std::env::set_var(name, value) };
+                } else {
+                    // Tests serialize environment mutations with ENV_LOCK.
+                    unsafe { std::env::remove_var(name) };
+                }
+            }
+        }
+    }
 
     fn generate_test_password() -> String {
         Uuid::new_v4().to_string()
@@ -387,6 +423,130 @@ mod tests {
         assert_eq!(moniker_info.name, "mock-diag-moniker");
         assert_eq!(moniker_info.account_group, "mock-diag-group");
         assert_eq!(token_endpoint, jwt_endpoint);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_managed_identity_by_resource_id_uses_local_msi_res_id_endpoint() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let msi_server = MockServer::start().await;
+        let config_server = MockServer::start().await;
+        let full_resource_id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Kubernetes/connectedClusters/test-cluster/providers/Microsoft.KubernetesConfiguration/extensions/test-extension-a";
+        let fake_msi_token = "fake-msi-token";
+        let (mock_response, jwt_endpoint, valid_token) = config_service_response();
+        let _env_guard = EnvVarGuard::set(&[
+            (
+                "IDENTITY_ENDPOINT",
+                format!("{}/metadata/identity/oauth2/token", msi_server.uri()),
+            ),
+            ("IDENTITY_HEADER", "fake-identity-header".to_string()),
+        ]);
+
+        Mock::given(method("GET"))
+            .and(path("/metadata/identity/oauth2/token"))
+            .and(header("Metadata", "true"))
+            .and(header("X-IDENTITY-HEADER", "fake-identity-header"))
+            .and(query_param("api-version", "2018-02-01"))
+            .and(query_param("resource", "https://monitor.core.windows.net"))
+            .and(query_param("msi_res_id", full_resource_id))
+            .and(query_param_is_missing("client_id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": fake_msi_token,
+                "expires_on": "1777334267",
+                "resource": "https://monitor.core.windows.net/",
+                "token_type": "Bearer"
+            })))
+            .expect(1)
+            .mount(&msi_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/userapi/agent/v3/mockenv/mockacct/MonitoringStorageKeys/",
+            ))
+            .and(header("Authorization", "Bearer fake-msi-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(mock_response))
+            .expect(1)
+            .mount(&config_server)
+            .await;
+
+        let config = GenevaConfigClientConfig {
+            endpoint: config_server.uri(),
+            environment: "mockenv".into(),
+            account: "mockacct".into(),
+            namespace: "mockns".into(),
+            region: "mockregion".into(),
+            config_major_version: 1,
+            auth_method: AuthMethod::UserManagedIdentityByResourceId {
+                resource_id: full_resource_id.to_string(),
+            },
+            msi_resource: Some("https://monitor.core.windows.net/.default".into()),
+            test_root_ca_pem: None,
+        };
+
+        let client = GenevaConfigClient::new(config).unwrap();
+        let (ingestion_info, moniker_info, token_endpoint) =
+            client.get_ingestion_info().await.unwrap();
+
+        assert_eq!(ingestion_info.endpoint, "https://mock.ingestion.endpoint");
+        assert_eq!(ingestion_info.auth_token, valid_token);
+        assert_eq!(moniker_info.name, "mock-diag-moniker");
+        assert_eq!(token_endpoint, jwt_endpoint);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_managed_identity_by_resource_id_returns_error_on_local_msi_failure() {
+        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let msi_server = MockServer::start().await;
+        let config_server = MockServer::start().await;
+        let full_resource_id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Kubernetes/connectedClusters/test-cluster/providers/Microsoft.KubernetesConfiguration/extensions/test-extension-a";
+        let _env_guard = EnvVarGuard::set(&[
+            (
+                "IDENTITY_ENDPOINT",
+                format!("{}/metadata/identity/oauth2/token", msi_server.uri()),
+            ),
+            ("IDENTITY_HEADER", "fake-identity-header".to_string()),
+        ]);
+
+        Mock::given(method("GET"))
+            .and(path("/metadata/identity/oauth2/token"))
+            .and(query_param("msi_res_id", full_resource_id))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&msi_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/userapi/agent/v3/mockenv/mockacct/MonitoringStorageKeys/",
+            ))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&config_server)
+            .await;
+
+        let config = GenevaConfigClientConfig {
+            endpoint: config_server.uri(),
+            environment: "mockenv".into(),
+            account: "mockacct".into(),
+            namespace: "mockns".into(),
+            region: "mockregion".into(),
+            config_major_version: 1,
+            auth_method: AuthMethod::UserManagedIdentityByResourceId {
+                resource_id: full_resource_id.to_string(),
+            },
+            msi_resource: Some("https://monitor.core.windows.net/.default".into()),
+            test_root_ca_pem: None,
+        };
+
+        let client = GenevaConfigClient::new(config).unwrap();
+        let result = client.get_ingestion_info().await;
+
+        match result {
+            Err(crate::config_service::client::GenevaConfigClientError::MsiAuth(message)) => {
+                assert!(message.contains("503"));
+            }
+            other => panic!("Expected local MSI auth error, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -23,15 +23,15 @@ mod tests {
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::path::PathBuf;
-    use std::sync::Mutex;
     use std::thread;
     use tempfile::NamedTempFile;
+    use tokio::sync::Mutex;
     use uuid::Uuid;
     use wiremock::matchers::{header, method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // Tests that mutate IDENTITY_ENDPOINT / IDENTITY_HEADER must hold this lock.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     struct EnvVarGuard {
         previous: Vec<(&'static str, Option<String>)>,
@@ -427,7 +427,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn user_managed_identity_by_resource_id_uses_local_msi_res_id_endpoint() {
-        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _env_lock = ENV_LOCK.lock().await;
         let msi_server = MockServer::start().await;
         let config_server = MockServer::start().await;
         let full_resource_id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Kubernetes/connectedClusters/test-cluster/providers/Microsoft.KubernetesConfiguration/extensions/test-extension-a";
@@ -495,7 +495,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn user_managed_identity_by_resource_id_returns_error_on_local_msi_failure() {
-        let _env_lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _env_lock = ENV_LOCK.lock().await;
         let msi_server = MockServer::start().await;
         let config_server = MockServer::start().await;
         let full_resource_id = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Kubernetes/connectedClusters/test-cluster/providers/Microsoft.KubernetesConfiguration/extensions/test-extension-a";


### PR DESCRIPTION
This change lets `geneva-uploader` get a managed identity token by Azure resource ID when a local managed identity endpoint is available.
                                                                                                              
  This is needed for environments such as Azure Arc extensions, where managed identity is exposed through a local endpoint and the desired identity is selected by resource ID.                               
                                                                                                                                                                                                              
  The code is not hardcoded to Azure Arc. It uses the standard local managed identity endpoint contract exposed through:                                                                                      
                                                                                                                                                                                                              
  ```text                                                                                                                                                                                                     
  IDENTITY_ENDPOINT
  IDENTITY_HEADER
  ```

  ## Flow

  ```mermaid                                                                                                                                                                                                  
  sequenceDiagram 
      participant U as geneva-uploader
      participant MSI as Local managed identity endpoint                                                                                                                                                      
      participant Entra as Microsoft Entra ID
      participant GCS as Geneva Config Service                                                                                                                                                                
                  
      U->>MSI: GET $IDENTITY_ENDPOINT                                                                                                                                                                         
      Note over U,MSI: api-version=2018-02-01<br/>resource=msi_resource<br/>msi_res_id=resource_id<br/>Metadata: true<br/>X-IDENTITY-HEADER: header
      MSI->>MSI: Validate caller and identity selector                                                                                                                                                        
      MSI->>Entra: Request token for selected managed identity                                                                                                                                                
      Entra-->>MSI: Access token                                                                                                                                                                              
      MSI-->>U: JSON response with access_token                                                                                                                                                               
      U->>GCS: GET MonitoringStorageKeys                                                                                                                                                                      
      Note over U,GCS: Authorization: Bearer access_token
      GCS-->>U: Ingestion configuration                                                                                                                                                                       
  ```                                                                                                                                                                                                     
                  
  ## What changes                                                                                                                                                                                             
                  
  Today, this auth method relies on `azure_identity` to get the token. That does not work in all local MSI endpoint environments when the identity is selected by resource ID.                                
   
  With this change, when these environment variables are present:                                                                                                                                             
                  
  ```text
  IDENTITY_ENDPOINT
  IDENTITY_HEADER
  ```

  `geneva-uploader` calls the local MSI endpoint directly:                                                                                                                                                    
   
  ```text                                                                                                                                                                                                     
  GET $IDENTITY_ENDPOINT
    ?api-version=2018-02-01
    &resource=<msi_resource>
    &msi_res_id=<resource_id>                                                                                                                                                                                 
  Metadata: true
  X-IDENTITY-HEADER: <IDENTITY_HEADER>                                                                                                                                                                        
  ```             

  The response contains an `access_token`. `geneva-uploader` uses that token as the bearer token when calling Geneva Config Service.                                                                          
   
  If those environment variables are not present, the existing `azure_identity` flow is still used.                                                                                                           
                  
  ## Local MSI response                                                                                                                                                                                       
                  
  The local MSI endpoint returns the standard managed identity token response shape.

  Example:

  ```json
  {
    "access_token": "<access token>",
    "expires_on": "1777334267",                                                                                                                                                                               
    "resource": "https://monitor.core.windows.net",
    "token_type": "Bearer"                                                                                                                                                                                    
  }               
  ```

  `geneva-uploader` only reads `access_token` from this response.                                                                                                                                             
   
  It does not log the token or persist it. The token is kept in memory and used as:                                                                                                                           
                  
  ```text
  Authorization: Bearer <access_token>
  ```

  when calling Geneva Config Service.                                                                                                                                                                         
   
  ## Why                                                                                                                                                                                                      
                  
  Azure managed identity supports selecting an identity by resource ID using the `msi_res_id` query parameter.

  Some environments, including Azure Arc extensions, expose managed identity through a local endpoint using `IDENTITY_ENDPOINT` and `IDENTITY_HEADER`. In those environments, using `msi_res_id` is the       
  correct way to request a token for a resource-ID-selected identity.
                                                                                                                                                                                                              
  This change adds that path explicitly while keeping the previous SDK-based behavior as fallback.

  ## Retry behavior

  This change does not add a new retry loop around local MSI token acquisition.                                                                                                                               
   
  The request is made through the existing `reqwest` client path. If the local MSI endpoint returns a non-success status, `geneva-uploader` returns an MSI auth error and the existing caller/export retry    
  behavior applies.
                                                                                                                                                                                                              
  This keeps the first implementation small and avoids hiding configuration errors such as:

  - missing or invalid identity header                                                                                                                                                                        
  - invalid `resource_id`
  - identity not assigned or not available                                                                                                                                                                    
  - invalid `msi_resource`

  Future improvement: add targeted retry for transient local MSI endpoint statuses that are recommended by the managed identity documentation, such as:                                                       
   
  - 404                                                                                                                                                                                                       
  - 410           
  - 429
  - 5xx
  - timeout / connection reset

  That retry should use bounded exponential backoff and should not retry permanent 4xx errors.                                                                                                                
   
  ## Safety                                                                                                                                                                                                   
                  
  This does not log tokens or the identity header.

  The token is only kept in memory and is used only as:

  ```text
  Authorization: Bearer <token>
  ```
                                                                                                                                                                                                              
  for the Geneva Config Service request.
                                                                                                                                                                                                              
  ## Tests        

  Added a unit test that verifies:

  - the local MSI endpoint is called
  - `msi_res_id` is sent
  - `client_id` is not sent
  - `Metadata` and `X-IDENTITY-HEADER` headers are sent                                                                                                                                                       
  - the returned token is used as the bearer token for the Geneva Config Service request
                                                                                                                                                                                                              
  Validation:                                                                                                                                                                                                 
   
  ```bash                                                                                                                                                                                                     
  cargo test -p geneva-uploader --lib
  ```

  Result:

  ```text
  38 passed; 0 failed; 9 ignored
  ```                                                    


  ## References
                                                                                                                                                                                                              
  - Local managed identity endpoint contract (`IDENTITY_ENDPOINT`, `IDENTITY_HEADER`, `X-IDENTITY-HEADER`):                                                                                                   
    https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity#rest-endpoint-reference                                                                                                     
  - Identity selection by Azure resource ID using `msi_res_id`:                                                                                                                                               
    https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-managed-identities-work-vm