### PR TITLE
chore: Update OpenTelemetry packages to v0.32.0 and fix breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ resolver = "2"
 debug = 1
 
 [workspace.dependencies]
-opentelemetry = "0.31"
-opentelemetry-appender-tracing = "0.31"
-opentelemetry-http = "0.31"
-opentelemetry-proto = { version = "0.31", default-features = false }
-opentelemetry_sdk = { version = "0.31", default-features = false }
-opentelemetry-stdout = { version = "0.31", default-features = false }
-opentelemetry-semantic-conventions = { version = "0.31", features = [
+opentelemetry = "0.32"
+opentelemetry-appender-tracing = "0.32"
+opentelemetry-http = "0.32"
+opentelemetry-proto = { version = "0.32", default-features = false }
+opentelemetry_sdk = { version = "0.32", default-features = false }
+opentelemetry-stdout = { version = "0.32", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.32", features = [
     "semconv_experimental",
 ] }
 criterion = "0.8"

--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.20.0
+
+### Changed
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32.0
+
 ## v0.19.0
 
 ### Changed

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-aws"
-version = "0.19.0"
+version = "0.20.0"
 description = "AWS exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws"

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## v0.24.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+
 ## v0.23.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -23,7 +23,7 @@ api = []
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-jaeger_json_exporter = ["opentelemetry_sdk", "serde_json"]
+jaeger_json_exporter = ["opentelemetry_sdk", "opentelemetry_sdk/experimental_async_runtime", "serde_json"]
 rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
 

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-contrib"
-version = "0.23.0"
+version = "0.24.0"
 description = "Rust contrib repo for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-contrib"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-contrib"

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
 - Bump opentelemetry-http and opentelemetry-semantic-conventions versions to 0.32
+- Bump `reqwest` from 0.12 to 0.13 (required by `opentelemetry-http` 0.32).
 - **Breaking** `DatadogPipelineBuilder::build_exporter`, `install_simple`, and
   `install_batch` now return `Result<_, opentelemetry_datadog::Error>` (previously
   `opentelemetry_sdk::trace::TraceError`, which was removed upstream in 0.32).

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## vNext
 
+## v0.20.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- Bump opentelemetry-http and opentelemetry-semantic-conventions versions to 0.32
+- **Breaking** `DatadogPipelineBuilder::build_exporter`, `install_simple`, and
+  `install_batch` now return `Result<_, opentelemetry_datadog::Error>` (previously
+  `opentelemetry_sdk::trace::TraceError`, which was removed upstream in 0.32).
+
 ## v0.19.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -32,7 +32,7 @@ opentelemetry-http = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 rmp = "0.8"
 url = "2.2"
-reqwest = { version = "0.12", default-features = false, optional = true }
+reqwest = { version = "0.13", default-features = false, optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
 thiserror = "2.0"
 http = "1"

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-datadog"
-version = "0.19.0"
+version = "0.20.0"
 description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -1,10 +1,10 @@
 use opentelemetry::{
     global,
-    trace::{SamplingResult, Span, TraceContextExt, Tracer, TracerProvider},
+    trace::{Span, TraceContextExt, Tracer, TracerProvider},
     InstrumentationScope, Key, KeyValue, Value,
 };
 use opentelemetry_datadog::{new_pipeline, ApiVersion, DatadogTraceStateBuilder};
-use opentelemetry_sdk::trace::{self, RandomIdGenerator, ShouldSample};
+use opentelemetry_sdk::trace::{self, RandomIdGenerator, SamplingResult, ShouldSample};
 use opentelemetry_semantic_conventions as semcov;
 use std::thread;
 use std::time::Duration;
@@ -36,7 +36,7 @@ impl ShouldSample for AgentBasedSampler {
         _span_kind: &opentelemetry::trace::SpanKind,
         _attributes: &[opentelemetry::KeyValue],
         _links: &[opentelemetry::trace::Link],
-    ) -> opentelemetry::trace::SamplingResult {
+    ) -> opentelemetry_sdk::trace::SamplingResult {
         let trace_state = parent_context
             .map(
                 |parent_context| parent_context.span().span_context().trace_state().clone(), // inherit sample decision from parent span
@@ -49,7 +49,7 @@ impl ShouldSample for AgentBasedSampler {
             });
 
         SamplingResult {
-            decision: opentelemetry::trace::SamplingDecision::RecordAndSample, // send all spans to datadog-agent
+            decision: opentelemetry_sdk::trace::SamplingDecision::RecordAndSample, // send all spans to datadog-agent
             attributes: vec![],
             trace_state,
         }

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -260,7 +260,7 @@ impl DatadogPipelineBuilder {
         let path_str = paths.join("/");
         endpoint.set_path(path_str.as_str());
 
-        Ok(endpoint.as_str().parse().map_err::<Error, _>(Into::into)?)
+        endpoint.as_str().parse().map_err::<Error, _>(Into::into)
     }
 
     fn build_exporter_with_service_name(

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -12,7 +12,7 @@ use opentelemetry_http::{HttpClient, ResponseExt};
 use opentelemetry_sdk::{
     error::{OTelSdkError, OTelSdkResult},
     resource::{ResourceDetector, SdkProvidedResourceDetector},
-    trace::{Config, SdkTracerProvider, TraceError},
+    trace::{Config, SdkTracerProvider},
     trace::{SpanData, SpanExporter},
     Resource,
 };
@@ -116,8 +116,8 @@ impl DatadogExporter {
                 env!("CARGO_PKG_VERSION"),
             )
             .body(data)
-            .map_err(|e| OTelSdkError::InternalFailure(format!("{e:?}")));
-        Ok(req)?
+            .map_err(|e| OTelSdkError::InternalFailure(format!("{e:?}")))?;
+        Ok(req)
     }
 }
 
@@ -205,7 +205,7 @@ impl DatadogPipelineBuilder {
     /// Building a new exporter.
     ///
     /// This is useful if you are manually constructing a pipeline.
-    pub fn build_exporter(mut self) -> Result<DatadogExporter, TraceError> {
+    pub fn build_exporter(mut self) -> Result<DatadogExporter, Error> {
         let (_, service_name) = self.build_config_and_service_name();
         self.build_exporter_with_service_name(service_name)
     }
@@ -246,7 +246,7 @@ impl DatadogPipelineBuilder {
 
     // parse the endpoint and append the path based on versions.
     // keep the query and host the same.
-    fn build_endpoint(agent_endpoint: &str, version: &str) -> Result<Uri, TraceError> {
+    fn build_endpoint(agent_endpoint: &str, version: &str) -> Result<Uri, Error> {
         // build agent endpoint based on version
         let mut endpoint = agent_endpoint
             .parse::<Url>()
@@ -266,7 +266,7 @@ impl DatadogPipelineBuilder {
     fn build_exporter_with_service_name(
         self,
         service_name: String,
-    ) -> Result<DatadogExporter, TraceError> {
+    ) -> Result<DatadogExporter, Error> {
         if let Some(client) = self.client {
             let model_config = ModelConfig { service_name };
 
@@ -280,12 +280,12 @@ impl DatadogPipelineBuilder {
             );
             Ok(exporter)
         } else {
-            Err(Error::NoHttpClient.into())
+            Err(Error::NoHttpClient)
         }
     }
 
     /// Install the Datadog trace exporter pipeline using a simple span processor.
-    pub fn install_simple(mut self) -> Result<SdkTracerProvider, TraceError> {
+    pub fn install_simple(mut self) -> Result<SdkTracerProvider, Error> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
         Ok(SdkTracerProvider::builder()
@@ -296,7 +296,7 @@ impl DatadogPipelineBuilder {
 
     /// Install the Datadog trace exporter pipeline using a batch span processor with the specified
     /// runtime.
-    pub fn install_batch(mut self) -> Result<SdkTracerProvider, TraceError> {
+    pub fn install_batch(mut self) -> Result<SdkTracerProvider, Error> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
         Ok(SdkTracerProvider::builder()

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -44,7 +44,7 @@ static DD_MEASURED_KEY: &str = "_dd.measured";
 /// use opentelemetry::global;
 /// use opentelemetry_datadog::{ApiVersion, new_pipeline};
 ///
-/// fn main() -> Result<(), opentelemetry_sdk::trace::TraceError> {
+/// fn main() -> Result<(), opentelemetry_datadog::Error> {
 ///     let provider = new_pipeline()
 ///         .with_service_name("my_app")
 ///         .with_api_version(ApiVersion::Version05)

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -48,7 +48,7 @@
 //! ```
 //!
 //! ```no_run
-//! # fn main() -> Result<(), opentelemetry_sdk::trace::TraceError> {
+//! # fn main() -> Result<(), opentelemetry_datadog::Error> {
 //! let provider = opentelemetry_datadog::new_pipeline()
 //!     .install_batch()?;
 //! # Ok(())

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -13,6 +13,15 @@
   looked for the bare field names (`role`, `roleInstance`) in PartA will need
   to be updated.
 
+## vNext
+
+## v0.11.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- **Breaking** Removed the `spec_unstable_logs_enabled` cargo feature. The
+  capability is now stable and always-on in upstream `opentelemetry` 0.32, so
+  the `event_enabled` callback is unconditionally available.
+
 ## v0.10.1
 
 - Added a `with_resource_attributes` method to the processor builder, allowing

--- a/opentelemetry-etw-logs/CHANGELOG.md
+++ b/opentelemetry-etw-logs/CHANGELOG.md
@@ -18,11 +18,11 @@
 ## v0.11.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
-- **Breaking** Removed the `spec_unstable_logs_enabled` cargo feature. The
-  capability is now stable and always-on in upstream `opentelemetry` 0.32, so
-  the `event_enabled` callback is unconditionally available.
-
-## v0.10.1
+- Removed the `spec_unstable_logs_enabled` cargo feature, since the underlying
+  capability is now stable and always-on in upstream `opentelemetry` 0.32 (the
+  `event_enabled` callback is unconditionally available). This only affects
+  users who explicitly opted into the experimental feature flag; no change is
+  needed for users on the default (stable) feature set.
 
 - Added a `with_resource_attributes` method to the processor builder, allowing
   users to specify which resource attribute keys are exported with each log

--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-etw-logs"
 description = "OpenTelemetry logs exporter to ETW (Event Tracing for Windows)"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-logs"
@@ -39,7 +39,6 @@ ferrisetw = "1.2"
 windows = { version = "0.57", features = ["Win32_System_Diagnostics_Etw"] }
 
 [features]
-spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
 internal-logs = [
     "tracing",
     "opentelemetry/internal-logs",
@@ -56,7 +55,6 @@ path = "examples/basic.rs"
 [[bench]]
 name = "logs"
 harness = false
-required-features = ["spec_unstable_logs_enabled"]
 
 [lints]
 workspace = true

--- a/opentelemetry-etw-logs/src/exporter/mod.rs
+++ b/opentelemetry-etw-logs/src/exporter/mod.rs
@@ -143,7 +143,6 @@ impl ETWExporter {
         Ok(())
     }
 
-    #[cfg(feature = "spec_unstable_logs_enabled")]
     pub(crate) fn event_enabled(
         &self,
         level: Severity,

--- a/opentelemetry-etw-logs/src/processor.rs
+++ b/opentelemetry-etw-logs/src/processor.rs
@@ -90,7 +90,6 @@ impl opentelemetry_sdk::logs::LogProcessor for Processor {
         self.event_exporter.shutdown()
     }
 
-    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn event_enabled(
         &self,
         level: opentelemetry::logs::Severity,
@@ -274,7 +273,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn test_event_enabled() {
         let processor = Processor::new(test_options());
 

--- a/opentelemetry-etw-metrics/CHANGELOG.md
+++ b/opentelemetry-etw-metrics/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+## v0.11.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- Bump opentelemetry-proto version to 0.32
+
 ## v0.10.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-etw-metrics"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "OpenTelemetry metrics exporter to ETW (Event Tracing for Windows)"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-etw-metrics"
@@ -11,9 +11,9 @@ license = "Apache-2.0"
 rust-version = "1.75.0"
 
 [dependencies]
-opentelemetry = { version = "0.31", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.31", features = ["metrics"] }
-opentelemetry-proto = { version = "0.31", features = ["gen-tonic", "metrics"], default-features = false }
+opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
+opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
 prost = "0.14"
 tracelogging = "1.2.4"
 tracing = { version = "0.1", optional = true }
@@ -21,7 +21,7 @@ tracing = { version = "0.1", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 criterion = { workspace = true, features = ["html_reports"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "std", "fmt"] }
-opentelemetry-proto = { version = "0.31", features = ["gen-tonic", "metrics", "gen-tonic-messages"], default-features = false }
+opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics", "gen-tonic-messages"] }
 
 [features]
 internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.5.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 keywords = ["opentelemetry", "geneva", "ffi", "uploader"]
 license = "Apache-2.0"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
-opentelemetry-proto = { workspace = true, default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
 otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
-opentelemetry-proto = {workspace = true, default-features = false, features = ["logs", "trace", "gen-tonic-messages"]}
+opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.5.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
@@ -30,6 +30,9 @@ lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = fa
 azure_identity = "0.29"
 azure_core = "0.29"
 tracing = "0.1"
+# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; pulled in transitively
+# via azure_identity / rcgen / yasna. Not used directly by this crate.
+time = ">=0.3.47"
 
 [features]
 mock_auth = [] # Disabled by default. Not to be enabled in the prod release. 
@@ -53,4 +56,4 @@ rand = {version = "0.9"}
 workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["md-5"] # cargo machete is incorrectly detecting this as an unused crate
+ignored = ["md-5", "time"] # md-5 is incorrectly detected as unused; time is pinned to pull in the RUSTSEC-2026-0009 fix transitively.

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -10,16 +10,16 @@ keywords = ["opentelemetry", "geneva", "logs", "traces", "exporter"]
 license = "Apache-2.0"
 
 [dependencies]
-opentelemetry_sdk = {workspace = true, default-features = false, features = ["logs", "trace"]}
-opentelemetry-proto = {workspace = true, default-features = false, features = ["logs", "trace"]}
+opentelemetry_sdk = { version = "0.31", default-features = false, features = ["logs", "trace"] }
+opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 futures = "0.3"
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
 
 [dev-dependencies]
-opentelemetry-appender-tracing = {workspace = true}
-opentelemetry = {workspace = true}
-opentelemetry_sdk = { workspace = true, features = ["logs", "trace", "experimental_logs_batch_log_processor_with_async_runtime", "experimental_async_runtime", "rt-tokio"] }
+opentelemetry-appender-tracing = { version = "0.31" }
+opentelemetry = { version = "0.31" }
+opentelemetry_sdk = { version = "0.31", features = ["logs", "trace", "experimental_logs_batch_log_processor_with_async_runtime", "experimental_async_runtime", "rt-tokio"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "registry", "std"] }

--- a/opentelemetry-instrumentation-actix-web/Cargo.toml
+++ b/opentelemetry-instrumentation-actix-web/Cargo.toml
@@ -34,6 +34,9 @@ opentelemetry-semantic-conventions = { workspace = true, features = [
   "semconv_experimental",
 ] }
 serde = "1.0"
+# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; pulled in transitively
+# via actix-web / cookie. Not used directly by this crate.
+time = ">=0.3.47"
 
 [dev-dependencies]
 actix-rt = "2"
@@ -61,6 +64,9 @@ required-features = ["metrics"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-machete]
+ignored = ["time"] # Pinned to pull in the RUSTSEC-2026-0009 fix transitively via actix-web.
 
 [lints]
 workspace = true

--- a/opentelemetry-instrumentation-tower/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/Cargo.toml
@@ -21,7 +21,7 @@ axum = { features = ["matched-path", "macros"], version = "0.8", default-feature
 http = { version = "1", features = ["std"], default-features = false }
 http-body = { version = "1", default-features = false }
 opentelemetry = { workspace = true, features = ["futures", "metrics", "trace"] }
-opentelemetry-http = "0.31"
+opentelemetry-http = "0.32"
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
 tower-service = { version = "0.3", default-features = false }
 tower-layer = { version = "0.3", default-features = false }

--- a/opentelemetry-instrumentation-tower/examples/axum-http-service/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/axum-http-service/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { version = "1", default-features = false }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["spec_unstable_metrics_views"], default-features = false }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"], default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
+opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }
 rand = { version = "0.9" }
 

--- a/opentelemetry-instrumentation-tower/examples/custom-route-extractor/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/custom-route-extractor/Cargo.toml
@@ -10,7 +10,7 @@ axum = { features = ["http1", "tokio"], version = "0.8", default-features = fals
 http = { version = "1", default-features = false }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
+opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"], default-features = false }
 
 [lints]

--- a/opentelemetry-instrumentation-tower/examples/hyper-http-service/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/examples/hyper-http-service/Cargo.toml
@@ -14,7 +14,7 @@ hyper-util = { version = "0.1", features = ["http1", "service", "server", "tokio
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["spec_unstable_metrics_views"], default-features = false }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"], default-features = false }
-opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
+opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "metrics", "trace"], default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5", default-features = false }
 rand = { version = "0.9" }

--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+## v0.11.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- Bump opentelemetry-semantic-conventions version to 0.32
+
 ## v0.10.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-resource-detectors"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "A collection of community supported resource detectors for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-resource-detectors"

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.29.0
+
+- Update to opentelemetry v0.32.0, opentelemetry_sdk v0.32.0, opentelemetry-semantic-conventions v0.32.0
+- **Breaking** `StackDriverExporter::shutdown` now takes `&self` instead of `&mut self`,
+  matching the upstream `SpanExporter` trait change in 0.32.
+
 ## v0.28.0
 
 - Update to opentelemetry v0.31.0, opentelemetry_sdk v0.31.0, opentelemetry-semantic-conventions v0.31.0

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stackdriver"
-version = "0.28.0"
+version = "0.29.0"
 description = "A Rust opentelemetry exporter that uploads traces to Google Stackdriver trace."
 documentation = "https://docs.rs/opentelemetry-stackdriver/"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib"

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -96,7 +96,7 @@ impl SpanExporter for StackDriverExporter {
         }
     }
 
-    fn shutdown(&mut self) -> OTelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         let start = Instant::now();
         while (Instant::now() - start) < self.maximum_shutdown_duration && self.pending_count() > 0
         {

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - Bump eventheader and eventheader_dynamic versions to 0.5.0
 
+## v0.16.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- **Breaking** Removed the `spec_unstable_logs_enabled` cargo feature. The
+  capability is now stable and always-on in upstream `opentelemetry` 0.32, so
+  the `event_enabled` callback is unconditionally available.
+
 ## v0.15.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -7,9 +7,11 @@
 ## v0.16.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
-- **Breaking** Removed the `spec_unstable_logs_enabled` cargo feature. The
-  capability is now stable and always-on in upstream `opentelemetry` 0.32, so
-  the `event_enabled` callback is unconditionally available.
+- Removed the `spec_unstable_logs_enabled` cargo feature, since the underlying
+  capability is now stable and always-on in upstream `opentelemetry` 0.32 (the
+  `event_enabled` callback is unconditionally available). This only affects
+  users who explicitly opted into the experimental feature flag; no change is
+  needed for users on the default (stable) feature set.
 
 ## v0.15.0
 

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-user-events-logs"
 description = "OpenTelemetry Logs Exporter for Linux user_events"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs"
@@ -13,14 +13,14 @@ license = "Apache-2.0"
 [dependencies]
 eventheader = "0.5.0"
 eventheader_dynamic = "0.5.0"
-opentelemetry = { version= "0.31", features = ["logs"] }
-opentelemetry_sdk = { version= "0.31", features = ["logs"] }
+opentelemetry = { workspace = true, features = ["logs"] }
+opentelemetry_sdk = { workspace = true, features = ["logs"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures-executor = "0.3"
 
 [dev-dependencies]
-opentelemetry-appender-tracing = { version= "0.31" }
-opentelemetry_sdk = { version= "0.31", features = ["logs", "trace"] }
+opentelemetry-appender-tracing = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["logs", "trace"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "registry", "std"] }
@@ -29,7 +29,6 @@ criterion = "0.8"
 serde_json = "1.0.140"
 
 [features]
-spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled", "opentelemetry_sdk/spec_unstable_logs_enabled", "opentelemetry-appender-tracing/spec_unstable_logs_enabled"]
 internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
 experimental_eventname_callback = []
 default = ["internal-logs"]
@@ -38,7 +37,7 @@ default = ["internal-logs"]
 
 name = "logs"
 harness = false
-required-features = ["spec_unstable_logs_enabled", "experimental_eventname_callback"]
+required-features = ["experimental_eventname_callback"]
 
 [lints]
 workspace = true

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -606,14 +606,14 @@ mod tests {
             .get("ext_dt_spanId")
             .expect("PartA.ext_dt_spanId is missing");
 
-        // Validate trace_id and span_id (zero-padded to full width)
+        // Validate trace_id and span_id
         assert_eq!(
             part_a_ext_dt_trace_id.as_str().unwrap(),
-            format!("{trace_id_expected:032x}")
+            format!("{trace_id_expected:x}")
         );
         assert_eq!(
             part_a_ext_dt_span_id.as_str().unwrap(),
-            format!("{span_id_expected:016x}")
+            format!("{span_id_expected:x}")
         );
 
         // Validate PartB

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -606,14 +606,14 @@ mod tests {
             .get("ext_dt_spanId")
             .expect("PartA.ext_dt_spanId is missing");
 
-        // Validate trace_id and span_id
+        // Validate trace_id and span_id (zero-padded to full width)
         assert_eq!(
             part_a_ext_dt_trace_id.as_str().unwrap(),
-            format!("{trace_id_expected:x}")
+            format!("{trace_id_expected:032x}")
         );
         assert_eq!(
             part_a_ext_dt_span_id.as_str().unwrap(),
-            format!("{span_id_expected:x}")
+            format!("{span_id_expected:016x}")
         );
 
         // Validate PartB

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -451,7 +451,6 @@ where
         }
     }
 
-    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn event_enabled(&self, level: Severity, _target: &str, _name: Option<&str>) -> bool {
         // EventSets are stored in the same order as their int representation,
         // so we can use the level as index to the Vec.

--- a/opentelemetry-user-events-logs/src/logs/processor.rs
+++ b/opentelemetry-user-events-logs/src/logs/processor.rs
@@ -64,7 +64,6 @@ where
         self.exporter.shutdown()
     }
 
-    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn event_enabled(
         &self,
         level: opentelemetry::logs::Severity,
@@ -339,7 +338,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "spec_unstable_logs_enabled")]
     fn test_event_enabled() {
         let processor = Processor::builder("test_provider").build().unwrap();
 

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Update eventheader version to 0.5.0
 
+## v0.13.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- Bump opentelemetry-proto version to 0.32
+
 ## v0.12.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-user-events-metrics"
-version = "0.12.0"
+version = "0.13.0"
 description = "OpenTelemetry metrics exporter to user events"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics"
@@ -11,9 +11,9 @@ edition = "2021"
 rust-version = "1.75.0"
 
 [dependencies]
-opentelemetry = { version= "0.31", features = ["metrics"] }
-opentelemetry_sdk = { version= "0.31", features = ["metrics"] }
-opentelemetry-proto = { version= "0.31", features = ["gen-tonic", "metrics"], default-features = false }
+opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
+opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics"] }
 eventheader = { version = "= 0.5.0" }
 prost = "0.14"
 

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Bump eventheader and eventheader_dynamic versions to 0.5.0
 
+## v0.5.0
+
+- Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- **Breaking** `UserEventsSpanExporter::shutdown` now takes `&self` instead of
+  `&mut self`, matching the upstream `SpanExporter` trait change in 0.32.
+
 ## v0.4.0
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.31

--- a/opentelemetry-user-events-trace/Cargo.toml
+++ b/opentelemetry-user-events-trace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-user-events-trace"
 description = "OpenTelemetry-Rust exporter to user_events"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-traces"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-traces"
@@ -13,8 +13,8 @@ license = "Apache-2.0"
 [dependencies]
 eventheader = "0.5.0"
 eventheader_dynamic = "0.5.0"
-opentelemetry = { version= "0.31", features = ["trace"] }
-opentelemetry_sdk = { version= "0.31", features = ["trace"] }
+opentelemetry = { workspace = true, features = ["trace"] }
+opentelemetry_sdk = { workspace = true, features = ["trace"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 futures-executor = "0.3"
 

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -72,7 +72,7 @@ impl SpanExporter for UserEventsSpanExporter {
         }
     }
 
-    fn shutdown(&mut self) -> OTelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         // The explicit unregister() is done in shutdown()
         // as it may not be possible to unregister during Drop
         // as `Tracers` are typically *not* dropped.

--- a/opentelemetry-user-events-trace/src/trace/reentrant_spanprocessor.rs
+++ b/opentelemetry-user-events-trace/src/trace/reentrant_spanprocessor.rs
@@ -38,7 +38,7 @@ impl<T: SpanExporter> opentelemetry_sdk::trace::SpanProcessor for ReentrantSpanP
 
     // Ensures all spans are flushed.
     fn force_flush(&self) -> OTelSdkResult {
-        if let Ok(mut exporter) = self.exporter.lock() {
+        if let Ok(exporter) = self.exporter.lock() {
             exporter.force_flush()
         } else {
             Ok(())
@@ -53,7 +53,7 @@ impl<T: SpanExporter> opentelemetry_sdk::trace::SpanProcessor for ReentrantSpanP
 
     // Properly shuts down the exporter.
     fn shutdown(&self) -> OTelSdkResult {
-        if let Ok(mut exporter) = self.exporter.lock() {
+        if let Ok(exporter) = self.exporter.lock() {
             exporter.shutdown()
         } else {
             Ok(())

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -16,7 +16,6 @@ cargo clippy --workspace --all-targets --all-features -- -Dwarnings
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 cargo_feature opentelemetry-etw-logs "default"
-cargo_feature opentelemetry-etw-logs "spec_unstable_logs_enabled"
 cargo_feature opentelemetry-etw-logs "serde_json"
 cargo_feature opentelemetry-etw-logs "logs_unstable_etw_event_name_from_callback"
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -33,7 +33,6 @@ cargo_feature opentelemetry-stackdriver "tls-native-roots"
 cargo_feature opentelemetry-stackdriver "tls-webpki-roots"
 
 cargo_feature opentelemetry-user-events-logs "default"
-cargo_feature opentelemetry-user-events-logs "spec_unstable_logs_enabled"
 
 cargo_feature opentelemetry-user-events-metrics ""
 

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -29,10 +29,10 @@ tokio = { version = "1", features = ["full", "test-util"] }
 wiremock = "=0.5.22"
 futures = "0.3"
 
-opentelemetry-appender-tracing = { version = "0.31", features= ["spec_unstable_logs_enabled"] }
-opentelemetry_sdk = { version = "0.31", features = ["logs", "spec_unstable_logs_enabled"] }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "gen-tonic-messages"] }
-opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs", features = ["spec_unstable_logs_enabled"]}
+opentelemetry-appender-tracing = { version = "0.32" }
+opentelemetry_sdk = { version = "0.32", features = ["logs"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "gen-tonic-messages"] }
+opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs" }
 opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -71,12 +71,14 @@ fn create_test_logs(base_timestamp: u64) -> Vec<ResourceLogs> {
                     value: Some(AnyValue {
                         value: Some(Value::StringValue("stress".to_string())),
                     }),
+                    ..Default::default()
                 },
                 KeyValue {
                     key: "index".to_string(),
                     value: Some(AnyValue {
                         value: Some(Value::IntValue(i as i64)),
                     }),
+                    ..Default::default()
                 },
             ],
             ..Default::default()


### PR DESCRIPTION
Bumps the workspace OpenTelemetry dependencies from 0.31 to 0.32 and fixes the breaking changes.

Notable changes:
- Removed the `spec_unstable_logs_enabled` cargo feature from `opentelemetry-etw-logs` and `opentelemetry-user-events-logs` (capability is now stable and always-on upstream).
- `SpanExporter::shutdown` is now `&self`: updated `opentelemetry-stackdriver` and `opentelemetry-user-events-trace`.
- `opentelemetry-datadog`: replaced removed `opentelemetry_sdk::trace::TraceError` with the crate's own `Error` enum in public APIs (`build_exporter`, `install_simple`, `install_batch`).
- Migrated `opentelemetry-user-events-{logs,trace,metrics}` and `opentelemetry-etw-metrics` to use workspace deps.
- `opentelemetry-exporter-geneva` and `opentelemetry-config` intentionally remain on 0.31 (handled separately).