### PR TITLE
feat: [Geneva Exporter] Add Common Schema auto-detect to Geneva uploader

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -2561,11 +2561,8 @@ mod tests {
     #[cfg(all(feature = "mock_auth", feature = "otlp_bytes"))]
     fn test_encode_log_records_all_attribute_types_match_otlp() {
         use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
-        use opentelemetry_proto::tonic::common::v1::{
-            any_value, AnyValue, InstrumentationScope, KeyValue,
-        };
+        use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, KeyValue};
         use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
-        use opentelemetry_proto::tonic::resource::v1::Resource;
         use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
 
         let cfg = GenevaClientConfig {
@@ -2664,22 +2661,7 @@ mod tests {
 
         let req = ExportLogsServiceRequest {
             resource_logs: vec![ResourceLogs {
-                resource: Some(Resource {
-                    attributes: vec![KeyValue {
-                        key: "service.name".to_string(),
-                        value: Some(AnyValue {
-                            value: Some(any_value::Value::StringValue(
-                                "ffi-attr-types".to_string(),
-                            )),
-                        }),
-                    }],
-                    ..Default::default()
-                }),
                 scope_logs: vec![ScopeLogs {
-                    scope: Some(InstrumentationScope {
-                        name: "ffi.attr.types".to_string(),
-                        ..Default::default()
-                    }),
                     log_records: vec![LogRecord {
                         time_unix_nano: record.time_unix_nano,
                         severity_number: record.severity_number,

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -25,6 +25,14 @@ pub struct EncodedBatch {
     pub row_count: usize,
 }
 
+impl EncodedBatch {
+    /// Returns the size in bytes of the compressed payload uploaded to Geneva.
+    #[must_use]
+    pub fn compressed_size(&self) -> usize {
+        self.data.len()
+    }
+}
+
 /// Configuration for GenevaClient (user-facing)
 #[derive(Clone, Debug)]
 pub struct GenevaClientConfig {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -126,14 +126,18 @@ impl RoleOverrides {
             };
             match key {
                 "service.name" if overrides.role.is_none() => {
-                    overrides.role = attr
-                        .value()
-                        .and_then(|value| value_as_utf8(&value).map(str::to_owned));
+                    overrides.role = attr.value().and_then(|value| {
+                        value_as_utf8(&value)
+                            .filter(|value| !value.trim().is_empty())
+                            .map(str::to_owned)
+                    });
                 }
                 "service.instance.id" if overrides.role_instance.is_none() => {
-                    overrides.role_instance = attr
-                        .value()
-                        .and_then(|value| value_as_utf8(&value).map(str::to_owned));
+                    overrides.role_instance = attr.value().and_then(|value| {
+                        value_as_utf8(&value)
+                            .filter(|value| !value.trim().is_empty())
+                            .map(str::to_owned)
+                    });
                 }
                 _ => {}
             }
@@ -222,7 +226,8 @@ impl<'a> LogRecordParts<'a> {
             .and_then(|b| std::str::from_utf8(b).ok())
             .filter(|s| !s.is_empty())
             .map(Cow::Borrowed);
-        let body = record.body().and_then(|body| {
+        let body_value = record.body();
+        let body = body_value.as_ref().and_then(|body| {
             (body.value_type() == ValueType::String)
                 .then(|| body.as_string())
                 .flatten()
@@ -247,6 +252,12 @@ impl<'a> LogRecordParts<'a> {
             dynamic_fields: Vec::new(),
             dynamic_values: Vec::new(),
         };
+
+        if let Some(body) = body_value.as_ref() {
+            if parts.body.is_none() {
+                parts.push_dynamic_value(Cow::Borrowed(FIELD_BODY), body);
+            }
+        }
 
         for attr in record.attributes() {
             let Ok(key) = std::str::from_utf8(attr.key()) else {
@@ -331,19 +342,15 @@ impl<'a> LogRecordParts<'a> {
                 }
                 "PartA.ext_dt_traceId" => {
                     if let Some(trace_id) = value.as_ref().and_then(value_as_utf8) {
-                        if let Some(bytes) = parse_hex_bytes::<16>(trace_id) {
+                        if let Some(bytes) = parse_hex_bytes::<16>(trace_id.trim()) {
                             parts.trace_id = Some(bytes);
-                        } else {
-                            parts.push_dynamic_str(Cow::Borrowed("trace.id"), trace_id);
                         }
                     }
                 }
                 "PartA.ext_dt_spanId" => {
                     if let Some(span_id) = value.as_ref().and_then(value_as_utf8) {
-                        if let Some(bytes) = parse_hex_bytes::<8>(span_id) {
+                        if let Some(bytes) = parse_hex_bytes::<8>(span_id.trim()) {
                             parts.span_id = Some(bytes);
-                        } else {
-                            parts.push_dynamic_str(Cow::Borrowed("span.id"), span_id);
                         }
                     }
                 }
@@ -358,7 +365,7 @@ impl<'a> LogRecordParts<'a> {
                     if let Some(value) = value
                         .as_ref()
                         .and_then(value_as_utf8)
-                        .filter(|s| !s.is_empty())
+                        .filter(|s| !s.trim().is_empty())
                     {
                         parts.role = Cow::Owned(value.to_owned());
                     }
@@ -367,7 +374,7 @@ impl<'a> LogRecordParts<'a> {
                     if let Some(value) = value
                         .as_ref()
                         .and_then(value_as_utf8)
-                        .filter(|s| !s.is_empty())
+                        .filter(|s| !s.trim().is_empty())
                     {
                         parts.role_instance = Cow::Owned(value.to_owned());
                     }
@@ -383,7 +390,7 @@ impl<'a> LogRecordParts<'a> {
                 }
                 "PartB.severityNumber" => {
                     if let Some(number) = value.as_ref().and_then(value_as_i64) {
-                        parts.severity_number = number.clamp(0, 24) as i32;
+                        parts.severity_number = number as i32;
                     }
                 }
                 "PartB.severityText" => {
@@ -456,18 +463,6 @@ impl<'a> LogRecordParts<'a> {
             value_len,
         });
         true
-    }
-
-    fn push_dynamic_str(&mut self, name: Cow<'static, str>, value: &str) {
-        let value_start = self.dynamic_values.len();
-        BondWriter::write_string(&mut self.dynamic_values, value);
-        let value_len = self.dynamic_values.len() - value_start;
-        self.dynamic_fields.push(DynamicField {
-            name,
-            type_id: BondDataType::BT_STRING,
-            value_start,
-            value_len,
-        });
     }
 
     fn finish_fields(&mut self) {
@@ -616,9 +611,9 @@ fn value_as_i64<'value, V>(value: &V) -> Option<i64>
 where
     V: AnyValueView<'value>,
 {
-    (value.value_type() == ValueType::Int64)
-        .then(|| value.as_int64())
-        .flatten()
+    // Numeric-only on purpose: string values such as "1024" or "0x400" must not
+    // trigger Common Schema auto-detection by accident.
+    value.as_int64()
 }
 
 fn bond_type_for_value<'value, V>(value: &V) -> Option<BondDataType>
@@ -1837,6 +1832,8 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "test_event");
+        assert_eq!(result[0].compressed_size(), result[0].data.len());
+        assert!(result[0].compressed_size() > 0);
     }
 
     #[test]
@@ -2043,7 +2040,9 @@ mod tests {
 
         let canonical = LogRecord {
             event_name: "BodyEvent".to_string(),
-            attributes: vec![int_attr(FIELD_BODY, 42)],
+            body: Some(AnyValue {
+                value: Some(Value::IntValue(42)),
+            }),
             ..Default::default()
         };
 
@@ -2064,6 +2063,160 @@ mod tests {
                 .unwrap();
 
         assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_malformed_trace_context_is_omitted_like_canonical() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-malformed-trace-context");
+
+        let canonical = LogRecord {
+            event_name: "MalformedIds".to_string(),
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("body".to_string())),
+            }),
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartB.name", "MalformedIds"),
+                string_attr("PartB.body", "body"),
+                string_attr("PartA.ext_dt_traceId", "not-a-trace-id"),
+                string_attr("PartA.ext_dt_spanId", "   "),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&canonical), &metadata).unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_out_of_range_severity_matches_canonical() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-severity-parity");
+
+        let canonical = LogRecord {
+            event_name: "SeverityEvent".to_string(),
+            severity_number: 50,
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("body".to_string())),
+            }),
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartB.name", "SeverityEvent"),
+                int_attr("PartB.severityNumber", 50),
+                string_attr("PartB.body", "body"),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&canonical), &metadata).unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_blank_role_matches_blank_resource_service_attributes() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-blank-role-parity");
+
+        let canonical = LogRecord {
+            event_name: "BlankRole".to_string(),
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("body".to_string())),
+            }),
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.ext_cloud_role", ""),
+                string_attr("PartA.ext_cloud_roleInstance", "   "),
+                string_attr("PartB.name", "BlankRole"),
+                string_attr("PartB.body", "body"),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded = encode_log_batch_with_resource_attrs(
+            &encoder,
+            std::iter::once(&canonical),
+            vec![
+                string_attr("service.name", ""),
+                string_attr("service.instance.id", "   "),
+            ],
+            &metadata,
+        )
+        .unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_and_canonical_records_share_batch_by_route_and_role() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-canonical-co-batch");
+
+        let canonical = LogRecord {
+            event_name: "SharedEvent".to_string(),
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("canonical".to_string())),
+            }),
+            attributes: vec![int_attr("result", 1)],
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.ext_cloud_role", "checkout"),
+                string_attr("PartA.ext_cloud_roleInstance", "instance-1"),
+                string_attr("PartB.name", "SharedEvent"),
+                string_attr("PartB.body", "common-schema"),
+                int_attr("PartC.result", 2),
+            ],
+            ..Default::default()
+        };
+
+        let encoded = encode_log_batch_with_resource_attrs(
+            &encoder,
+            [&canonical, &common_schema],
+            vec![
+                string_attr("service.name", "checkout"),
+                string_attr("service.instance.id", "instance-1"),
+            ],
+            &metadata,
+        )
+        .unwrap();
+
+        assert_eq!(encoded.len(), 1);
+        assert_eq!(encoded[0].event_name, "SharedEvent");
+        assert_eq!(encoded[0].row_count, 2);
+        assert!(!encoded[0].metadata.schema_ids.is_empty());
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -1688,7 +1688,22 @@ mod tests {
         logs: impl IntoIterator<Item = &'a LogRecord>,
         metadata: &MetadataFields,
     ) -> Result<Vec<EncodedBatch>, String> {
-        encode_log_batch_with_resource_attrs(encoder, logs, Vec::new(), metadata)
+        encode_log_batch_via_proto_with_obo(encoder, logs, metadata, None)
+    }
+
+    fn encode_log_batch_via_proto_with_obo<'a>(
+        encoder: &OtlpEncoder,
+        logs: impl IntoIterator<Item = &'a LogRecord>,
+        metadata: &MetadataFields,
+        obo_event_map: Option<&OboEventMap>,
+    ) -> Result<Vec<EncodedBatch>, String> {
+        encode_log_batch_with_resource_attrs_and_obo(
+            encoder,
+            logs,
+            Vec::new(),
+            metadata,
+            obo_event_map,
+        )
     }
 
     fn encode_log_batch_with_resource_attrs<'a>(
@@ -1696,6 +1711,16 @@ mod tests {
         logs: impl IntoIterator<Item = &'a LogRecord>,
         resource_attrs: Vec<KeyValue>,
         metadata: &MetadataFields,
+    ) -> Result<Vec<EncodedBatch>, String> {
+        encode_log_batch_with_resource_attrs_and_obo(encoder, logs, resource_attrs, metadata, None)
+    }
+
+    fn encode_log_batch_with_resource_attrs_and_obo<'a>(
+        encoder: &OtlpEncoder,
+        logs: impl IntoIterator<Item = &'a LogRecord>,
+        resource_attrs: Vec<KeyValue>,
+        metadata: &MetadataFields,
+        obo_event_map: Option<&OboEventMap>,
     ) -> Result<Vec<EncodedBatch>, String> {
         use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
         use prost::Message as _;
@@ -1714,7 +1739,7 @@ mod tests {
             }],
         }
         .encode_to_vec();
-        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, None)
+        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, obo_event_map)
     }
 
     fn string_attr(key: &str, value: &str) -> KeyValue {
@@ -3119,5 +3144,434 @@ mod tests {
         assert_eq!(alpha.metadata.end_time, 3_000);
         assert_eq!(beta.metadata.start_time, 2_000);
         assert_eq!(beta.metadata.end_time, 4_000);
+    }
+
+    // ==================== OBO (On Behalf Of) Per-Event Tests ====================
+
+    fn make_obo_event_map(
+        event_name: &str,
+        identity: &str,
+        annotations: Option<&str>,
+    ) -> OboEventMap {
+        let mut map = HashMap::new();
+        map.insert(
+            event_name.to_string(),
+            OboEventConfig {
+                identity: identity.to_string(),
+                annotations: annotations.map(|s| s.to_string()),
+            },
+        );
+        map
+    }
+
+    #[test]
+    fn test_obo_lookup_matches_literal_event_name() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", Some("<Config/>"));
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "MyEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_obo_lookup_matches_anchored_event_name() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("^MyEvent$", "Microsoft.TestService", Some("<Config/>"));
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "MyEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_obo_lookup_no_match_for_different_event() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", None);
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "OtherEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_obo_lookup_strips_anchored_event_name() {
+        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", None);
+        let config = lookup_obo_config(Some(&obo_map), "^MyEvent$");
+        assert!(config.is_some());
+    }
+
+    #[test]
+    fn test_obo_fields_in_log_schema() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "TestEvent",
+            "Microsoft.SomeService",
+            Some(r#"<Config onBehalfFields="resourceId" priority="Normal"/>"#),
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "OBO log batch should encode successfully");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_obo_fields_absent_when_not_configured() {
+        let metadata = make_metadata("TestNamespace");
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(&OtlpEncoder::new(), [log].iter(), &metadata);
+        assert!(
+            result.is_ok(),
+            "Log batch without OBO should encode successfully"
+        );
+    }
+
+    #[test]
+    fn test_obo_identity_only_no_annotations() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map("TestEvent", "Microsoft.SomeService", None);
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(
+            result.is_ok(),
+            "OBO with identity only should encode successfully"
+        );
+    }
+
+    #[test]
+    fn test_obo_fields_in_span_schema() {
+        let obo_config = OboEventConfig {
+            identity: "Microsoft.SomeService".to_string(),
+            annotations: Some(r#"<Config onBehalfFields="resourceId"/>"#.to_string()),
+        };
+        let span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "test_span".to_string(),
+            kind: 1,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+        let fields = OtlpEncoder::determine_span_fields(&span, "Span", Some(&obo_config));
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.name.as_ref() == FIELD_OBO_SERVICE_ID),
+            "Span schema should include onbehalfServiceId"
+        );
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.name.as_ref() == FIELD_OBO_ANNOTATIONS),
+            "Span schema should include onbehalfAnnotations"
+        );
+    }
+
+    #[test]
+    fn test_encode_log_batch_with_obo() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "TestEvent",
+            "Microsoft.BatchService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "encode with OBO should succeed");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_encode_span_batch_with_obo() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "Span",
+            "Microsoft.SpanBatchService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let encoder = OtlpEncoder::new();
+        let span = Span {
+            trace_id: vec![1; 16],
+            span_id: vec![2; 8],
+            name: "test_span".to_string(),
+            kind: 1,
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            end_time_unix_nano: 1_700_000_001_000_000_000,
+            ..Default::default()
+        };
+        let result = encoder.encode_span_batch([span].iter(), &metadata, Some(&obo_map));
+        assert!(result.is_ok(), "encode_span_batch with OBO should succeed");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_mixed_batch_obo_and_non_obo_events() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "OboEvent",
+            "Microsoft.OboService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let obo_log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "OboEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let regular_log = LogRecord {
+            observed_time_unix_nano: 1_700_000_001_000_000_000,
+            event_name: "RegularEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [obo_log, regular_log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Mixed batch should succeed");
+        let batches = result.unwrap();
+        assert_eq!(
+            batches.len(),
+            2,
+            "Should have separate batches for different event names"
+        );
+    }
+
+    #[test]
+    fn test_no_obo_map_means_no_obo() {
+        let metadata = make_metadata("TestNamespace");
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto(&OtlpEncoder::new(), [log].iter(), &metadata);
+        assert!(result.is_ok(), "encode without OBO should succeed");
+    }
+
+    #[test]
+    fn test_obo_empty_identity_not_active() {
+        let metadata = make_metadata("TestNamespace");
+        let mut obo_map = HashMap::new();
+        obo_map.insert(
+            "TestEvent".to_string(),
+            OboEventConfig {
+                identity: "".to_string(),
+                annotations: Some("some annotations".to_string()),
+            },
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Should succeed even with empty identity");
+    }
+
+    #[test]
+    fn test_obo_whitespace_identity_not_active() {
+        let metadata = make_metadata("TestNamespace");
+        let mut obo_map = HashMap::new();
+        obo_map.insert(
+            "TestEvent".to_string(),
+            OboEventConfig {
+                identity: "   ".to_string(),
+                annotations: None,
+            },
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Should succeed with whitespace identity");
+    }
+
+    #[test]
+    fn test_obo_blank_annotations_suppressed() {
+        let metadata = make_metadata("TestNamespace");
+        let mut obo_map = HashMap::new();
+        obo_map.insert(
+            "TestEvent".to_string(),
+            OboEventConfig {
+                identity: "Microsoft.TestService".to_string(),
+                annotations: Some("   ".to_string()),
+            },
+        );
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            event_name: "TestEvent".to_string(),
+            severity_number: 9,
+            ..Default::default()
+        };
+        let result = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            [log].iter(),
+            &metadata,
+            Some(&obo_map),
+        );
+        assert!(result.is_ok(), "Should succeed with blank annotations");
+        let batches = result.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].row_count, 1);
+    }
+
+    #[test]
+    fn test_common_schema_part_b_name_drives_obo_lookup() {
+        let metadata = make_metadata("TestNamespace");
+        let obo_map = make_obo_event_map(
+            "CommonSchemaEvent",
+            "Microsoft.CommonSchemaService",
+            Some(r#"<Config onBehalfFields="resourceId"/>"#),
+        );
+        let log = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartB.name", "CommonSchemaEvent"),
+                string_attr("PartB.body", "body"),
+            ],
+            ..Default::default()
+        };
+
+        let without_obo =
+            encode_log_batch_via_proto(&OtlpEncoder::new(), std::iter::once(&log), &metadata)
+                .unwrap();
+        let with_obo = encode_log_batch_via_proto_with_obo(
+            &OtlpEncoder::new(),
+            std::iter::once(&log),
+            &metadata,
+            Some(&obo_map),
+        )
+        .unwrap();
+
+        assert_eq!(with_obo.len(), 1);
+        assert_eq!(with_obo[0].event_name, "CommonSchemaEvent");
+        assert_ne!(
+            with_obo[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
+            "Common Schema PartB.name should select the OBO config for that event"
+        );
+    }
+
+    #[test]
+    fn test_obo_event_config_helpers() {
+        let active = OboEventConfig {
+            identity: "Microsoft.Service".to_string(),
+            annotations: Some("config".to_string()),
+        };
+        assert!(active.is_active());
+        assert_eq!(active.active_annotations(), Some("config"));
+
+        let empty_id = OboEventConfig {
+            identity: "".to_string(),
+            annotations: Some("config".to_string()),
+        };
+        assert!(!empty_id.is_active());
+
+        let whitespace_id = OboEventConfig {
+            identity: "   ".to_string(),
+            annotations: None,
+        };
+        assert!(!whitespace_id.is_active());
+
+        let blank_ann = OboEventConfig {
+            identity: "Microsoft.Service".to_string(),
+            annotations: Some("  ".to_string()),
+        };
+        assert!(blank_ann.is_active());
+        assert_eq!(blank_ann.active_annotations(), None);
+
+        let none_ann = OboEventConfig {
+            identity: "Microsoft.Service".to_string(),
+            annotations: None,
+        };
+        assert_eq!(none_ann.active_annotations(), None);
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -201,13 +201,17 @@ impl<'a> LogRecordParts<'a> {
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Borrowed(&metadata_fields.role_instance));
 
-        let mut parts = LogRecordPartsParser::new(record, role, role_instance).parse(record);
+        let mut parts = if is_common_schema_record(record) {
+            CommonSchemaParts::parse(record, role, role_instance).finish()
+        } else {
+            Self::from_canonical(record, role, role_instance)
+        };
         parts.obo_config = lookup_obo_config(obo_event_map, parts.routing_event_name.as_ref());
         parts.finish_fields();
         parts
     }
 
