### PR TITLE
chore: prep release for OTel 0.32 contrib crates

### DIFF
--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## v0.20.0
 
+Released 2026-May-13
+
 ### Changed
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32.0

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## v0.24.0
 
+Released 2026-May-13
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
 
 ## v0.23.0

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## v0.20.0
 
+Released 2026-May-13
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
 - Bump opentelemetry-http and opentelemetry-semantic-conventions versions to 0.32
 - Bump `reqwest` from 0.12 to 0.13 (required by `opentelemetry-http` 0.32).

--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## v0.11.0
 
+Released 2026-May-13
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
 - Bump opentelemetry-semantic-conventions version to 0.32
 

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## v0.29.0
 
+Released 2026-May-13
+
 - Update to opentelemetry v0.32.0, opentelemetry_sdk v0.32.0, opentelemetry-semantic-conventions v0.32.0
 - **Breaking** `StackDriverExporter::shutdown` now takes `&self` instead of `&mut self`,
   matching the upstream `SpanExporter` trait change in 0.32.

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## vNext
 
-- Bump eventheader and eventheader_dynamic versions to 0.5.0
-
 ## v0.16.0
 
+Released 2026-May-13
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- Bump eventheader and eventheader_dynamic versions to 0.5.0
 - Removed the `spec_unstable_logs_enabled` cargo feature, since the underlying
   capability is now stable and always-on in upstream `opentelemetry` 0.32 (the
   `event_enabled` callback is unconditionally available). This only affects

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## vNext
 
-- Update eventheader version to 0.5.0
-
 ## v0.13.0
+
+Released 2026-May-13
 
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
 - Bump opentelemetry-proto version to 0.32
+- Update eventheader version to 0.5.0
 
 ## v0.12.0
 

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## vNext
 
-- Bump eventheader and eventheader_dynamic versions to 0.5.0
-
 ## v0.5.0
 
+Released 2026-May-13
+
 - Bump opentelemetry and opentelemetry_sdk versions to 0.32
+- Bump eventheader and eventheader_dynamic versions to 0.5.0
 - **Breaking** `UserEventsSpanExporter::shutdown` now takes `&self` instead of
   `&mut self`, matching the upstream `SpanExporter` trait change in 0.32.
 

--- a/scripts/RELEASING.md
+++ b/scripts/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing OpenTelemetry Rust Contrib
+
+The primary audience for this is the SIG Maintainers. It provides the list of steps for how to release the crates and the
+considerations to make before releasing the crate. It may provide use to consumers of the crate if/when we develop a
+release cadence.
+
+## Release cadence
+
+There is no established cadence for the OpenTelemetry Rust Contrib crates. Each crate in this repository may be released
+independently as needed. The balance is required between too many breaking changes in a single release, and since we
+have instability flipping between implementations across 0.x releases.
+
+## Considerations
+
+A draft PR can be created, but before releasing consider the following:
+
+* Are there any pending pull requests which should be included in the next release?
+  * Are they blockers?
+* Are there any unresolved issues which should be resolved before the next release? Check the release [blockers milestone](https://github.com/open-telemetry/opentelemetry-rust-contrib/milestones) for every release
+* For crates that depend on `opentelemetry`, `opentelemetry-sdk`, or other core crates, ensure the contrib crate is compatible with the latest released versions of those core crates.
+* Bring it up at a SIG meeting, this can usually get some of these questions answered sooner than later. It will also
+  help establish a person to perform the release. Ideally this can be someone different each time to ensure that the
+  process is documented.
+
+## Steps to Release
+
+1. Create a release PR
+
+* For each crate being released
+  * Bump appropriate version
+  * Update change logs to reflect release version.
+  * Update dependency versions on core `opentelemetry-*` crates as necessary
+* If there's a large enough set of changes, consider writing a migration guide.
+
+2. Merge the PR
+
+* Get reviews from other Maintainers
+* Ensure that there haven't been any interfering PRs
+
+3. Tag the release commit based on the [tagging convention](#tagging-convention). It should usually be a bump on minor version before 1.0
+4. Create Github Release
+5. [Publish](#publishing-crates) to crates.io using the version as of the release commit
+6. Post to [#otel-rust](https://cloud-native.slack.com/archives/C03GDP0H023) on CNCF Slack.
+
+[Publish.sh](./publish.sh) may be used to automate steps 3 and 5.
+
+## Tagging Convention
+
+For each crate: it should be `<crate-name>-<version>` `<version>` being the simple `X.Y.Z`.
+For example:
+
+```sh
+git tag -a opentelemetry-etw-logs-0.10.0 -m "opentelemetry-etw-logs 0.10.0 release"
+git push origin opentelemetry-etw-logs-0.10.0
+```
+
+## Publishing Crates
+
+For now we use the [basic procedure](https://doc.rust-lang.org/cargo/reference/publishing.html) from crates.io.
+
+Follow this for each crate as necessary.
+
+For any new crates remember to add open-telemetry/rust-maintainers to the list of owners.


### PR DESCRIPTION
Prepares the next release wave for OTel 0.32 contrib crates (follow-up to #608 and #614).

## Crates being released

| Crate | Version |
|---|---|
| opentelemetry-aws | 0.20.0 |
| opentelemetry-contrib | 0.24.0 |
| opentelemetry-datadog | 0.20.0 |
| opentelemetry-resource-detectors | 0.11.0 |
| opentelemetry-stackdriver | 0.29.0 |
| opentelemetry-user-events-logs | 0.16.0 |
| opentelemetry-user-events-metrics | 0.13.0 |
| opentelemetry-user-events-trace | 0.5.0 |

Version bumps and the bulk of the CHANGELOG content were already landed in #608. This PR only:

- Adds a `Released 2026-May-13` date line under each released version heading.
- Moves the `eventheader` 0.5.0 bump line out of `vNext` and into the matching released version for the three `user-events-*` crates (it had been left over in `vNext` since #520 without an associated version bump at the time).
- Adds a `scripts/RELEASING.md` document describing the release process, adapted from the main `opentelemetry-rust` repo.

## Out of scope for this wave

Intentionally not released here:
- `opentelemetry-etw-logs`, `opentelemetry-etw-metrics` — already released by @utpilla.
- `opentelemetry-instrumentation-actix-web`, `opentelemetry-instrumentation-tower` — substantial unreleased changes still in `vNext`; needs separate decision.
- `opentelemetry-exporter-geneva`, `opentelemetry-config` — intentionally remain on OTel 0.31 per #608.

Once merged, the merge commit will be tagged per crate and published to crates.io using `scripts/publish.sh`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
