### PR TITLE
chore: Add @jan-xyz as co-owner of opentelemetry-instrumentation-tower

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -46,6 +46,7 @@ components:
 
   opentelemetry-instrumentation-tower/:
     - francoposa
+    - jan-xyz
 
   opentelemetry-resource-detectors/:
     - gruebel

--- a/opentelemetry-instrumentation-tower/README.md
+++ b/opentelemetry-instrumentation-tower/README.md
@@ -7,7 +7,7 @@
 | Status    |                                              |
 |-----------|----------------------------------------------|
 | Stability | alpha                                        |
-| Owners    | [Franco Posa](https://github.com/francoposa) |
+| Owners    | [Franco Posa](https://github.com/francoposa), [Jan Steinke](https://github.com/jan-xyz) |
 
 OpenTelemetry HTTP Metrics and Tracing Middleware for Tower-compatible Rust HTTP servers.
 


### PR DESCRIPTION
@jan-xyz has been a substantial contributor to the tower instrumentation crate (PRs #431, #435, #528, #561). Adding him as a co-owner of the crate alongside @francoposa.

Requesting sign-off from both @francoposa and @jan-xyz.