-    fn canonical_base<R: LogRecordView>(
+    fn from_canonical<R: LogRecordView>(
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
@@ -253,6 +257,16 @@ impl<'a> LogRecordParts<'a> {
             if parts.body.is_none() {
                 parts.push_dynamic_value(Cow::Borrowed(FIELD_BODY), body);
             }
+        }
+
+        for attr in record.attributes() {
+            let Ok(key) = std::str::from_utf8(attr.key()) else {
+                continue;
+            };
+            let Some(value) = attr.value() else {
+                continue;
+            };
+            parts.push_dynamic_value(Cow::Owned(key.to_owned()), &value);
         }
 
         parts
@@ -310,33 +324,6 @@ impl<'a> LogRecordParts<'a> {
             value_len,
         });
         true
-    }
-
-    fn append_dynamic_prefix_from(&mut self, source: &Self, field_count: usize) {
-        if field_count == 0 {
-            return;
-        }
-
-        let Some(byte_end) = source.dynamic_fields[..field_count]
-            .last()
-            .map(|field| field.value_start + field.value_len)
-        else {
-            return;
-        };
-
-        let value_offset = self.dynamic_values.len();
-        self.dynamic_values
-            .extend_from_slice(&source.dynamic_values[..byte_end]);
-        self.dynamic_fields
-            .extend(
-                source.dynamic_fields[..field_count]
-                    .iter()
-                    .cloned()
-                    .map(|mut field| {
-                        field.value_start += value_offset;
-                        field
-                    }),
-            );
     }
 
     fn finish_fields(&mut self) {
@@ -424,113 +411,6 @@ impl<'a> LogRecordParts<'a> {
     }
 }
 
-struct LogRecordPartsParser<'a> {
-    canonical: Option<LogRecordParts<'a>>,
-    common_schema: Option<CommonSchemaParts<'a>>,
-    role: Cow<'a, str>,
-    role_instance: Cow<'a, str>,
-    has_cs_version: bool,
-    has_cs_log_type: bool,
-}
-
-impl<'a> LogRecordPartsParser<'a> {
-    fn new<R: LogRecordView>(
-        record: &'a R,
-        role: Cow<'a, str>,
-        role_instance: Cow<'a, str>,
-    ) -> Self {
-        Self {
-            canonical: Some(LogRecordParts::canonical_base(
-                record,
-                role.clone(),
-                role_instance.clone(),
-            )),
-            common_schema: None,
-            role,
-            role_instance,
-            has_cs_version: false,
-            has_cs_log_type: false,
-        }
-    }
-
-    fn parse<R: LogRecordView>(mut self, record: &'a R) -> LogRecordParts<'a> {
-        for attr in record.attributes() {
-            let Ok(key) = std::str::from_utf8(attr.key()) else {
-                continue;
-            };
-
-            let value = attr.value();
-            if self.common_schema.is_some() || is_common_schema_key(key) {
-                self.ensure_common_schema(record);
-                if let Some(common_schema) = &mut self.common_schema {
-                    common_schema.apply_attr(key, value.as_ref());
-                }
-                self.update_common_schema_markers(key, value.as_ref());
-            }
-
-            if let Some(canonical) = &mut self.canonical {
-                if let Some(value) = value.as_ref() {
-                    canonical.push_dynamic_value(Cow::Owned(key.to_owned()), value);
-                }
-            }
-
-            if self.is_common_schema() {
-                self.confirm_common_schema();
-            }
-        }
-
-        match self.canonical {
-            Some(canonical) => canonical,
-            None => self
-                .common_schema
-                .expect("Common Schema state is retained once confirmed")
-                .finish(),
-        }
-    }
-
-    fn ensure_common_schema<R: LogRecordView>(&mut self, record: &'a R) {
-        if self.common_schema.is_some() {
-            return;
-        }
-
-        let mut common_schema =
-            CommonSchemaParts::new(record, self.role.clone(), self.role_instance.clone());
-        if let Some(canonical) = &self.canonical {
-            common_schema
-                .parts
-                .append_dynamic_prefix_from(canonical, canonical.dynamic_fields.len());
-        }
-        self.common_schema = Some(common_schema);
-    }
-
-    fn update_common_schema_markers<'value, V>(&mut self, key: &str, value: Option<&V>)
-    where
-        V: AnyValueView<'value>,
-    {
-        match key {
-            KEY_CSVER => {
-                self.has_cs_version = value
-                    .and_then(value_as_i64)
-                    .is_some_and(|value| value == CS_VERSION_4);
-            }
-            KEY_PARTB_TYPENAME => {
-                self.has_cs_log_type = value
-                    .and_then(value_as_utf8)
-                    .is_some_and(|value| value == CS_LOG_TYPENAME);
-            }
-            _ => {}
-        }
-    }
-
-    fn is_common_schema(&self) -> bool {
-        self.has_cs_version && self.has_cs_log_type
-    }
-
-    fn confirm_common_schema(&mut self) {
-        self.canonical.take();
-    }
-}
-
 struct CommonSchemaParts<'a> {
     parts: LogRecordParts<'a>,
     part_a_name: Option<Cow<'a, str>>,
@@ -548,6 +428,33 @@ impl<'a> CommonSchemaParts<'a> {
             part_a_name: None,
             part_b_name: None,
         }
+    }
+
+    fn parse<R: LogRecordView>(
+        record: &'a R,
+        role: Cow<'a, str>,
+        role_instance: Cow<'a, str>,
+    ) -> Self {
+        let mut common_schema = Self::new(record, role, role_instance);
+        let mut seen_common_schema_key = false;
+
+        for attr in record.attributes() {
+            let Ok(key) = std::str::from_utf8(attr.key()) else {
+                continue;
+            };
+            let value = attr.value();
+
+            if seen_common_schema_key || is_common_schema_key(key) {
+                seen_common_schema_key = true;
+                common_schema.apply_attr(key, value.as_ref());
+            } else if let Some(value) = value.as_ref() {
+                common_schema
+                    .parts
+                    .push_dynamic_value(Cow::Owned(key.to_owned()), value);
+            }
+        }
+
+        common_schema
     }
 
     fn apply_attr<'value, V>(&mut self, key: &str, value: Option<&V>)
