### PR TITLE
fix: include benches/ in tower instrumentation package

### DIFF
--- a/opentelemetry-instrumentation-tower/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib"
 documentation = "https://docs.rs/tower-otel-http-metrics"
 readme = "README.md"
-include = ["src/"]
+include = ["src/", "benches/"]
 
 [features]
 default = []


### PR DESCRIPTION
The `include` field in `Cargo.toml` only listed `src/`, so the `[[bench]]` target added in #548 would reference a missing file in the published crate. Adding `benches/` to the include list.