### PR TITLE
fix: Pin time>=0.3.47 in actix-web and geneva-uploader to fix RUSTSEC-2026-0009

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.5.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 keywords = ["opentelemetry", "geneva", "ffi", "uploader"]
 license = "Apache-2.0"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.5.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
@@ -30,6 +30,9 @@ lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = fa
 azure_identity = "0.29"
 azure_core = "0.29"
 tracing = "0.1"
+# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; pulled in transitively
+# via azure_identity / rcgen / yasna. Not used directly by this crate.
+time = ">=0.3.47"
 
 [features]
 mock_auth = [] # Disabled by default. Not to be enabled in the prod release. 
@@ -53,4 +56,4 @@ rand = {version = "0.9"}
 workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["md-5"] # cargo machete is incorrectly detecting this as an unused crate
+ignored = ["md-5", "time"] # md-5 is incorrectly detected as unused; time is pinned to pull in the RUSTSEC-2026-0009 fix transitively.

--- a/opentelemetry-instrumentation-actix-web/Cargo.toml
+++ b/opentelemetry-instrumentation-actix-web/Cargo.toml
@@ -34,6 +34,9 @@ opentelemetry-semantic-conventions = { workspace = true, features = [
   "semconv_experimental",
 ] }
 serde = "1.0"
+# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; pulled in transitively
+# via actix-web / cookie. Not used directly by this crate.
+time = ">=0.3.47"
 
 [dev-dependencies]
 actix-rt = "2"
@@ -61,6 +64,9 @@ required-features = ["metrics"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-machete]
+ignored = ["time"] # Pinned to pull in the RUSTSEC-2026-0009 fix transitively via actix-web.
 
 [lints]
 workspace = true


### PR DESCRIPTION
Fixes #539.

The cargo-deny advisory check has been failing due to [RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009) in `time` v0.3.41 (DoS via stack exhaustion in RFC 2822 parsing). The fix is in `time` 0.3.47, but cargo's MSRV-aware resolver was capping `time` at 0.3.41 because most workspace crates declare `rust-version = 1.75` while `time` 0.3.47 declares `1.88`.

Per @lalitb's [suggestion in #539](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/539#issuecomment-3968142694):

- Bump `geneva-uploader` and `geneva-uploader-ffi` MSRV from `1.87` → `1.88` (`opentelemetry-exporter-geneva` is already at `1.88`).
- Pin `time = ">=0.3.47"` in the two crate trees that actually pull it in: `opentelemetry-instrumentation-actix-web` (transitively via `actix-web`/`cookie`) and `geneva-uploader` (transitively via `azure_identity`/`rcgen`/`yasna`).

`cargo tree -i time` confirms `0.3.47` is selected after this change. The rest of the workspace stays at MSRV `1.75`.

cargo-machete ignores added for the unused direct `time` dep in both crates.