@@ -622,7 +529,7 @@ impl<'a> CommonSchemaParts<'a> {
             }
             "PartB.severityNumber" => {
                 if let Some(number) = value.and_then(value_as_i64) {
-                    self.parts.severity_number = number as i32;
+                    self.parts.severity_number = i32::try_from(number).unwrap_or(0);
                 }
             }
             "PartB.severityText" => {
@@ -677,6 +584,43 @@ fn is_common_schema_key(key: &str) -> bool {
         || key.starts_with("PartA.")
         || key.starts_with("PartB.")
         || key.starts_with("PartC.")
+}
+
+fn is_common_schema_record(record: &impl LogRecordView) -> bool {
+    let mut has_cs_version = false;
+    let mut has_cs_log_type = false;
+
+    // Common Schema producers can emit PartB after PartC, so detect the shape
+    // in a first pass before choosing the canonical or Common Schema encoder.
+    for attr in record.attributes() {
+        let Ok(key) = std::str::from_utf8(attr.key()) else {
+            continue;
+        };
+
+        match key {
+            KEY_CSVER => {
+                has_cs_version = attr
+                    .value()
+                    .as_ref()
+                    .and_then(value_as_i64)
+                    .is_some_and(|value| value == CS_VERSION_4);
+            }
+            KEY_PARTB_TYPENAME => {
+                has_cs_log_type = attr
+                    .value()
+                    .as_ref()
+                    .and_then(value_as_utf8)
+                    .is_some_and(|value| value == CS_LOG_TYPENAME);
+            }
+            _ => {}
+        }
+
+        if has_cs_version && has_cs_log_type {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn record_timestamp(record: &impl LogRecordView) -> u64 {
@@ -834,6 +778,7 @@ impl MetadataFields {
 /// iterators with `flat_map`.
 struct LogBatchAccumulator {
     batches: HashMap<String, BatchData>,
+    batch_key_scratch: String,
 }
 
 struct BatchData {
@@ -873,6 +818,7 @@ impl LogBatchAccumulator {
     fn new() -> Self {
         Self {
             batches: HashMap::new(),
+            batch_key_scratch: String::new(),
         }
     }
 
@@ -889,15 +835,21 @@ impl LogBatchAccumulator {
         let routing_event_name = parts.routing_event_name.as_ref();
         // Role identity is included because the central blob metadata is batch-level.
         // Mixing roles would make the per-row Role columns disagree with upload metadata.
-        let batch_key = format!(
-            "{}\0{}\0{}",
-            routing_event_name, parts.role, parts.role_instance
-        );
+        self.batch_key_scratch.clear();
+        {
+            use std::fmt::Write as _;
+            let _ = write!(
+                self.batch_key_scratch,
+                "{}\0{}\0{}",
+                routing_event_name, parts.role, parts.role_instance
+            );
+        }
+        let batch_key = self.batch_key_scratch.as_str();
 
-        if !self.batches.contains_key(&batch_key) {
+        if !self.batches.contains_key(batch_key) {
             let key: Arc<str> = Arc::from(routing_event_name);
             self.batches.insert(
-                batch_key.clone(),
+                batch_key.to_owned(),
                 BatchData {
                     routing_name: key,
                     blob_metadata: metadata_fields
@@ -913,7 +865,7 @@ impl LogBatchAccumulator {
             );
         }
 
-        let entry = self.batches.get_mut(&batch_key).unwrap();
+        let entry = self.batches.get_mut(batch_key).unwrap();
 
         if timestamp != 0 {
             entry.metadata.start_time = entry.metadata.start_time.min(timestamp);
@@ -2068,6 +2020,68 @@ mod tests {
     }
 
     #[test]
+    fn test_common_schema_user_events_order_matches_equivalent_canonical_log() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-user-events-order");
+        let timestamp = parse_rfc3339_nanos("2024-06-15T06:00:00Z").unwrap();
+
+        let canonical = LogRecord {
+            time_unix_nano: timestamp,
+            event_name: "UserEventsCheckoutFailure".to_string(),
+            severity_number: 17,
+            severity_text: "ERROR".to_string(),
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("failed".to_string())),
+            }),
+            trace_id: hex::decode("0102030405060708090a0b0c0d0e0f10").unwrap(),
+            span_id: hex::decode("a1b2c3d4e5f60718").unwrap(),
+            attributes: vec![
+                string_attr("operation", "checkout"),
+                int_attr("result", 127),
+                int_attr("eventId", 42),
+            ],
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            observed_time_unix_nano: 1,
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr("PartA.time", "2024-06-15T06:00:00Z"),
+                string_attr("PartA.ext_dt_traceId", "0102030405060708090a0b0c0d0e0f10"),
+                string_attr("PartA.ext_dt_spanId", "a1b2c3d4e5f60718"),
+                string_attr("PartA.ext_cloud_role", "checkout"),
+                string_attr("PartA.ext_cloud_roleInstance", "instance-1"),
+                string_attr("PartC.operation", "checkout"),
+                int_attr("PartC.result", 127),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartB.body", "failed"),
+                int_attr("PartB.severityNumber", 17),
+                string_attr("PartB.severityText", "ERROR"),
+                int_attr("PartB.eventId", 42),
+                string_attr("PartB.name", "UserEventsCheckoutFailure"),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded = encode_log_batch_with_resource_attrs(
+            &encoder,
+            std::iter::once(&canonical),
+            vec![
+                string_attr("service.name", "checkout"),
+                string_attr("service.instance.id", "instance-1"),
+            ],
+            &metadata,
+        )
+        .unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
     fn test_common_schema_role_overrides_match_resource_service_attributes() {
         let encoder = OtlpEncoder::new();
         let metadata = make_metadata("cs-role-parity");
@@ -2223,19 +2237,19 @@ mod tests {
 
         let canonical = LogRecord {
             event_name: "SeverityEvent".to_string(),
-            severity_number: 50,
             body: Some(AnyValue {
                 value: Some(Value::StringValue("body".to_string())),
             }),
             ..Default::default()
         };
+        let out_of_i32_severity = i64::from(i32::MAX) + 1;
 
         let common_schema = LogRecord {
             attributes: vec![
                 int_attr(KEY_CSVER, CS_VERSION_4),
                 string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
                 string_attr("PartB.name", "SeverityEvent"),
-                int_attr("PartB.severityNumber", 50),
+                int_attr("PartB.severityNumber", out_of_i32_severity),
                 string_attr("PartB.body", "body"),
             ],
             ..Default::default()

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -146,6 +146,7 @@ impl RoleOverrides {
     }
 }
 
+#[derive(Clone)]
 struct DynamicField {
     name: Cow<'static, str>,
     type_id: BondDataType,
@@ -189,7 +190,6 @@ impl<'a> LogRecordParts<'a> {
         resource_role: &'a RoleOverrides,
         obo_event_map: Option<&'a OboEventMap>,
     ) -> Self {
-        let cs = CommonSchemaRecord::detect(record);
         let role = resource_role
             .role
             .as_deref()
@@ -201,17 +201,13 @@ impl<'a> LogRecordParts<'a> {
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Borrowed(&metadata_fields.role_instance));
 
-        let mut parts = if cs.is_common_schema {
-            Self::from_common_schema(record, role, role_instance)
-        } else {
-            Self::from_canonical(record, role, role_instance)
-        };
+        let mut parts = LogRecordPartsParser::new(record, role, role_instance).parse(record);
         parts.obo_config = lookup_obo_config(obo_event_map, parts.routing_event_name.as_ref());
         parts.finish_fields();
         parts
     }
 
-    fn from_canonical<R: LogRecordView>(
+    fn canonical_base<R: LogRecordView>(
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
@@ -259,25 +255,15 @@ impl<'a> LogRecordParts<'a> {
             }
         }
 
-        for attr in record.attributes() {
-            let Ok(key) = std::str::from_utf8(attr.key()) else {
-                continue;
-            };
-            let Some(value) = attr.value() else {
-                continue;
-            };
-            parts.push_dynamic_value(Cow::Owned(key.to_owned()), &value);
-        }
-
         parts
     }
 
-    fn from_common_schema<R: LogRecordView>(
+    fn common_schema_base<R: LogRecordView>(
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
     ) -> Self {
-        let mut parts = Self {
+        Self {
             timestamp: record_timestamp(record),
             routing_event_name: Cow::Borrowed(CS_LOG_TYPENAME),
             name: None,
@@ -304,146 +290,7 @@ impl<'a> LogRecordParts<'a> {
             dynamic_fields_start: 0,
             dynamic_fields: Vec::new(),
             dynamic_values: Vec::new(),
-        };
-
-        let mut part_a_name = None;
-        let mut part_b_name = None;
-        for attr in record.attributes() {
-            let Ok(key) = std::str::from_utf8(attr.key()) else {
-                continue;
-            };
-            let value = attr.value();
-            match key {
-                KEY_CSVER | KEY_PARTB_TYPENAME => {}
-                "PartA.time" => {
-                    if let Some(time) = value.as_ref().and_then(value_as_utf8) {
-                        if let Some(nanos) = parse_rfc3339_nanos(time) {
-                            parts.timestamp = nanos;
-                        }
-                    }
-                }
-                "PartA.name" => {
-                    if let Some(name) = value
-                        .as_ref()
-                        .and_then(value_as_utf8)
-                        .filter(|s| !s.is_empty())
-                    {
-                        part_a_name = Some(Cow::Owned(name.to_owned()));
-                    }
-                }
-                "PartB.name" => {
-                    if let Some(name) = value
-                        .as_ref()
-                        .and_then(value_as_utf8)
-                        .filter(|s| !s.is_empty())
-                    {
-                        part_b_name = Some(Cow::Owned(name.to_owned()));
-                    }
-                }
-                "PartA.ext_dt_traceId" => {
-                    if let Some(trace_id) = value.as_ref().and_then(value_as_utf8) {
-                        if let Some(bytes) = parse_hex_bytes::<16>(trace_id.trim()) {
-                            parts.trace_id = Some(bytes);
-                        }
-                    }
-                }
-                "PartA.ext_dt_spanId" => {
-                    if let Some(span_id) = value.as_ref().and_then(value_as_utf8) {
-                        if let Some(bytes) = parse_hex_bytes::<8>(span_id.trim()) {
-                            parts.span_id = Some(bytes);
-                        }
-                    }
-                }
-                "PartA.ext_dt_traceFlags" => {
-                    if let Some(flags) = value.as_ref().and_then(value_as_i64) {
-                        if let Ok(flags) = u32::try_from(flags) {
-                            parts.trace_flags = Some(flags);
-                        }
-                    }
-                }
-                "PartA.ext_cloud_role" => {
-                    if let Some(value) = value
-                        .as_ref()
-                        .and_then(value_as_utf8)
-                        .filter(|s| !s.trim().is_empty())
-                    {
-                        parts.role = Cow::Owned(value.to_owned());
-                    }
-                }
-                "PartA.ext_cloud_roleInstance" => {
-                    if let Some(value) = value
-                        .as_ref()
-                        .and_then(value_as_utf8)
-                        .filter(|s| !s.trim().is_empty())
-                    {
-                        parts.role_instance = Cow::Owned(value.to_owned());
-                    }
-                }
-                "PartB.body" => {
-                    if let Some(value) = value.as_ref() {
-                        if let Some(body) = value_as_utf8(value) {
-                            parts.body = Some(Cow::Owned(body.to_owned()));
-                        } else {
-                            parts.push_dynamic_value(Cow::Borrowed(FIELD_BODY), value);
-                        }
-                    }
-                }
-                "PartB.severityNumber" => {
-                    if let Some(number) = value.as_ref().and_then(value_as_i64) {
-                        parts.severity_number = number as i32;
-                    }
-                }
-                "PartB.severityText" => {
-                    if let Some(text) = value
-                        .as_ref()
-                        .and_then(value_as_utf8)
-                        .filter(|s| !s.is_empty())
-                    {
-                        parts.severity_text = Some(Cow::Owned(text.to_owned()));
-                    }
-                }
-                "PartB.eventId" => {
-                    if let Some(value) = value.as_ref() {
-                        parts.push_dynamic_value(Cow::Borrowed("eventId"), value);
-                    }
-                }
-                key if key.starts_with("PartC.") => {
-                    if let Some(value) = value.as_ref() {
-                        parts.push_dynamic_value(
-                            Cow::Owned(key["PartC.".len()..].to_owned()),
-                            value,
-                        );
-                    }
-                }
-                key if key.starts_with("PartA.") => {
-                    if let Some(value) = value.as_ref() {
-                        parts.push_dynamic_value(
-                            Cow::Owned(key["PartA.".len()..].to_owned()),
-                            value,
-                        );
-                    }
-                }
-                key if key.starts_with("PartB.") => {
-                    if let Some(value) = value.as_ref() {
-                        parts.push_dynamic_value(
-                            Cow::Owned(key["PartB.".len()..].to_owned()),
-                            value,
-                        );
-                    }
-                }
-                _ => {
-                    if let Some(value) = value.as_ref() {
-                        parts.push_dynamic_value(Cow::Owned(key.to_owned()), value);
-                    }
-                }
-            }
         }
-
-        parts.name = part_b_name.or(part_a_name);
-        if let Some(name) = &parts.name {
-            parts.routing_event_name = Cow::Owned(name.to_string());
-        }
-        parts
     }
 
     fn push_dynamic_value<'value, V>(&mut self, name: Cow<'static, str>, value: &V) -> bool
@@ -463,6 +310,33 @@ impl<'a> LogRecordParts<'a> {
             value_len,
         });
         true
+    }
+
+    fn append_dynamic_prefix_from(&mut self, source: &Self, field_count: usize) {
+        if field_count == 0 {
+            return;
+        }
+
+        let Some(byte_end) = source.dynamic_fields[..field_count]
+            .last()
+            .map(|field| field.value_start + field.value_len)
+        else {
+            return;
+        };
+
+        let value_offset = self.dynamic_values.len();
+        self.dynamic_values
+            .extend_from_slice(&source.dynamic_values[..byte_end]);
+        self.dynamic_fields
+            .extend(
+                source.dynamic_fields[..field_count]
+                    .iter()
+                    .cloned()
+                    .map(|mut field| {
+                        field.value_start += value_offset;
+                        field
+                    }),
+            );
     }
 
     fn finish_fields(&mut self) {
@@ -550,41 +424,259 @@ impl<'a> LogRecordParts<'a> {
     }
 }
 
-#[derive(Default)]
-struct CommonSchemaRecord {
-    is_common_schema: bool,
+struct LogRecordPartsParser<'a> {
+    canonical: Option<LogRecordParts<'a>>,
+    common_schema: Option<CommonSchemaParts<'a>>,
+    role: Cow<'a, str>,
+    role_instance: Cow<'a, str>,
+    has_cs_version: bool,
+    has_cs_log_type: bool,
 }
 
-impl CommonSchemaRecord {
-    fn detect(record: &impl LogRecordView) -> Self {
-        let mut has_version = false;
-        let mut has_log_type = false;
+impl<'a> LogRecordPartsParser<'a> {
+    fn new<R: LogRecordView>(
+        record: &'a R,
+        role: Cow<'a, str>,
+        role_instance: Cow<'a, str>,
+    ) -> Self {
+        Self {
+            canonical: Some(LogRecordParts::canonical_base(
+                record,
+                role.clone(),
+                role_instance.clone(),
+            )),
+            common_schema: None,
+            role,
+            role_instance,
+            has_cs_version: false,
+            has_cs_log_type: false,
+        }
+    }
+
+    fn parse<R: LogRecordView>(mut self, record: &'a R) -> LogRecordParts<'a> {
         for attr in record.attributes() {
             let Ok(key) = std::str::from_utf8(attr.key()) else {
                 continue;
             };
-            match key {
-                KEY_CSVER => {
-                    has_version = attr
-                        .value()
-                        .and_then(|value| value_as_i64(&value))
-                        .is_some_and(|value| value == CS_VERSION_4);
+
+            let value = attr.value();
+            if self.common_schema.is_some() || is_common_schema_key(key) {
+                self.ensure_common_schema(record);
+                if let Some(common_schema) = &mut self.common_schema {
+                    common_schema.apply_attr(key, value.as_ref());
                 }
-                KEY_PARTB_TYPENAME => {
-                    has_log_type = attr.value().is_some_and(|value| {
-                        value_as_utf8(&value).is_some_and(|value| value == CS_LOG_TYPENAME)
-                    });
-                }
-                _ => {}
+                self.update_common_schema_markers(key, value.as_ref());
             }
-            if has_version && has_log_type {
-                return Self {
-                    is_common_schema: true,
-                };
+
+            if let Some(canonical) = &mut self.canonical {
+                if let Some(value) = value.as_ref() {
+                    canonical.push_dynamic_value(Cow::Owned(key.to_owned()), value);
+                }
+            }
+
+            if self.is_common_schema() {
+                self.confirm_common_schema();
             }
         }
-        Self::default()
+
+        match self.canonical {
+            Some(canonical) => canonical,
+            None => self
+                .common_schema
+                .expect("Common Schema state is retained once confirmed")
+                .finish(),
+        }
     }
+
+    fn ensure_common_schema<R: LogRecordView>(&mut self, record: &'a R) {
+        if self.common_schema.is_some() {
+            return;
+        }
+
+        let mut common_schema =
+            CommonSchemaParts::new(record, self.role.clone(), self.role_instance.clone());
+        if let Some(canonical) = &self.canonical {
+            common_schema
+                .parts
+                .append_dynamic_prefix_from(canonical, canonical.dynamic_fields.len());
+        }
+        self.common_schema = Some(common_schema);
+    }
+
+    fn update_common_schema_markers<'value, V>(&mut self, key: &str, value: Option<&V>)
+    where
+        V: AnyValueView<'value>,
+    {
+        match key {
+            KEY_CSVER => {
+                self.has_cs_version = value
+                    .and_then(value_as_i64)
+                    .is_some_and(|value| value == CS_VERSION_4);
+            }
+            KEY_PARTB_TYPENAME => {
+                self.has_cs_log_type = value
+                    .and_then(value_as_utf8)
+                    .is_some_and(|value| value == CS_LOG_TYPENAME);
+            }
+            _ => {}
+        }
+    }
+
+    fn is_common_schema(&self) -> bool {
+        self.has_cs_version && self.has_cs_log_type
+    }
+
+    fn confirm_common_schema(&mut self) {
+        self.canonical.take();
+    }
+}
+
+struct CommonSchemaParts<'a> {
+    parts: LogRecordParts<'a>,
+    part_a_name: Option<Cow<'a, str>>,
+    part_b_name: Option<Cow<'a, str>>,
+}
+
+impl<'a> CommonSchemaParts<'a> {
+    fn new<R: LogRecordView>(
+        record: &'a R,
+        role: Cow<'a, str>,
+        role_instance: Cow<'a, str>,
+    ) -> Self {
+        Self {
+            parts: LogRecordParts::common_schema_base(record, role, role_instance),
+            part_a_name: None,
+            part_b_name: None,
+        }
+    }
+
+    fn apply_attr<'value, V>(&mut self, key: &str, value: Option<&V>)
+    where
+        V: AnyValueView<'value>,
+    {
+        match key {
+            KEY_CSVER | KEY_PARTB_TYPENAME => {}
+            "PartA.time" => {
+                if let Some(time) = value.and_then(value_as_utf8) {
+                    if let Some(nanos) = parse_rfc3339_nanos(time) {
+                        self.parts.timestamp = nanos;
+                    }
+                }
+            }
+            "PartA.name" => {
+                if let Some(name) = value.and_then(value_as_utf8).filter(|s| !s.is_empty()) {
+                    self.part_a_name = Some(Cow::Owned(name.to_owned()));
+                }
+            }
+            "PartB.name" => {
+                if let Some(name) = value.and_then(value_as_utf8).filter(|s| !s.is_empty()) {
+                    self.part_b_name = Some(Cow::Owned(name.to_owned()));
+                }
+            }
+            "PartA.ext_dt_traceId" => {
+                if let Some(trace_id) = value.and_then(value_as_utf8) {
+                    if let Some(bytes) = parse_hex_bytes::<16>(trace_id.trim()) {
+                        self.parts.trace_id = Some(bytes);
+                    }
+                }
+            }
+            "PartA.ext_dt_spanId" => {
+                if let Some(span_id) = value.and_then(value_as_utf8) {
+                    if let Some(bytes) = parse_hex_bytes::<8>(span_id.trim()) {
+                        self.parts.span_id = Some(bytes);
+                    }
+                }
+            }
+            "PartA.ext_dt_traceFlags" => {
+                if let Some(flags) = value.and_then(value_as_i64) {
+                    if let Ok(flags) = u32::try_from(flags) {
+                        self.parts.trace_flags = Some(flags);
+                    }
+                }
+            }
+            "PartA.ext_cloud_role" => {
+                if let Some(value) = value
+                    .and_then(value_as_utf8)
+                    .filter(|s| !s.trim().is_empty())
+                {
+                    self.parts.role = Cow::Owned(value.to_owned());
+                }
+            }
+            "PartA.ext_cloud_roleInstance" => {
+                if let Some(value) = value
+                    .and_then(value_as_utf8)
+                    .filter(|s| !s.trim().is_empty())
+                {
+                    self.parts.role_instance = Cow::Owned(value.to_owned());
+                }
+            }
+            "PartB.body" => {
+                if let Some(value) = value {
+                    if let Some(body) = value_as_utf8(value) {
+                        self.parts.body = Some(Cow::Owned(body.to_owned()));
+                    } else {
+                        self.parts
+                            .push_dynamic_value(Cow::Borrowed(FIELD_BODY), value);
+                    }
+                }
+            }
+            "PartB.severityNumber" => {
+                if let Some(number) = value.and_then(value_as_i64) {
+                    self.parts.severity_number = number as i32;
+                }
+            }
+            "PartB.severityText" => {
+                if let Some(text) = value.and_then(value_as_utf8).filter(|s| !s.is_empty()) {
+                    self.parts.severity_text = Some(Cow::Owned(text.to_owned()));
+                }
+            }
+            "PartB.eventId" => {
+                if let Some(value) = value {
+                    self.parts
+                        .push_dynamic_value(Cow::Borrowed("eventId"), value);
+                }
+            }
+            key if key.starts_with("PartC.") => {
+                if let Some(value) = value {
+                    self.parts
+                        .push_dynamic_value(Cow::Owned(key["PartC.".len()..].to_owned()), value);
+                }
+            }
+            key if key.starts_with("PartA.") => {
+                if let Some(value) = value {
+                    self.parts
+                        .push_dynamic_value(Cow::Owned(key["PartA.".len()..].to_owned()), value);
+                }
+            }
+            key if key.starts_with("PartB.") => {
+                if let Some(value) = value {
+                    self.parts
+                        .push_dynamic_value(Cow::Owned(key["PartB.".len()..].to_owned()), value);
+                }
+            }
+            _ => {
+                if let Some(value) = value {
+                    self.parts
+                        .push_dynamic_value(Cow::Owned(key.to_owned()), value);
+                }
+            }
+        }
+    }
+
+    fn finish(mut self) -> LogRecordParts<'a> {
+        self.parts.name = self.part_b_name.or(self.part_a_name);
+        if let Some(name) = &self.parts.name {
+            self.parts.routing_event_name = Cow::Owned(name.to_string());
+        }
+        self.parts
+    }
+}
+
+fn is_common_schema_key(key: &str) -> bool {
+    matches!(key, KEY_CSVER | KEY_PARTB_TYPENAME)
+        || key.starts_with("PartA.")
+        || key.starts_with("PartB.")
+        || key.starts_with("PartC.")
 }
 
 fn record_timestamp(record: &impl LogRecordView) -> u64 {
@@ -2217,6 +2309,77 @@ mod tests {
         assert_eq!(encoded[0].event_name, "SharedEvent");
         assert_eq!(encoded[0].row_count, 2);
         assert!(!encoded[0].metadata.schema_ids.is_empty());
+    }
+
+    #[test]
+    fn test_common_schema_late_confirmation_keeps_prior_plain_attributes() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-late-confirm");
+
+        let canonical = LogRecord {
+            event_name: "LateConfirm".to_string(),
+            attributes: vec![string_attr("prelude", "kept"), int_attr("result", 7)],
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                string_attr("prelude", "kept"),
+                int_attr("PartC.result", 7),
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr("PartB.name", "LateConfirm"),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&canonical), &metadata).unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_requires_version_and_log_typename_markers() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-marker-strictness");
+
+        let missing_typename = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr("PartB.name", "ShouldStayCanonical"),
+            ],
+            ..Default::default()
+        };
+        let wrong_typename = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, "Metric"),
+                string_attr("PartB.name", "ShouldStayCanonical"),
+            ],
+            ..Default::default()
+        };
+        let missing_version = LogRecord {
+            attributes: vec![
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartB.name", "ShouldStayCanonical"),
+            ],
+            ..Default::default()
+        };
+
+        let encoded = encode_log_batch_via_proto(
+            &encoder,
+            [&missing_typename, &wrong_typename, &missing_version],
+            &metadata,
+        )
+        .unwrap();
+
+        assert_eq!(encoded.len(), 1);
+        assert_eq!(encoded[0].event_name, CS_LOG_TYPENAME);
+        assert_eq!(encoded[0].row_count, 3);
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -15,10 +15,16 @@ use otap_df_pdata_views::views::common::{AnyValueView, AttributeView, ValueType}
 use otap_df_pdata_views::views::logs::{
     LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView,
 };
+use otap_df_pdata_views::views::resource::ResourceView;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, error};
+
+const CS_VERSION_4: i64 = 0x400;
+const KEY_CSVER: &str = "__csver__";
+const KEY_PARTB_TYPENAME: &str = "PartB._typeName";
+const CS_LOG_TYPENAME: &str = "Log";
 
 const FIELD_ENV_NAME: &str = "env_name";
 const FIELD_ENV_VER: &str = "env_ver";
@@ -71,7 +77,7 @@ impl OboEventConfig {
     }
 }
 
-/// Map of event_name → OBO config. Events not in the map don't get OBO.
+/// Map of event_name -> OBO config. Events not in the map don't get OBO.
 pub type OboEventMap = HashMap<String, OboEventConfig>;
 
 fn non_blank_utf8(bytes: &[u8]) -> Option<&str> {
@@ -103,6 +109,574 @@ pub(crate) fn lookup_obo_config<'a>(
     }
     let anchored = format!("^{event_name}$");
     map.get(&anchored)
+}
+
+#[derive(Default)]
+struct RoleOverrides {
+    role: Option<String>,
+    role_instance: Option<String>,
+}
+
+impl RoleOverrides {
+    fn from_resource<R: ResourceView>(resource: &R) -> Self {
+        let mut overrides = Self::default();
+        for attr in resource.attributes() {
+            let Ok(key) = std::str::from_utf8(attr.key()) else {
+                continue;
+            };
+            match key {
+                "service.name" if overrides.role.is_none() => {
+                    overrides.role = attr
+                        .value()
+                        .and_then(|value| value_as_utf8(&value).map(str::to_owned));
+                }
+                "service.instance.id" if overrides.role_instance.is_none() => {
+                    overrides.role_instance = attr
+                        .value()
+                        .and_then(|value| value_as_utf8(&value).map(str::to_owned));
+                }
+                _ => {}
+            }
+        }
+        overrides
+    }
+}
+
+struct DynamicField {
+    name: Cow<'static, str>,
+    type_id: BondDataType,
+    value_start: usize,
+    value_len: usize,
+}
+
+impl DynamicField {
+    fn field_def(&self, field_id: u16) -> FieldDef {
+        FieldDef {
+            name: self.name.clone(),
+            type_id: self.type_id,
+            field_id,
+        }
+    }
+}
+
+struct LogRecordParts<'a> {
+    timestamp: u64,
+    routing_event_name: Cow<'a, str>,
+    name: Option<Cow<'a, str>>,
+    severity_number: i32,
+    severity_text: Option<Cow<'a, str>>,
+    body: Option<Cow<'a, str>>,
+    trace_id: Option<[u8; 16]>,
+    span_id: Option<[u8; 8]>,
+    trace_flags: Option<u32>,
+    role: Cow<'a, str>,
+    role_instance: Cow<'a, str>,
+    obo_config: Option<&'a OboEventConfig>,
+    fields: Vec<FieldDef>,
+    dynamic_fields_start: usize,
+    dynamic_fields: Vec<DynamicField>,
+    dynamic_values: Vec<u8>,
+}
+
+impl<'a> LogRecordParts<'a> {
+    fn new<R: LogRecordView>(
+        record: &'a R,
+        metadata_fields: &'a MetadataFields,
+        resource_role: &'a RoleOverrides,
+        obo_event_map: Option<&'a OboEventMap>,
+    ) -> Self {
+        let cs = CommonSchemaRecord::detect(record);
+        let role = resource_role
+            .role
+            .as_deref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Borrowed(&metadata_fields.role));
+        let role_instance = resource_role
+            .role_instance
+            .as_deref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Borrowed(&metadata_fields.role_instance));
+
+        let mut parts = if cs.is_common_schema {
+            Self::from_common_schema(record, role, role_instance)
+        } else {
+            Self::from_canonical(record, role, role_instance)
+        };
+        parts.obo_config = lookup_obo_config(obo_event_map, parts.routing_event_name.as_ref());
+        parts.finish_fields();
+        parts
+    }
+
+    fn from_canonical<R: LogRecordView>(
+        record: &'a R,
+        role: Cow<'a, str>,
+        role_instance: Cow<'a, str>,
+    ) -> Self {
+        let event_name = normalized_event_name(record);
+        let name = event_name.map(Cow::Borrowed);
+        let routing_event_name = event_name
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Borrowed(CS_LOG_TYPENAME));
+        let severity_text = record
+            .severity_text()
+            .and_then(|b| std::str::from_utf8(b).ok())
+            .filter(|s| !s.is_empty())
+            .map(Cow::Borrowed);
+        let body = record.body().and_then(|body| {
+            (body.value_type() == ValueType::String)
+                .then(|| body.as_string())
+                .flatten()
+                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                .map(|value| Cow::Owned(value.to_owned()))
+        });
+        let mut parts = Self {
+            timestamp: record_timestamp(record),
+            routing_event_name,
+            name,
+            severity_number: record.severity_number().unwrap_or(0),
+            severity_text,
+            body,
+            trace_id: record.trace_id().copied(),
+            span_id: record.span_id().copied(),
+            trace_flags: record.flags(),
+            role,
+            role_instance,
+            obo_config: None,
+            fields: Vec::new(),
+            dynamic_fields_start: 0,
+            dynamic_fields: Vec::new(),
+            dynamic_values: Vec::new(),
+        };
+
+        for attr in record.attributes() {
+            let Ok(key) = std::str::from_utf8(attr.key()) else {
+                continue;
+            };
+            let Some(value) = attr.value() else {
+                continue;
+            };
+            parts.push_dynamic_value(Cow::Owned(key.to_owned()), &value);
+        }
+
+        parts
+    }
+
+    fn from_common_schema<R: LogRecordView>(
+        record: &'a R,
+        role: Cow<'a, str>,
+        role_instance: Cow<'a, str>,
+    ) -> Self {
+        let mut parts = Self {
+            timestamp: record_timestamp(record),
+            routing_event_name: Cow::Borrowed(CS_LOG_TYPENAME),
+            name: None,
+            severity_number: record.severity_number().unwrap_or(0),
+            severity_text: record
+                .severity_text()
+                .and_then(|b| std::str::from_utf8(b).ok())
+                .filter(|s| !s.is_empty())
+                .map(Cow::Borrowed),
+            body: record.body().and_then(|body| {
+                (body.value_type() == ValueType::String)
+                    .then(|| body.as_string())
+                    .flatten()
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .map(|value| Cow::Owned(value.to_owned()))
+            }),
+            trace_id: record.trace_id().copied(),
+            span_id: record.span_id().copied(),
+            trace_flags: record.flags(),
+            role,
+            role_instance,
+            obo_config: None,
+            fields: Vec::new(),
+            dynamic_fields_start: 0,
+            dynamic_fields: Vec::new(),
+            dynamic_values: Vec::new(),
+        };
+
+        let mut part_a_name = None;
+        let mut part_b_name = None;
+        for attr in record.attributes() {
+            let Ok(key) = std::str::from_utf8(attr.key()) else {
+                continue;
+            };
+            let value = attr.value();
+            match key {
+                KEY_CSVER | KEY_PARTB_TYPENAME => {}
+                "PartA.time" => {
+                    if let Some(time) = value.as_ref().and_then(value_as_utf8) {
+                        if let Some(nanos) = parse_rfc3339_nanos(time) {
+                            parts.timestamp = nanos;
+                        }
+                    }
+                }
+                "PartA.name" => {
+                    if let Some(name) = value
+                        .as_ref()
+                        .and_then(value_as_utf8)
+                        .filter(|s| !s.is_empty())
+                    {
+                        part_a_name = Some(Cow::Owned(name.to_owned()));
+                    }
+                }
+                "PartB.name" => {
+                    if let Some(name) = value
+                        .as_ref()
+                        .and_then(value_as_utf8)
+                        .filter(|s| !s.is_empty())
+                    {
+                        part_b_name = Some(Cow::Owned(name.to_owned()));
+                    }
+                }
+                "PartA.ext_dt_traceId" => {
+                    if let Some(trace_id) = value.as_ref().and_then(value_as_utf8) {
+                        if let Some(bytes) = parse_hex_bytes::<16>(trace_id) {
+                            parts.trace_id = Some(bytes);
+                        } else {
+                            parts.push_dynamic_str(Cow::Borrowed("trace.id"), trace_id);
+                        }
+                    }
+                }
+                "PartA.ext_dt_spanId" => {
+                    if let Some(span_id) = value.as_ref().and_then(value_as_utf8) {
+                        if let Some(bytes) = parse_hex_bytes::<8>(span_id) {
+                            parts.span_id = Some(bytes);
+                        } else {
+                            parts.push_dynamic_str(Cow::Borrowed("span.id"), span_id);
+                        }
+                    }
+                }
+                "PartA.ext_dt_traceFlags" => {
+                    if let Some(flags) = value.as_ref().and_then(value_as_i64) {
+                        if let Ok(flags) = u32::try_from(flags) {
+                            parts.trace_flags = Some(flags);
+                        }
+                    }
+                }
+                "PartA.ext_cloud_role" => {
+                    if let Some(value) = value
+                        .as_ref()
+                        .and_then(value_as_utf8)
+                        .filter(|s| !s.is_empty())
+                    {
+                        parts.role = Cow::Owned(value.to_owned());
+                    }
+                }
+                "PartA.ext_cloud_roleInstance" => {
+                    if let Some(value) = value
+                        .as_ref()
+                        .and_then(value_as_utf8)
+                        .filter(|s| !s.is_empty())
+                    {
+                        parts.role_instance = Cow::Owned(value.to_owned());
+                    }
+                }
+                "PartB.body" => {
+                    if let Some(value) = value.as_ref() {
+                        if let Some(body) = value_as_utf8(value) {
+                            parts.body = Some(Cow::Owned(body.to_owned()));
+                        } else {
+                            parts.push_dynamic_value(Cow::Borrowed(FIELD_BODY), value);
+                        }
+                    }
+                }
+                "PartB.severityNumber" => {
+                    if let Some(number) = value.as_ref().and_then(value_as_i64) {
+                        parts.severity_number = number.clamp(0, 24) as i32;
+                    }
+                }
+                "PartB.severityText" => {
+                    if let Some(text) = value
+                        .as_ref()
+                        .and_then(value_as_utf8)
+                        .filter(|s| !s.is_empty())
+                    {
+                        parts.severity_text = Some(Cow::Owned(text.to_owned()));
+                    }
+                }
+                "PartB.eventId" => {
+                    if let Some(value) = value.as_ref() {
+                        parts.push_dynamic_value(Cow::Borrowed("eventId"), value);
+                    }
+                }
+                key if key.starts_with("PartC.") => {
+                    if let Some(value) = value.as_ref() {
+                        parts.push_dynamic_value(
+                            Cow::Owned(key["PartC.".len()..].to_owned()),
+                            value,
+                        );
+                    }
+                }
+                key if key.starts_with("PartA.") => {
+                    if let Some(value) = value.as_ref() {
+                        parts.push_dynamic_value(
+                            Cow::Owned(key["PartA.".len()..].to_owned()),
+                            value,
+                        );
+                    }
+                }
+                key if key.starts_with("PartB.") => {
+                    if let Some(value) = value.as_ref() {
+                        parts.push_dynamic_value(
+                            Cow::Owned(key["PartB.".len()..].to_owned()),
+                            value,
+                        );
+                    }
+                }
+                _ => {
+                    if let Some(value) = value.as_ref() {
+                        parts.push_dynamic_value(Cow::Owned(key.to_owned()), value);
+                    }
+                }
+            }
+        }
+
+        parts.name = part_b_name.or(part_a_name);
+        if let Some(name) = &parts.name {
+            parts.routing_event_name = Cow::Owned(name.to_string());
+        }
+        parts
+    }
+
+    fn push_dynamic_value<'value, V>(&mut self, name: Cow<'static, str>, value: &V) -> bool
+    where
+        V: AnyValueView<'value>,
+    {
+        let Some(type_id) = bond_type_for_value(value) else {
+            return false;
+        };
+        let value_start = self.dynamic_values.len();
+        write_view_value(&mut self.dynamic_values, value, type_id);
+        let value_len = self.dynamic_values.len() - value_start;
+        self.dynamic_fields.push(DynamicField {
+            name,
+            type_id,
+            value_start,
+            value_len,
+        });
+        true
+    }
+
+    fn push_dynamic_str(&mut self, name: Cow<'static, str>, value: &str) {
+        let value_start = self.dynamic_values.len();
+        BondWriter::write_string(&mut self.dynamic_values, value);
+        let value_len = self.dynamic_values.len() - value_start;
+        self.dynamic_fields.push(DynamicField {
+            name,
+            type_id: BondDataType::BT_STRING,
+            value_start,
+            value_len,
+        });
+    }
+
+    fn finish_fields(&mut self) {
+        let estimated_capacity = 14 + self.dynamic_fields.len();
+        self.fields = Vec::with_capacity(estimated_capacity);
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_ENV_NAME),
+            type_id: BondDataType::BT_STRING,
+            field_id: 1,
+        });
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_ENV_VER),
+            type_id: BondDataType::BT_STRING,
+            field_id: 2,
+        });
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_TIMESTAMP),
+            type_id: BondDataType::BT_STRING,
+            field_id: 3,
+        });
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_ENV_TIME),
+            type_id: BondDataType::BT_STRING,
+            field_id: 4,
+        });
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_TENANT),
+            type_id: BondDataType::BT_STRING,
+            field_id: 5,
+        });
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_ROLE),
+            type_id: BondDataType::BT_STRING,
+            field_id: 6,
+        });
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(FIELD_ROLE_INSTANCE),
+            type_id: BondDataType::BT_STRING,
+            field_id: 7,
+        });
+
+        if self.trace_id.is_some() {
+            self.push_field(FIELD_TRACE_ID, BondDataType::BT_STRING);
+        }
+        if self.span_id.is_some() {
+            self.push_field(FIELD_SPAN_ID, BondDataType::BT_STRING);
+        }
+        if self.trace_flags.is_some() {
+            self.push_field(FIELD_TRACE_FLAGS, BondDataType::BT_UINT32);
+        }
+        if self.name.is_some() {
+            self.push_field(FIELD_NAME, BondDataType::BT_STRING);
+        }
+        self.push_field(FIELD_SEVERITY_NUMBER, BondDataType::BT_INT32);
+        if self.severity_text.is_some() {
+            self.push_field(FIELD_SEVERITY_TEXT, BondDataType::BT_STRING);
+        }
+        if self.body.is_some() {
+            self.push_field(FIELD_BODY, BondDataType::BT_STRING);
+        }
+        if self.obo_config.is_some_and(|c| c.is_active()) {
+            self.push_field(FIELD_OBO_SERVICE_ID, BondDataType::BT_STRING);
+            if self
+                .obo_config
+                .and_then(OboEventConfig::active_annotations)
+                .is_some()
+            {
+                self.push_field(FIELD_OBO_ANNOTATIONS, BondDataType::BT_STRING);
+            }
+        }
+
+        self.dynamic_fields_start = self.fields.len();
+        for dynamic in &self.dynamic_fields {
+            let field_id = (self.fields.len() + 1) as u16;
+            self.fields.push(dynamic.field_def(field_id));
+        }
+    }
+
+    fn push_field(&mut self, name: &'static str, type_id: BondDataType) {
+        self.fields.push(FieldDef {
+            name: Cow::Borrowed(name),
+            type_id,
+            field_id: (self.fields.len() + 1) as u16,
+        });
+    }
+}
+
+#[derive(Default)]
+struct CommonSchemaRecord {
+    is_common_schema: bool,
+}
+
+impl CommonSchemaRecord {
+    fn detect(record: &impl LogRecordView) -> Self {
+        let mut has_version = false;
+        let mut has_log_type = false;
+        for attr in record.attributes() {
+            let Ok(key) = std::str::from_utf8(attr.key()) else {
+                continue;
+            };
+            match key {
+                KEY_CSVER => {
+                    has_version = attr
+                        .value()
+                        .and_then(|value| value_as_i64(&value))
+                        .is_some_and(|value| value == CS_VERSION_4);
+                }
+                KEY_PARTB_TYPENAME => {
+                    has_log_type = attr.value().is_some_and(|value| {
+                        value_as_utf8(&value).is_some_and(|value| value == CS_LOG_TYPENAME)
+                    });
+                }
+                _ => {}
+            }
+            if has_version && has_log_type {
+                return Self {
+                    is_common_schema: true,
+                };
+            }
+        }
+        Self::default()
+    }
+}
+
+fn record_timestamp(record: &impl LogRecordView) -> u64 {
+    record
+        .time_unix_nano()
+        .filter(|&t| t != 0)
+        .or_else(|| record.observed_time_unix_nano())
+        .unwrap_or(0)
+}
+
+fn value_as_utf8<'value, V>(value: &V) -> Option<&str>
+where
+    V: AnyValueView<'value>,
+{
+    if value.value_type() != ValueType::String {
+        return None;
+    }
+    value
+        .as_string()
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+}
+
+fn value_as_i64<'value, V>(value: &V) -> Option<i64>
+where
+    V: AnyValueView<'value>,
+{
+    (value.value_type() == ValueType::Int64)
+        .then(|| value.as_int64())
+        .flatten()
+}
+
+fn bond_type_for_value<'value, V>(value: &V) -> Option<BondDataType>
+where
+    V: AnyValueView<'value>,
+{
+    match value.value_type() {
+        ValueType::String if value_as_utf8(value).is_some() => Some(BondDataType::BT_STRING),
+        ValueType::Int64 if value.as_int64().is_some() => Some(BondDataType::BT_INT64),
+        ValueType::Double if value.as_double().is_some() => Some(BondDataType::BT_DOUBLE),
+        ValueType::Bool if value.as_bool().is_some() => Some(BondDataType::BT_BOOL),
+        _ => None,
+    }
+}
+
+fn write_view_value<'value, V>(buffer: &mut Vec<u8>, value: &V, type_id: BondDataType)
+where
+    V: AnyValueView<'value>,
+{
+    match type_id {
+        BondDataType::BT_STRING => {
+            if let Some(value) = value_as_utf8(value) {
+                BondWriter::write_string(buffer, value);
+            }
+        }
+        BondDataType::BT_INT64 => {
+            if let Some(value) = value.as_int64() {
+                BondWriter::write_numeric(buffer, value);
+            }
+        }
+        BondDataType::BT_DOUBLE => {
+            if let Some(value) = value.as_double() {
+                BondWriter::write_numeric(buffer, value);
+            }
+        }
+        BondDataType::BT_BOOL => {
+            if let Some(value) = value.as_bool() {
+                BondWriter::write_bool(buffer, value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_rfc3339_nanos(value: &str) -> Option<u64> {
+    let nanos = chrono::DateTime::parse_from_rfc3339(value)
+        .ok()?
+        .timestamp_nanos_opt()?;
+    u64::try_from(nanos).ok()
+}
+
+fn parse_hex_bytes<const N: usize>(value: &str) -> Option<[u8; N]> {
+    if value.len() != N * 2 {
+        return None;
+    }
+    let mut bytes = [0u8; N];
+    hex::decode_to_slice(value, &mut bytes).ok()?;
+    Some(bytes)
 }
 
 /// Metadata fields that should appear as Bond schema fields (queryable in Geneva)
@@ -150,13 +724,21 @@ impl MetadataFields {
     pub(crate) fn metadata_string(&self) -> &str {
         &self.metadata_string
     }
+
+    fn metadata_string_for(&self, role: &str, role_instance: &str) -> String {
+        format!(
+            "namespace={}/eventVersion={}/tenant={}/role={}/roleinstance={}",
+            self.namespace, self.event_version, self.tenant, role, role_instance
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Log batch accumulator
 // ---------------------------------------------------------------------------
 
-/// Accumulates log records (from any source) into per-event-name Bond batches.
+/// Accumulates log records (from any source) into Bond batches keyed by routing
+/// event name and effective role identity.
 ///
 /// Drive it with a `for` loop calling [`push`](LogBatchAccumulator::push) for
 /// each record, then call [`finalize`](LogBatchAccumulator::finalize) to
@@ -164,14 +746,13 @@ impl MetadataFields {
 /// "lending iterator" problem that arises when flattening GAT-backed view
 /// iterators with `flat_map`.
 struct LogBatchAccumulator {
-    // Arc<str> as key: Borrow<str> is satisfied (unlike Arc<String>), so
-    // get_mut/contains_key can be called with a plain &str — no allocation on lookup.
-    batches: HashMap<Arc<str>, BatchData>,
+    batches: HashMap<String, BatchData>,
 }
 
 struct BatchData {
     // Cached Arc clone of the HashMap key for cheap reuse in CentralEventEntry.
     routing_name: Arc<str>,
+    blob_metadata: String,
     schemas: Vec<CentralSchemaEntry>,
     events: Vec<CentralEventEntry>,
     metadata: BatchMetadata,
@@ -213,28 +794,27 @@ impl LogBatchAccumulator {
         &mut self,
         record: &R,
         metadata_fields: &MetadataFields,
+        resource_role: &RoleOverrides,
         obo_event_map: Option<&OboEventMap>,
     ) {
-        let timestamp = record
-            .time_unix_nano()
-            .filter(|&t| t != 0)
-            .or_else(|| record.observed_time_unix_nano())
-            .unwrap_or(0);
-        let routing_event_name = normalized_event_name(record).unwrap_or("Log");
+        let parts = LogRecordParts::new(record, metadata_fields, resource_role, obo_event_map);
+        let timestamp = parts.timestamp;
+        let routing_event_name = parts.routing_event_name.as_ref();
+        // Role identity is included because the central blob metadata is batch-level.
+        // Mixing roles would make the per-row Role columns disagree with upload metadata.
+        let batch_key = format!(
+            "{}\0{}\0{}",
+            routing_event_name, parts.role, parts.role_instance
+        );
 
-        // Look up per-event OBO config
-        let obo_config = lookup_obo_config(obo_event_map, routing_event_name);
-
-        let (field_info, dynamic_fields_start) = OtlpEncoder::determine_fields(record, obo_config);
-
-        // Only allocate Arc<str> when we see a new event name for the first time.
-        // Arc<str>: Borrow<str>, so contains_key / get_mut accept a plain &str.
-        if !self.batches.contains_key(routing_event_name) {
+        if !self.batches.contains_key(&batch_key) {
             let key: Arc<str> = Arc::from(routing_event_name);
             self.batches.insert(
-                Arc::clone(&key),
+                batch_key.clone(),
                 BatchData {
                     routing_name: key,
+                    blob_metadata: metadata_fields
+                        .metadata_string_for(parts.role.as_ref(), parts.role_instance.as_ref()),
                     schemas: Vec::new(),
                     events: Vec::new(),
                     metadata: BatchMetadata {
@@ -246,7 +826,7 @@ impl LogBatchAccumulator {
             );
         }
 
-        let entry = self.batches.get_mut(routing_event_name).unwrap();
+        let entry = self.batches.get_mut(&batch_key).unwrap();
 
         if timestamp != 0 {
             entry.metadata.start_time = entry.metadata.start_time.min(timestamp);
@@ -255,30 +835,24 @@ impl LogBatchAccumulator {
 
         // Find or create schema (reverse comparison: dynamic attrs vary more)
         let schema_id = match entry.schemas.iter().position(|s| {
-            s.fields.len() == field_info.len()
+            s.fields.len() == parts.fields.len()
                 && s.fields
                     .iter()
-                    .zip(&field_info)
+                    .zip(&parts.fields)
                     .rev()
                     .all(|(a, b)| a.type_id == b.type_id && a.name == b.name)
         }) {
             Some(idx) => (idx + 1) as u64,
             None => {
                 let new_id = (entry.schemas.len() + 1) as u64;
-                let schema_entry = OtlpEncoder::create_schema(new_id, &field_info);
+                let schema_entry = OtlpEncoder::create_schema(new_id, &parts.fields);
                 entry.schemas.push(schema_entry);
                 new_id
             }
         };
 
-        let row_buffer = OtlpEncoder::write_row_data(
-            record,
-            &field_info,
-            dynamic_fields_start,
-            metadata_fields,
-            obo_config,
-        );
-        let level = record.severity_number().unwrap_or(0) as u8;
+        let row_buffer = OtlpEncoder::write_row_parts(&parts, metadata_fields);
+        let level = parts.severity_number as u8;
         // Reuse the Arc already stored in BatchData — just a refcount increment.
         let event_name = Arc::clone(&entry.routing_name);
 
@@ -291,10 +865,11 @@ impl LogBatchAccumulator {
     }
 
     /// Compress all accumulated batches and return the encoded results.
-    fn finalize(self, metadata_fields: &MetadataFields) -> Result<Vec<EncodedBatch>, String> {
+    fn finalize(self) -> Result<Vec<EncodedBatch>, String> {
         let mut blobs = Vec::with_capacity(self.batches.len());
 
-        for (batch_event_name, mut batch_data) in self.batches {
+        for (_, mut batch_data) in self.batches {
+            let batch_event_name = Arc::clone(&batch_data.routing_name);
             let schema_ids_string = batch_data.format_schema_ids();
             batch_data.metadata.schema_ids = schema_ids_string;
 
@@ -304,7 +879,7 @@ impl LogBatchAccumulator {
             let blob = CentralBlob {
                 version: 1,
                 format: 2,
-                metadata: metadata_fields.metadata_string().to_owned(),
+                metadata: batch_data.blob_metadata,
                 schemas: batch_data.schemas,
                 events: batch_data.events,
             };
@@ -380,13 +955,18 @@ impl OtlpEncoder {
     ) -> Result<Vec<EncodedBatch>, String> {
         let mut acc = LogBatchAccumulator::new();
         for resource_logs in view.resources() {
+            let resource_role = resource_logs
+                .resource()
+                .as_ref()
+                .map(RoleOverrides::from_resource)
+                .unwrap_or_default();
             for scope_logs in resource_logs.scopes() {
                 for log_record in scope_logs.log_records() {
-                    acc.push(&log_record, metadata_fields, obo_event_map);
+                    acc.push(&log_record, metadata_fields, &resource_role, obo_event_map);
                 }
             }
         }
-        acc.finalize(metadata_fields)
+        acc.finalize()
     }
 
     /// Encode a batch of spans into a single payload
@@ -402,9 +982,7 @@ impl OtlpEncoder {
         // All spans use "Span" as event name for routing - no grouping by span name
         const EVENT_NAME: &str = "Span";
 
-        // Look up OBO for span events
         let obo_config = lookup_obo_config(obo_event_map, EVENT_NAME);
-
         let mut schemas = Vec::new();
         let mut events = Vec::new();
         let mut start_time = u64::MAX;
@@ -546,154 +1124,52 @@ impl OtlpEncoder {
     // ---------------------------------------------------------------------------
 
     /// Determine Bond schema fields for any [`LogRecordView`].
-    fn determine_fields(
-        record: &impl LogRecordView,
-        obo_config: Option<&OboEventConfig>,
-    ) -> (Vec<FieldDef>, usize) {
-        let estimated_capacity = 14 + 3; // base + conditional; attributes appended below
-        let mut fields: Vec<(Cow<'static, str>, BondDataType)> =
-            Vec::with_capacity(estimated_capacity);
-
-        // Part A – always present
-        fields.push((Cow::Borrowed(FIELD_ENV_NAME), BondDataType::BT_STRING));
-        fields.push((FIELD_ENV_VER.into(), BondDataType::BT_STRING));
-        fields.push((FIELD_TIMESTAMP.into(), BondDataType::BT_STRING));
-        fields.push((FIELD_ENV_TIME.into(), BondDataType::BT_STRING));
-        fields.push((FIELD_TENANT.into(), BondDataType::BT_STRING));
-        fields.push((FIELD_ROLE.into(), BondDataType::BT_STRING));
-        fields.push((FIELD_ROLE_INSTANCE.into(), BondDataType::BT_STRING));
-
-        // Part A extension – conditional correlation fields
-        if record.trace_id().is_some() {
-            fields.push((FIELD_TRACE_ID.into(), BondDataType::BT_STRING));
-        }
-        if record.span_id().is_some() {
-            fields.push((FIELD_SPAN_ID.into(), BondDataType::BT_STRING));
-        }
-        if record.flags().is_some() {
-            fields.push((FIELD_TRACE_FLAGS.into(), BondDataType::BT_UINT32));
-        }
-
-        // Part B – core log fields
-        if record.event_name().and_then(non_blank_utf8).is_some() {
-            fields.push((FIELD_NAME.into(), BondDataType::BT_STRING));
-        }
-        fields.push((FIELD_SEVERITY_NUMBER.into(), BondDataType::BT_INT32));
-        if record
-            .severity_text()
-            .and_then(|b| std::str::from_utf8(b).ok())
-            .filter(|s| !s.is_empty())
-            .is_some()
-        {
-            fields.push((FIELD_SEVERITY_TEXT.into(), BondDataType::BT_STRING));
-        }
-        if record.body().is_some_and(|b| {
-            b.value_type() == ValueType::String
-                && b.as_string()
-                    .and_then(|bs| std::str::from_utf8(bs).ok())
-                    .is_some()
-        }) {
-            fields.push((FIELD_BODY.into(), BondDataType::BT_STRING));
-        }
-
-        // OBO fields — only if this event has OBO config with non-empty identity
-        if obo_config.is_some_and(|c| c.is_active()) {
-            fields.push((FIELD_OBO_SERVICE_ID.into(), BondDataType::BT_STRING));
-            if obo_config.unwrap().active_annotations().is_some() {
-                fields.push((FIELD_OBO_ANNOTATIONS.into(), BondDataType::BT_STRING));
-            }
-        }
-
-        // Part C – dynamic attributes
-        let dynamic_fields_start = fields.len();
-        for attr in record.attributes() {
-            let key = match std::str::from_utf8(attr.key()) {
-                Ok(k) => k,
-                Err(_) => continue,
-            };
-            let val = match attr.value() {
-                Some(v) => v,
-                None => continue,
-            };
-            let type_id = match val.value_type() {
-                ValueType::String => {
-                    if val
-                        .as_string()
-                        .and_then(|bs| std::str::from_utf8(bs).ok())
-                        .is_some()
-                    {
-                        BondDataType::BT_STRING
-                    } else {
-                        continue;
-                    }
-                }
-                ValueType::Int64 => {
-                    if val.as_int64().is_some() {
-                        BondDataType::BT_INT64
-                    } else {
-                        continue;
-                    }
-                }
-                ValueType::Double => {
-                    if val.as_double().is_some() {
-                        BondDataType::BT_DOUBLE
-                    } else {
-                        continue;
-                    }
-                }
-                ValueType::Bool => {
-                    if val.as_bool().is_some() {
-                        BondDataType::BT_BOOL
-                    } else {
-                        continue;
-                    }
-                }
-                _ => continue,
-            };
-            fields.push((Cow::Owned(key.to_owned()), type_id));
-        }
-
-        let fields = fields
-            .into_iter()
-            .enumerate()
-            .map(|(i, (name, type_id))| FieldDef {
-                name,
-                type_id,
-                field_id: (i + 1) as u16,
-            })
-            .collect();
-        (fields, dynamic_fields_start)
+    #[cfg(test)]
+    fn determine_fields(record: &impl LogRecordView) -> (Vec<FieldDef>, usize) {
+        let metadata_fields = MetadataFields::new(
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        );
+        let role_overrides = RoleOverrides::default();
+        let parts = LogRecordParts::new(record, &metadata_fields, &role_overrides, None);
+        (parts.fields, parts.dynamic_fields_start)
     }
 
     /// Write Bond row data for any [`LogRecordView`].
+    #[cfg(test)]
     fn write_row_data(
         record: &impl LogRecordView,
         fields: &[FieldDef],
         dynamic_fields_start: usize,
         metadata_fields: &MetadataFields,
-        obo_config: Option<&OboEventConfig>,
     ) -> Vec<u8> {
-        let mut buffer = Vec::with_capacity(fields.len() * 50);
-        let timestamp_nanos = record
-            .time_unix_nano()
-            .filter(|&t| t != 0)
-            .or_else(|| record.observed_time_unix_nano())
-            .unwrap_or(0);
-        let formatted_timestamp = Self::format_timestamp(timestamp_nanos);
-        for field in &fields[..dynamic_fields_start] {
+        let role_overrides = RoleOverrides::default();
+        let parts = LogRecordParts::new(record, metadata_fields, &role_overrides, None);
+        debug_assert_eq!(fields.len(), parts.fields.len());
+        debug_assert_eq!(dynamic_fields_start, parts.dynamic_fields_start);
+        Self::write_row_parts(&parts, metadata_fields)
+    }
+
+    fn write_row_parts(parts: &LogRecordParts<'_>, metadata_fields: &MetadataFields) -> Vec<u8> {
+        let mut buffer = Vec::with_capacity(parts.fields.len() * 50);
+        let formatted_timestamp = Self::format_timestamp(parts.timestamp);
+        for field in &parts.fields[..parts.dynamic_fields_start] {
             match field.name.as_ref() {
                 FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, &metadata_fields.env_name),
                 FIELD_ENV_VER => BondWriter::write_string(&mut buffer, &metadata_fields.env_ver),
                 FIELD_TENANT => BondWriter::write_string(&mut buffer, &metadata_fields.tenant),
-                FIELD_ROLE => BondWriter::write_string(&mut buffer, &metadata_fields.role),
-                FIELD_ROLE_INSTANCE => {
-                    BondWriter::write_string(&mut buffer, &metadata_fields.role_instance)
-                }
+                FIELD_ROLE => BondWriter::write_string(&mut buffer, &parts.role),
+                FIELD_ROLE_INSTANCE => BondWriter::write_string(&mut buffer, &parts.role_instance),
                 FIELD_TIMESTAMP | FIELD_ENV_TIME => {
                     BondWriter::write_string(&mut buffer, &formatted_timestamp);
                 }
                 FIELD_TRACE_ID => {
-                    if let Some(id) = record.trace_id().copied() {
+                    if let Some(id) = parts.trace_id {
                         let hex = Self::encode_id_to_hex::<32>(&id);
                         let s = std::str::from_utf8(&hex)
                             .expect("hex encoding always produces valid UTF-8");
@@ -701,7 +1177,7 @@ impl OtlpEncoder {
                     }
                 }
                 FIELD_SPAN_ID => {
-                    if let Some(id) = record.span_id().copied() {
+                    if let Some(id) = parts.span_id {
                         let hex = Self::encode_id_to_hex::<16>(&id);
                         let s = std::str::from_utf8(&hex)
                             .expect("hex encoding always produces valid UTF-8");
@@ -709,43 +1185,34 @@ impl OtlpEncoder {
                     }
                 }
                 FIELD_TRACE_FLAGS => {
-                    BondWriter::write_numeric(&mut buffer, record.flags().unwrap_or(0));
+                    BondWriter::write_numeric(&mut buffer, parts.trace_flags.unwrap_or(0));
                 }
                 FIELD_NAME => {
-                    BondWriter::write_string(
-                        &mut buffer,
-                        normalized_event_name(record).unwrap_or(""),
-                    );
+                    BondWriter::write_string(&mut buffer, parts.name.as_deref().unwrap_or(""));
                 }
                 FIELD_SEVERITY_NUMBER => {
-                    BondWriter::write_numeric(&mut buffer, record.severity_number().unwrap_or(0));
+                    BondWriter::write_numeric(&mut buffer, parts.severity_number);
                 }
                 FIELD_SEVERITY_TEXT => {
-                    if let Some(text) = record
-                        .severity_text()
-                        .and_then(|b| std::str::from_utf8(b).ok())
-                    {
+                    if let Some(text) = &parts.severity_text {
                         BondWriter::write_string(&mut buffer, text);
                     }
                 }
                 FIELD_BODY => {
-                    if let Some(body) = record.body() {
-                        if body.value_type() == ValueType::String {
-                            if let Some(bytes) = body.as_string() {
-                                if let Ok(s) = std::str::from_utf8(bytes) {
-                                    BondWriter::write_string(&mut buffer, s);
-                                }
-                            }
-                        }
+                    if let Some(body) = &parts.body {
+                        BondWriter::write_string(&mut buffer, body);
                     }
                 }
                 FIELD_OBO_SERVICE_ID => {
-                    if let Some(config) = obo_config.filter(|c| c.is_active()) {
+                    if let Some(config) = parts.obo_config.filter(|c| c.is_active()) {
                         BondWriter::write_string(&mut buffer, config.identity.trim());
                     }
                 }
                 FIELD_OBO_ANNOTATIONS => {
-                    if let Some(ann) = obo_config.and_then(|c| c.active_annotations()) {
+                    if let Some(ann) = parts
+                        .obo_config
+                        .and_then(OboEventConfig::active_annotations)
+                    {
                         BondWriter::write_string(&mut buffer, ann);
                     }
                 }
@@ -753,80 +1220,17 @@ impl OtlpEncoder {
             }
         }
 
-        let expected_dynamic_fields = fields.len().saturating_sub(dynamic_fields_start);
+        let expected_dynamic_fields = parts
+            .fields
+            .len()
+            .saturating_sub(parts.dynamic_fields_start);
         if expected_dynamic_fields > 0 {
-            let mut written_dynamic_fields = 0usize;
-            // IMPORTANT: This iteration must yield attributes in the same order as
-            // determine_fields. All current LogRecordView implementations are
-            // deterministic, but this is an implicit contract not enforced by the trait.
-            for attr in record.attributes() {
-                let key = match std::str::from_utf8(attr.key()) {
-                    Ok(key) => key,
-                    Err(_) => continue,
-                };
-                let val = match attr.value() {
-                    Some(v) => v,
-                    None => continue,
-                };
-                match val.value_type() {
-                    ValueType::String => {
-                        if let Some(bytes) = val.as_string() {
-                            if let Ok(s) = std::str::from_utf8(bytes) {
-                                debug_assert_eq!(
-                                    fields
-                                        .get(dynamic_fields_start + written_dynamic_fields)
-                                        .map(|field| field.name.as_ref()),
-                                    Some(key),
-                                    "attribute iteration order mismatch between determine_fields and write_row_data"
-                                );
-                                BondWriter::write_string(&mut buffer, s);
-                                written_dynamic_fields += 1;
-                            }
-                        }
-                    }
-                    ValueType::Int64 => {
-                        if let Some(i) = val.as_int64() {
-                            debug_assert_eq!(
-                                fields
-                                    .get(dynamic_fields_start + written_dynamic_fields)
-                                    .map(|field| field.name.as_ref()),
-                                Some(key),
-                                "attribute iteration order mismatch between determine_fields and write_row_data"
-                            );
-                            BondWriter::write_numeric(&mut buffer, i);
-                            written_dynamic_fields += 1;
-                        }
-                    }
-                    ValueType::Double => {
-                        if let Some(d) = val.as_double() {
-                            debug_assert_eq!(
-                                fields
-                                    .get(dynamic_fields_start + written_dynamic_fields)
-                                    .map(|field| field.name.as_ref()),
-                                Some(key),
-                                "attribute iteration order mismatch between determine_fields and write_row_data"
-                            );
-                            BondWriter::write_numeric(&mut buffer, d);
-                            written_dynamic_fields += 1;
-                        }
-                    }
-                    ValueType::Bool => {
-                        if let Some(b) = val.as_bool() {
-                            debug_assert_eq!(
-                                fields
-                                    .get(dynamic_fields_start + written_dynamic_fields)
-                                    .map(|field| field.name.as_ref()),
-                                Some(key),
-                                "attribute iteration order mismatch between determine_fields and write_row_data"
-                            );
-                            BondWriter::write_bool(&mut buffer, b);
-                            written_dynamic_fields += 1;
-                        }
-                    }
-                    _ => {}
-                }
+            for dynamic in &parts.dynamic_fields {
+                buffer.extend_from_slice(
+                    &parts.dynamic_values
+                        [dynamic.value_start..dynamic.value_start + dynamic.value_len],
+                );
             }
-            debug_assert_eq!(written_dynamic_fields, expected_dynamic_fields);
         }
         buffer
     }
@@ -888,11 +1292,12 @@ impl OtlpEncoder {
                 fields.push((FIELD_STATUS_MESSAGE.into(), BondDataType::BT_STRING));
             }
         }
-
-        // OBO fields — only if this event has OBO config with non-empty identity
         if obo_config.is_some_and(|c| c.is_active()) {
             fields.push((FIELD_OBO_SERVICE_ID.into(), BondDataType::BT_STRING));
-            if obo_config.unwrap().active_annotations().is_some() {
+            if obo_config
+                .and_then(OboEventConfig::active_annotations)
+                .is_some()
+            {
                 fields.push((FIELD_OBO_ANNOTATIONS.into(), BondDataType::BT_STRING));
             }
         }
@@ -1043,7 +1448,7 @@ impl OtlpEncoder {
                     }
                 }
                 FIELD_OBO_ANNOTATIONS => {
-                    if let Some(ann) = obo_config.and_then(|c| c.active_annotations()) {
+                    if let Some(ann) = obo_config.and_then(OboEventConfig::active_annotations) {
                         BondWriter::write_string(&mut buffer, ann);
                     }
                 }
@@ -1177,6 +1582,7 @@ mod tests {
     use super::*;
     use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
     use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+    use opentelemetry_proto::tonic::resource::v1::Resource;
 
     fn make_metadata(namespace: &str) -> MetadataFields {
         MetadataFields::new(
@@ -1194,13 +1600,25 @@ mod tests {
         encoder: &OtlpEncoder,
         logs: impl IntoIterator<Item = &'a LogRecord>,
         metadata: &MetadataFields,
-        obo_event_map: Option<&OboEventMap>,
+    ) -> Result<Vec<EncodedBatch>, String> {
+        encode_log_batch_with_resource_attrs(encoder, logs, Vec::new(), metadata)
+    }
+
+    fn encode_log_batch_with_resource_attrs<'a>(
+        encoder: &OtlpEncoder,
+        logs: impl IntoIterator<Item = &'a LogRecord>,
+        resource_attrs: Vec<KeyValue>,
+        metadata: &MetadataFields,
     ) -> Result<Vec<EncodedBatch>, String> {
         use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
         use prost::Message as _;
         let log_records: Vec<LogRecord> = logs.into_iter().cloned().collect();
         let bytes = opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest {
             resource_logs: vec![ResourceLogs {
+                resource: (!resource_attrs.is_empty()).then_some(Resource {
+                    attributes: resource_attrs,
+                    ..Default::default()
+                }),
                 scope_logs: vec![ScopeLogs {
                     log_records,
                     ..Default::default()
@@ -1209,7 +1627,43 @@ mod tests {
             }],
         }
         .encode_to_vec();
-        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, obo_event_map)
+        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, None)
+    }
+
+    fn string_attr(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_string())),
+            }),
+        }
+    }
+
+    fn int_attr(key: &str, value: i64) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::IntValue(value)),
+            }),
+        }
+    }
+
+    fn bool_attr(key: &str, value: bool) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::BoolValue(value)),
+            }),
+        }
+    }
+
+    fn double_attr(key: &str, value: f64) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::DoubleValue(value)),
+            }),
+        }
     }
 
     /// Wraps raw LogRecord proto bytes into a minimal ExportLogsServiceRequest encoding.
@@ -1281,7 +1735,7 @@ mod tests {
         });
 
         let metadata = make_metadata("testNamespace");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
 
         assert!(!result.is_empty());
     }
@@ -1329,8 +1783,7 @@ mod tests {
 
         // Encode multiple log records with different schema structures but same event_name
         let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata, None)
-                .unwrap();
+            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata).unwrap();
 
         // Should create one batch (same event_name = "user_action")
         assert_eq!(result.len(), 1);
@@ -1380,7 +1833,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "test_event");
@@ -1397,7 +1850,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Log");
@@ -1435,11 +1888,182 @@ mod tests {
         });
 
         let encoded =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
         // Smoke test: a rich proto-backed view encodes to a single non-empty batch.
         assert_eq!(encoded.len(), 1);
         assert_eq!(encoded[0].event_name, "view_event");
         assert!(!encoded[0].data.is_empty());
+    }
+
+    #[test]
+    fn test_common_schema_log_matches_equivalent_canonical_log() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-parity");
+        let timestamp = parse_rfc3339_nanos("2024-06-15T06:00:00Z").unwrap();
+
+        let canonical = LogRecord {
+            time_unix_nano: timestamp,
+            event_name: "CheckoutFailure".to_string(),
+            severity_number: 17,
+            severity_text: "ERROR".to_string(),
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("failed".to_string())),
+            }),
+            trace_id: hex::decode("0102030405060708090a0b0c0d0e0f10").unwrap(),
+            span_id: hex::decode("a1b2c3d4e5f60718").unwrap(),
+            flags: 1,
+            attributes: vec![
+                int_attr("eventId", 42),
+                string_attr("iKey", "AIM-abcd-1234"),
+                int_attr("result", 127),
+                double_attr("duration", 53.16),
+                bool_attr("success", false),
+            ],
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            observed_time_unix_nano: 1,
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.time", "2024-06-15T06:00:00Z"),
+                string_attr("PartA.ext_dt_traceId", "0102030405060708090a0b0c0d0e0f10"),
+                string_attr("PartA.ext_dt_spanId", "a1b2c3d4e5f60718"),
+                int_attr("PartA.ext_dt_traceFlags", 1),
+                string_attr("PartB.body", "failed"),
+                int_attr("PartB.severityNumber", 17),
+                string_attr("PartB.severityText", "ERROR"),
+                string_attr("PartB.name", "CheckoutFailure"),
+                int_attr("PartB.eventId", 42),
+                string_attr("PartA.iKey", "AIM-abcd-1234"),
+                int_attr("PartC.result", 127),
+                double_attr("PartC.duration", 53.16),
+                bool_attr("PartC.success", false),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&canonical), &metadata).unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_role_overrides_match_resource_service_attributes() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-role-parity");
+
+        let canonical = LogRecord {
+            time_unix_nano: parse_rfc3339_nanos("2024-06-15T06:00:00Z").unwrap(),
+            event_name: "RoleEvent".to_string(),
+            severity_number: 9,
+            body: Some(AnyValue {
+                value: Some(Value::StringValue("body".to_string())),
+            }),
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.time", "2024-06-15T06:00:00Z"),
+                string_attr("PartA.ext_cloud_role", "checkout"),
+                string_attr("PartA.ext_cloud_roleInstance", "instance-1"),
+                string_attr("PartB.name", "RoleEvent"),
+                int_attr("PartB.severityNumber", 9),
+                string_attr("PartB.body", "body"),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded = encode_log_batch_with_resource_attrs(
+            &encoder,
+            std::iter::once(&canonical),
+            vec![
+                string_attr("service.name", "checkout"),
+                string_attr("service.instance.id", "instance-1"),
+            ],
+            &metadata,
+        )
+        .unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
+    }
+
+    #[test]
+    fn test_common_schema_role_overrides_split_batches() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-role-split");
+
+        let checkout = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.ext_cloud_role", "checkout"),
+                string_attr("PartA.ext_cloud_roleInstance", "instance-1"),
+                string_attr("PartB.name", "SharedEvent"),
+                string_attr("PartB.body", "checkout"),
+            ],
+            ..Default::default()
+        };
+        let billing = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.ext_cloud_role", "billing"),
+                string_attr("PartA.ext_cloud_roleInstance", "instance-2"),
+                string_attr("PartB.name", "SharedEvent"),
+                string_attr("PartB.body", "billing"),
+            ],
+            ..Default::default()
+        };
+
+        let encoded =
+            encode_log_batch_via_proto(&encoder, [&checkout, &billing], &metadata).unwrap();
+
+        assert_eq!(encoded.len(), 2);
+        assert!(encoded
+            .iter()
+            .all(|batch| batch.event_name == "SharedEvent" && batch.row_count == 1));
+    }
+
+    #[test]
+    fn test_common_schema_non_string_body_is_preserved_as_part_c_body() {
+        let encoder = OtlpEncoder::new();
+        let metadata = make_metadata("cs-non-string-body");
+
+        let canonical = LogRecord {
+            event_name: "BodyEvent".to_string(),
+            attributes: vec![int_attr(FIELD_BODY, 42)],
+            ..Default::default()
+        };
+
+        let common_schema = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartB.name", "BodyEvent"),
+                int_attr("PartB.body", 42),
+            ],
+            ..Default::default()
+        };
+
+        let canonical_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&canonical), &metadata).unwrap();
+        let common_schema_encoded =
+            encode_log_batch_via_proto(&encoder, std::iter::once(&common_schema), &metadata)
+                .unwrap();
+
+        assert_single_batch_equal(&canonical_encoded, &common_schema_encoded);
     }
 
     #[test]
