### PR TITLE
test: fix flaky span_id/trace_id formatting in user-events-logs integration test

### DIFF
--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -606,14 +606,15 @@ mod tests {
             .get("ext_dt_spanId")
             .expect("PartA.ext_dt_spanId is missing");
 
-        // Validate trace_id and span_id
+        // Validate trace_id and span_id (use to_string() for consistent
+        // zero-padded Display formatting, matching the exporter output)
         assert_eq!(
             part_a_ext_dt_trace_id.as_str().unwrap(),
-            format!("{trace_id_expected:x}")
+            trace_id_expected.to_string()
         );
         assert_eq!(
             part_a_ext_dt_span_id.as_str().unwrap(),
-            format!("{span_id_expected:x}")
+            span_id_expected.to_string()
         );
 
         // Validate PartB


### PR DESCRIPTION
The `integration_test_with_tracing` assertion used `format!("{:x}", span_id)` which goes through `SpanId`'s `LowerHex` impl (not zero-padded), causing the test to flake whenever the random `span_id` starts with a zero byte (~1 in 16 runs). Switch to `.to_string()` (Display impl, always zero-padded) so it matches the exporter output and the pattern already used in the `etw-logs` integration tests.

Discovered while running CI on #608.