@@ -1462,9 +2086,9 @@ mod tests {
         };
 
         let with_empty =
-            encode_log_batch_via_proto(&encoder, [log_with_empty].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log_with_empty].iter(), &metadata).unwrap();
         let without =
-            encode_log_batch_via_proto(&encoder, [log_without].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log_without].iter(), &metadata).unwrap();
 
         assert_single_batch_equal(&with_empty, &without);
     }
@@ -1488,7 +2112,7 @@ mod tests {
 
         // Expected: encode a log without body
         let expected =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
 
         // Inject invalid UTF-8 into the body field via raw proto wire bytes.
         // body = AnyValue { string_value: [0xFF] }
@@ -1522,7 +2146,7 @@ mod tests {
         };
 
         let expected =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
 
         // Inject severity_text = [0xFF] directly into the LogRecord wire bytes.
         // severity_text field = 3 (LEN) => [0x1A, 0x01, 0xFF]
@@ -1554,7 +2178,7 @@ mod tests {
         };
 
         let expected =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
 
         // Inject attributes = [ KeyValue { key: [0xFF], value: AnyValue { string_value: "a" } } ]
         // KeyValue bytes:
@@ -1600,26 +2224,19 @@ mod tests {
         use prost::Message as _;
         let base_bytes = base_log.encode_to_vec();
         let base_ref = RawLogRecord::new(&base_bytes);
-        let (base_fields, base_dynamic_fields_start) =
-            OtlpEncoder::determine_fields(&base_ref, None);
+        let (base_fields, base_dynamic_fields_start) = OtlpEncoder::determine_fields(&base_ref);
         let base_row = OtlpEncoder::write_row_data(
             &base_ref,
             &base_fields,
             base_dynamic_fields_start,
             &metadata,
-            None,
         );
 
         let dup_bytes = dup_log.encode_to_vec();
         let dup_ref = RawLogRecord::new(&dup_bytes);
-        let (dup_fields, dup_dynamic_fields_start) = OtlpEncoder::determine_fields(&dup_ref, None);
-        let dup_row = OtlpEncoder::write_row_data(
-            &dup_ref,
-            &dup_fields,
-            dup_dynamic_fields_start,
-            &metadata,
-            None,
-        );
+        let (dup_fields, dup_dynamic_fields_start) = OtlpEncoder::determine_fields(&dup_ref);
+        let dup_row =
+            OtlpEncoder::write_row_data(&dup_ref, &dup_fields, dup_dynamic_fields_start, &metadata);
 
         assert_eq!(dup_fields.len() - dup_dynamic_fields_start, 2);
         assert_eq!(dup_row.len() - base_row.len(), 16);
@@ -1659,8 +2276,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata, None)
-                .unwrap();
+            encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata).unwrap();
 
         // All should be in one batch with same event_name
         assert_eq!(result.len(), 1);
@@ -1687,8 +2303,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2].iter(), &metadata, None).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log1, log2].iter(), &metadata).unwrap();
 
         // Should create 2 separate batches
         assert_eq!(result.len(), 2);
@@ -1711,7 +2326,7 @@ mod tests {
         };
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata, None).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].event_name, "Log"); // Should default to "Log"
@@ -1759,7 +2374,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result =
-            encode_log_batch_via_proto(&encoder, [log1, log2, log3, log4].iter(), &metadata, None)
+            encode_log_batch_via_proto(&encoder, [log1, log2, log3, log4].iter(), &metadata)
                 .unwrap();
 
         // Should create 3 batches: "user_action", "system_alert", "Log"
@@ -2019,7 +2634,7 @@ mod tests {
         ];
 
         let metadata = make_metadata("test");
-        let result = encode_log_batch_via_proto(&encoder, logs.iter(), &metadata, None).unwrap();
+        let result = encode_log_batch_via_proto(&encoder, logs.iter(), &metadata).unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].row_count, 3);
@@ -2061,7 +2676,7 @@ mod tests {
         };
 
         let encoded =
-            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata, None).unwrap();
+            encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
 
         // Confirm the selected timestamp is time_unix_nano, not observed_time_unix_nano
         assert_eq!(encoded[0].metadata.start_time, 1_000_000_000);
@@ -2188,397 +2803,5 @@ mod tests {
         assert_eq!(alpha.metadata.end_time, 3_000);
         assert_eq!(beta.metadata.start_time, 2_000);
         assert_eq!(beta.metadata.end_time, 4_000);
-    }
-
-    // ==================== OBO (On Behalf Of) Per-Event Tests ====================
-
-    fn make_obo_event_map(
-        event_name: &str,
-        identity: &str,
-        annotations: Option<&str>,
-    ) -> OboEventMap {
-        let mut map = HashMap::new();
-        map.insert(
-            event_name.to_string(),
-            OboEventConfig {
-                identity: identity.to_string(),
-                annotations: annotations.map(|s| s.to_string()),
-            },
-        );
-        map
-    }
-
-    #[test]
-    fn test_obo_lookup_matches_literal_event_name() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", Some("<Config/>"));
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "MyEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_obo_lookup_matches_anchored_event_name() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map("^MyEvent$", "Microsoft.TestService", Some("<Config/>"));
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "MyEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_obo_lookup_no_match_for_different_event() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", None);
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "OtherEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_obo_lookup_strips_anchored_event_name() {
-        let obo_map = make_obo_event_map("MyEvent", "Microsoft.TestService", None);
-        let config = lookup_obo_config(Some(&obo_map), "^MyEvent$");
-        assert!(config.is_some());
-    }
-
-    #[test]
-    fn test_obo_fields_in_log_schema() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map(
-            "TestEvent",
-            "Microsoft.SomeService",
-            Some(r#"<Config onBehalfFields="resourceId" priority="Normal"/>"#),
-        );
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok(), "OBO log batch should encode successfully");
-        let batches = result.unwrap();
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].row_count, 1);
-    }
-
-    #[test]
-    fn test_obo_fields_absent_when_not_configured() {
-        let metadata = make_metadata("TestNamespace");
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(&OtlpEncoder::new(), [log].iter(), &metadata, None);
-        assert!(
-            result.is_ok(),
-            "Log batch without OBO should encode successfully"
-        );
-    }
-
-    #[test]
-    fn test_obo_identity_only_no_annotations() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map("TestEvent", "Microsoft.SomeService", None);
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(
-            result.is_ok(),
-            "OBO with identity only should encode successfully"
-        );
-    }
-
-    #[test]
-    fn test_obo_fields_in_span_schema() {
-        let obo_config = OboEventConfig {
-            identity: "Microsoft.SomeService".to_string(),
-            annotations: Some(r#"<Config onBehalfFields="resourceId"/>"#.to_string()),
-        };
-        let span = Span {
-            trace_id: vec![1; 16],
-            span_id: vec![2; 8],
-            name: "test_span".to_string(),
-            kind: 1,
-            start_time_unix_nano: 1_700_000_000_000_000_000,
-            end_time_unix_nano: 1_700_000_001_000_000_000,
-            ..Default::default()
-        };
-        let fields = OtlpEncoder::determine_span_fields(&span, "Span", Some(&obo_config));
-        assert!(
-            fields
-                .iter()
-                .any(|f| f.name.as_ref() == FIELD_OBO_SERVICE_ID),
-            "Span schema should include onbehalfServiceId"
-        );
-        assert!(
-            fields
-                .iter()
-                .any(|f| f.name.as_ref() == FIELD_OBO_ANNOTATIONS),
-            "Span schema should include onbehalfAnnotations"
-        );
-    }
-
-    #[test]
-    fn test_encode_log_batch_with_obo() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map(
-            "TestEvent",
-            "Microsoft.BatchService",
-            Some(r#"<Config onBehalfFields="resourceId"/>"#),
-        );
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            severity_text: "INFO".to_string(),
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok(), "encode with OBO should succeed");
-        let batches = result.unwrap();
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].row_count, 1);
-    }
-
-    #[test]
-    fn test_encode_span_batch_with_obo() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map(
-            "Span",
-            "Microsoft.SpanBatchService",
-            Some(r#"<Config onBehalfFields="resourceId"/>"#),
-        );
-        let encoder = OtlpEncoder::new();
-        let span = Span {
-            trace_id: vec![1; 16],
-            span_id: vec![2; 8],
-            name: "test_span".to_string(),
-            kind: 1,
-            start_time_unix_nano: 1_700_000_000_000_000_000,
-            end_time_unix_nano: 1_700_000_001_000_000_000,
-            ..Default::default()
-        };
-        let result = encoder.encode_span_batch([span].iter(), &metadata, Some(&obo_map));
-        assert!(result.is_ok(), "encode_span_batch with OBO should succeed");
-        let batches = result.unwrap();
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].row_count, 1);
-    }
-
-    #[test]
-    fn test_mixed_batch_obo_and_non_obo_events() {
-        let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map(
-            "OboEvent",
-            "Microsoft.OboService",
-            Some(r#"<Config onBehalfFields="resourceId"/>"#),
-        );
-        let obo_log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "OboEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let regular_log = LogRecord {
-            observed_time_unix_nano: 1_700_000_001_000_000_000,
-            event_name: "RegularEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [obo_log, regular_log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok(), "Mixed batch should succeed");
-        let batches = result.unwrap();
-        assert_eq!(
-            batches.len(),
-            2,
-            "Should have separate batches for different event names"
-        );
-    }
-
-    #[test]
-    fn test_no_obo_map_means_no_obo() {
-        let metadata = make_metadata("TestNamespace");
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(&OtlpEncoder::new(), [log].iter(), &metadata, None);
-        assert!(result.is_ok(), "encode without OBO should succeed");
-    }
-
-    #[test]
-    fn test_obo_empty_identity_not_active() {
-        let metadata = make_metadata("TestNamespace");
-        let mut obo_map = HashMap::new();
-        obo_map.insert(
-            "TestEvent".to_string(),
-            OboEventConfig {
-                identity: "".to_string(),
-                annotations: Some("some annotations".to_string()),
-            },
-        );
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok(), "Should succeed even with empty identity");
-    }
-
-    #[test]
-    fn test_obo_whitespace_identity_not_active() {
-        let metadata = make_metadata("TestNamespace");
-        let mut obo_map = HashMap::new();
-        obo_map.insert(
-            "TestEvent".to_string(),
-            OboEventConfig {
-                identity: "   ".to_string(),
-                annotations: None,
-            },
-        );
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok(), "Should succeed with whitespace identity");
-    }
-
-    #[test]
-    fn test_obo_blank_annotations_suppressed() {
-        let metadata = make_metadata("TestNamespace");
-        let mut obo_map = HashMap::new();
-        obo_map.insert(
-            "TestEvent".to_string(),
-            OboEventConfig {
-                identity: "Microsoft.TestService".to_string(),
-                annotations: Some("   ".to_string()),
-            },
-        );
-        let log = LogRecord {
-            observed_time_unix_nano: 1_700_000_000_000_000_000,
-            event_name: "TestEvent".to_string(),
-            severity_number: 9,
-            ..Default::default()
-        };
-        let result = encode_log_batch_via_proto(
-            &OtlpEncoder::new(),
-            [log].iter(),
-            &metadata,
-            Some(&obo_map),
-        );
-        assert!(result.is_ok(), "Should succeed with blank annotations");
-        let batches = result.unwrap();
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].row_count, 1);
-    }
-
-    #[test]
-    fn test_obo_event_config_helpers() {
-        let active = OboEventConfig {
-            identity: "Microsoft.Service".to_string(),
-            annotations: Some("config".to_string()),
-        };
-        assert!(active.is_active());
-        assert_eq!(active.active_annotations(), Some("config"));
-
-        let empty_id = OboEventConfig {
-            identity: "".to_string(),
-            annotations: Some("config".to_string()),
-        };
-        assert!(!empty_id.is_active());
-
-        let whitespace_id = OboEventConfig {
-            identity: "   ".to_string(),
-            annotations: None,
-        };
-        assert!(!whitespace_id.is_active());
-
-        let blank_ann = OboEventConfig {
-            identity: "Microsoft.Service".to_string(),
-            annotations: Some("  ".to_string()),
-        };
-        assert!(blank_ann.is_active());
-        assert_eq!(blank_ann.active_annotations(), None);
-
-        let none_ann = OboEventConfig {
-            identity: "Microsoft.Service".to_string(),
-            annotations: None,
-        };
-        assert_eq!(none_ann.active_annotations(), None);
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -51,16 +51,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     let request_bytes = request.encode_to_vec();
     let request_view = RawLogsData::new(&request_bytes);
 
-    let batches = client
-        .encode_and_compress_logs(&request_view)
-        .expect("batch should encode");
-    assert_eq!(batches.len(), 1);
-    client
-        .upload_batch(&batches[0])
-        .await
-        .expect("batch should upload");
-
-    let detail = server.wait_for_request(&batches[0].event_name).await;
+    let detail = upload_single_batch_and_wait(&client, &server, &request_view).await;
     assert_eq!(detail["decode_status"], "decoded");
     assert_eq!(detail["event_name"], "CheckoutEvent");
     assert_eq!(detail["row_count"], 1);
@@ -73,6 +64,73 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     assert_eq!(payload["body"], "checkout failed");
     assert_eq!(payload["operation"], "checkout");
     assert_eq!(payload["result"], 127);
+
+    let common_schema_request = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            scope_logs: vec![ScopeLogs {
+                log_records: vec![LogRecord {
+                    time_unix_nano: 1_718_432_000_000_000_000,
+                    attributes: vec![
+                        int_attr("__csver__", 0x400),
+                        string_attr("PartA.time", "2024-06-15T06:00:00Z"),
+                        string_attr("PartA.ext_cloud_role", "checkout"),
+                        string_attr("PartA.ext_cloud_roleInstance", "instance-1"),
+                        string_attr("PartC.operation", "checkout"),
+                        int_attr("PartC.result", 127),
+                        string_attr("PartB._typeName", "Log"),
+                        string_attr("PartB.name", "CommonSchemaCheckoutEvent"),
+                        string_attr("PartB.body", "common schema checkout failed"),
+                        int_attr("PartB.severityNumber", 17),
+                        string_attr("PartB.severityText", "ERROR"),
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+    let common_schema_request_bytes = common_schema_request.encode_to_vec();
+    let common_schema_request_view = RawLogsData::new(&common_schema_request_bytes);
+
+    let common_schema_detail =
+        upload_single_batch_and_wait(&client, &server, &common_schema_request_view).await;
+    assert_eq!(common_schema_detail["decode_status"], "decoded");
+    assert_eq!(
+        common_schema_detail["event_name"],
+        "CommonSchemaCheckoutEvent"
+    );
+    assert_eq!(common_schema_detail["row_count"], 1);
+
+    let records = common_schema_detail["records"]
+        .as_array()
+        .expect("common schema records array");
+    assert_eq!(records.len(), 1);
+    let payload = &records[0]["payload"];
+    assert_eq!(payload["Role"], "checkout");
+    assert_eq!(payload["RoleInstance"], "instance-1");
+    assert_eq!(payload["body"], "common schema checkout failed");
+    assert_eq!(payload["SeverityNumber"], 17);
+    assert_eq!(payload["SeverityText"], "ERROR");
+    assert_eq!(payload["operation"], "checkout");
+    assert_eq!(payload["result"], 127);
+}
+
+async fn upload_single_batch_and_wait(
+    client: &GenevaClient,
+    server: &TestServer,
+    request_view: &RawLogsData<'_>,
+) -> serde_json::Value {
+    let batches = client
+        .encode_and_compress_logs(request_view)
+        .expect("batch should encode");
+    assert_eq!(batches.len(), 1);
+    client
+        .upload_batch(&batches[0])
+        .await
+        .expect("batch should upload");
+
+    server.wait_for_request(&batches[0].event_name).await
 }
 
 fn string_attr(key: &str, value: &str) -> KeyValue {


### PR DESCRIPTION
 Adds Common Schema auto-detection in `geneva-uploader` so Geneva-bound pipelines can encode CS-shaped OTLP log records directly, without requiring a separate CS-to-canonical processor step.

  ## Details

  - Detects CS log records via `__csver__` and `PartB._typeName`.
  - Maps CS PartA/PartB/PartC fields into Geneva payload columns.
  - Preserves canonical OTLP log behavior for normal records.
  - Supports mixed canonical and CS records in the same batch when routing event name, role, and role instance
  match.
  - Splits batches by event name, role, and role instance to keep batch-level metadata consistent.
  - Adds regression coverage for CS/canonical parity, malformed trace IDs, non-string bodies, severity
  passthrough, role overrides, and co-batching.