### PR TITLE
feat(user-events-trace): Add links, statusMessage, rpc attrs and fix time format

### DIFF
--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 - Add `links` field to Part B (serialized as JSON array of `{toTraceId, toSpanId}`)
 - Add `statusMessage` field to Part B for error spans with descriptions
-- Add `rpcSystem` and `rpcGrpcStatusCode` to well-known attribute mappings
-- Update well-known attribute keys to stable semantic conventions
-  (`db.system.name`, `db.namespace`, `db.query.text`, `messaging.destination.name`)
+- **Breaking**: Update well-known attribute mappings to use stable OTel semantic
+  conventions. The Common Schema output field names are unchanged, but the OTel
+  attribute keys that trigger the mapping have been updated:
+  - `db.system` → `db.system.name`, `db.name` → `db.namespace`,
+    `db.statement` → `db.query.text`, `messaging.destination` → `messaging.destination.name`
+  - Added `rpc.system` → `rpcSystem`, `rpc.grpc.status_code` → `rpcGrpcStatusCode`
 - Fix `PartA.time` and `PartB.startTime` to use UTC ISO 8601 with trailing `Z`
   instead of `+00:00`
 

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add `links` field to Part B (serialized as JSON array of `{toTraceId, toSpanId}`)
 - Add `statusMessage` field to Part B for error spans with descriptions
 - Add `rpcSystem` and `rpcGrpcStatusCode` to well-known attribute mappings
-- Add stable semconv keys (`db.system.name`, `db.namespace`, `db.query.text`,
-  `messaging.destination.name`) as additional mappings to existing CS fields
+- Update well-known attribute keys to stable semantic conventions
+  (`db.system.name`, `db.namespace`, `db.query.text`, `messaging.destination.name`)
 - Fix `PartA.time` and `PartB.startTime` to use UTC ISO 8601 with trailing `Z`
   instead of `+00:00`
 

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -9,7 +9,7 @@
   attribute keys that trigger the mapping have been updated:
   - `db.system` → `db.system.name`, `db.name` → `db.namespace`,
     `db.statement` → `db.query.text`, `messaging.destination` → `messaging.destination.name`
-  - Added `rpc.system` → `rpcSystem`, `rpc.grpc.status_code` → `rpcGrpcStatusCode`
+  - Added `rpc.system.name` → `rpcSystem`, `rpc.response.status_code` → `rpcGrpcStatusCode`
 - Fix `PartA.time` and `PartB.startTime` to use UTC ISO 8601 with trailing `Z`
   instead of `+00:00`
 

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `links` field to Part B (serialized as JSON array of `{toTraceId, toSpanId}`)
 - Add `statusMessage` field to Part B for error spans with descriptions
 - Add `rpcSystem` and `rpcGrpcStatusCode` to well-known attribute mappings
+- Add stable semconv keys (`db.system.name`, `db.namespace`, `db.query.text`,
+  `messaging.destination.name`) as additional mappings to existing CS fields
 - Fix `PartA.time` and `PartB.startTime` to use UTC ISO 8601 with trailing `Z`
   instead of `+00:00`
 

--- a/opentelemetry-user-events-trace/CHANGELOG.md
+++ b/opentelemetry-user-events-trace/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+- Add `links` field to Part B (serialized as JSON array of `{toTraceId, toSpanId}`)
+- Add `statusMessage` field to Part B for error spans with descriptions
+- Add `rpcSystem` and `rpcGrpcStatusCode` to well-known attribute mappings
+- Fix `PartA.time` and `PartB.startTime` to use UTC ISO 8601 with trailing `Z`
+  instead of `+00:00`
+
 ## v0.5.0
 
 Released 2026-May-13

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -46,6 +46,8 @@
 //! | `messaging.system`          | `messagingSystem`      |
 //! | `messaging.destination`     | `messagingDestination` |
 //! | `messaging.url`             | `messagingUrl`         |
+//! | `rpc.system`                | `rpcSystem`            |
+//! | `rpc.grpc.status_code`      | `rpcGrpcStatusCode`    |
 //!
 //! All other span attributes are exported with their original keys.
 
@@ -450,6 +452,127 @@ mod tests {
         assert!(
             event.get("PartC").is_none(),
             "PartC should not be present when there are no attributes"
+        );
+    }
+
+    /// Test span links and statusMessage serialization.
+    /// Creates a span with links to another span context and an error status with description.
+    #[ignore]
+    #[test]
+    fn integration_test_links_and_status_message() {
+        use opentelemetry::trace::{
+            Link, Span, SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+        };
+
+        check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = SdkTracerProvider::builder()
+            .with_resource(
+                opentelemetry_sdk::Resource::builder()
+                    .with_service_name("links_test")
+                    .build(),
+            )
+            .with_user_events_exporter("otel_trace_links")
+            .build();
+
+        let user_event_status = check_user_events_available().unwrap();
+        assert!(user_event_status.contains("otel_trace_links_L4K1"));
+
+        let perf_thread =
+            std::thread::spawn(|| run_perf_and_decode(5, "user_events:otel_trace_links_L4K1"));
+
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+
+        let tracer = provider.tracer("test-tracer");
+
+        // Create a linked span context (simulating a link to another trace)
+        let linked_trace_id =
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap();
+        let linked_span_id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
+        let linked_context = SpanContext::new(
+            linked_trace_id,
+            linked_span_id,
+            TraceFlags::SAMPLED,
+            false,
+            TraceState::default(),
+        );
+
+        let span_id_expected = {
+            let mut span = tracer
+                .span_builder("span-with-links")
+                .with_kind(SpanKind::Internal)
+                .with_links(vec![Link::new(linked_context, vec![], 0)])
+                .start(&tracer);
+            let sid = span.span_context().span_id();
+            span.set_status(Status::error("something went wrong"));
+            span.end();
+            sid
+        };
+
+        let result = perf_thread.join().expect("Perf thread panicked");
+        assert!(result.is_ok());
+        let formatted_output = result.unwrap().trim().to_string();
+
+        let json_value: Value = from_str(&formatted_output).expect("Failed to parse JSON");
+        let perf_data_key = json_value
+            .as_object()
+            .unwrap()
+            .keys()
+            .find(|k| k.contains("perf.data"))
+            .expect("No perf.data key found");
+
+        let events = json_value[perf_data_key].as_array().unwrap();
+
+        let span_id_str = span_id_expected.to_string();
+        let event = events
+            .iter()
+            .find(|e| {
+                e.get("PartA")
+                    .and_then(|a| a.get("ext_dt_spanId"))
+                    .and_then(|s| s.as_str())
+                    == Some(&span_id_str)
+            })
+            .expect("Span event not found");
+
+        // Validate PartB
+        let part_b = &event["PartB"];
+        assert_eq!(part_b["name"].as_str().unwrap(), "span-with-links");
+        assert!(!part_b["success"].as_bool().unwrap());
+
+        // statusMessage should be present for Error status with description
+        let status_msg = part_b
+            .get("statusMessage")
+            .expect("PartB.statusMessage should be present for error span");
+        assert_eq!(status_msg.as_str().unwrap(), "something went wrong");
+
+        // links should be present as JSON string
+        let links_str = part_b
+            .get("links")
+            .expect("PartB.links should be present")
+            .as_str()
+            .expect("links should be a string");
+        let links: Vec<Value> =
+            serde_json::from_str(links_str).expect("links should be valid JSON");
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0]["toTraceId"].as_str().unwrap(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(
+            links[0]["toSpanId"].as_str().unwrap(),
+            "00f067aa0ba902b7"
+        );
+
+        // Validate time fields have Z suffix (UTC ISO 8601)
+        let time_str = event["PartA"]["time"].as_str().unwrap();
+        assert!(
+            time_str.ends_with('Z'),
+            "PartA.time should end with 'Z', got: {time_str}"
+        );
+        let start_time_str = part_b["startTime"].as_str().unwrap();
+        assert!(
+            start_time_str.ends_with('Z'),
+            "PartB.startTime should end with 'Z', got: {start_time_str}"
         );
     }
 

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -38,13 +38,17 @@
 //! | Span Attribute              | Exported Field         |
 //! |-----------------------------|------------------------|
 //! | `db.system`                 | `dbSystem`             |
+//! | `db.system.name`            | `dbSystem`             |
 //! | `db.name`                   | `dbName`               |
+//! | `db.namespace`              | `dbName`               |
 //! | `db.statement`              | `dbStatement`          |
+//! | `db.query.text`             | `dbStatement`          |
 //! | `http.request.method`       | `httpMethod`           |
 //! | `url.full`                  | `httpUrl`              |
 //! | `http.response.status_code` | `httpStatusCode`       |
 //! | `messaging.system`          | `messagingSystem`      |
 //! | `messaging.destination`     | `messagingDestination` |
+//! | `messaging.destination.name`| `messagingDestination` |
 //! | `messaging.url`             | `messagingUrl`         |
 //! | `rpc.system`                | `rpcSystem`            |
 //! | `rpc.grpc.status_code`      | `rpcGrpcStatusCode`    |

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -486,8 +486,7 @@ mod tests {
         let tracer = provider.tracer("test-tracer");
 
         // Create a linked span context (simulating a link to another trace)
-        let linked_trace_id =
-            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap();
+        let linked_trace_id = TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap();
         let linked_span_id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
         let linked_context = SpanContext::new(
             linked_trace_id,
@@ -558,10 +557,7 @@ mod tests {
             links[0]["toTraceId"].as_str().unwrap(),
             "0af7651916cd43dd8448eb211c80319c"
         );
-        assert_eq!(
-            links[0]["toSpanId"].as_str().unwrap(),
-            "00f067aa0ba902b7"
-        );
+        assert_eq!(links[0]["toSpanId"].as_str().unwrap(), "00f067aa0ba902b7");
 
         // Validate time fields have Z suffix (UTC ISO 8601)
         let time_str = event["PartA"]["time"].as_str().unwrap();

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -46,8 +46,8 @@
 //! | `messaging.system`          | `messagingSystem`      |
 //! | `messaging.destination.name`| `messagingDestination` |
 //! | `messaging.url`             | `messagingUrl`         |
-//! | `rpc.system`                | `rpcSystem`            |
-//! | `rpc.grpc.status_code`      | `rpcGrpcStatusCode`    |
+//! | `rpc.system.name`           | `rpcSystem`            |
+//! | `rpc.response.status_code`  | `rpcGrpcStatusCode`    |
 //!
 //! All other span attributes are exported with their original keys.
 
@@ -790,8 +790,8 @@ mod tests {
 
             // Add RPC attributes to the client span to test rpcSystem/rpcGrpcStatusCode
             if *name == "client-span" {
-                span.set_attribute(KeyValue::new("rpc.system", "grpc"));
-                span.set_attribute(KeyValue::new("rpc.grpc.status_code", 0_i64));
+                span.set_attribute(KeyValue::new("rpc.system.name", "grpc"));
+                span.set_attribute(KeyValue::new("rpc.response.status_code", 0_i64));
             }
 
             let sid = span.span_context().span_id().to_string();

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -460,13 +460,13 @@ mod tests {
         );
     }
 
-    /// Test span links and statusMessage serialization.
-    /// Creates a span with links to another span context and an error status with description.
+    /// Test span links serialization.
+    /// Creates a span with links to another span context.
     #[ignore]
     #[test]
-    fn integration_test_links_and_status_message() {
+    fn integration_test_links() {
         use opentelemetry::trace::{
-            Link, Span, SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+            Link, Span, SpanContext, SpanId, SpanKind, TraceFlags, TraceId, TraceState,
         };
 
         check_user_events_available().expect("Kernel does not support user_events.");
@@ -508,7 +508,6 @@ mod tests {
                 .with_links(vec![Link::new(linked_context, vec![], 0)])
                 .start(&tracer);
             let sid = span.span_context().span_id();
-            span.set_status(Status::error("something went wrong"));
             span.end();
             sid
         };
@@ -541,13 +540,7 @@ mod tests {
         // Validate PartB
         let part_b = &event["PartB"];
         assert_eq!(part_b["name"].as_str().unwrap(), "span-with-links");
-        assert!(!part_b["success"].as_bool().unwrap());
-
-        // statusMessage should be present for Error status with description
-        let status_msg = part_b
-            .get("statusMessage")
-            .expect("PartB.statusMessage should be present for error span");
-        assert_eq!(status_msg.as_str().unwrap(), "something went wrong");
+        assert!(part_b["success"].as_bool().unwrap());
 
         // links should be present as JSON string
         let links_str = part_b
@@ -564,16 +557,90 @@ mod tests {
         );
         assert_eq!(links[0]["toSpanId"].as_str().unwrap(), "00f067aa0ba902b7");
 
-        // Validate time fields have Z suffix (UTC ISO 8601)
-        let time_str = event["PartA"]["time"].as_str().unwrap();
+        // statusMessage should not be present (no error)
         assert!(
-            time_str.ends_with('Z'),
-            "PartA.time should end with 'Z', got: {time_str}"
+            part_b.get("statusMessage").is_none(),
+            "statusMessage should not be present for successful span"
         );
-        let start_time_str = part_b["startTime"].as_str().unwrap();
+    }
+
+    /// Test statusMessage serialization for error spans.
+    #[ignore]
+    #[test]
+    fn integration_test_status_message() {
+        use opentelemetry::trace::{Span, SpanKind, Status};
+
+        check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = SdkTracerProvider::builder()
+            .with_resource(
+                opentelemetry_sdk::Resource::builder()
+                    .with_service_name("statusmsg_test")
+                    .build(),
+            )
+            .with_user_events_exporter("otel_trace_stmsg")
+            .build();
+
+        let user_event_status = check_user_events_available().unwrap();
+        assert!(user_event_status.contains("otel_trace_stmsg_L4K1"));
+
+        let perf_thread =
+            std::thread::spawn(|| run_perf_and_decode(5, "user_events:otel_trace_stmsg_L4K1"));
+
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+
+        let tracer = provider.tracer("test-tracer");
+
+        let span_id_expected = {
+            let mut span = tracer
+                .span_builder("error-span")
+                .with_kind(SpanKind::Client)
+                .start(&tracer);
+            let sid = span.span_context().span_id();
+            span.set_status(Status::error("something went wrong"));
+            span.end();
+            sid
+        };
+
+        let result = perf_thread.join().expect("Perf thread panicked");
+        assert!(result.is_ok());
+        let formatted_output = result.unwrap().trim().to_string();
+
+        let json_value: Value = from_str(&formatted_output).expect("Failed to parse JSON");
+        let perf_data_key = json_value
+            .as_object()
+            .unwrap()
+            .keys()
+            .find(|k| k.contains("perf.data"))
+            .expect("No perf.data key found");
+
+        let events = json_value[perf_data_key].as_array().unwrap();
+
+        let span_id_str = span_id_expected.to_string();
+        let event = events
+            .iter()
+            .find(|e| {
+                e.get("PartA")
+                    .and_then(|a| a.get("ext_dt_spanId"))
+                    .and_then(|s| s.as_str())
+                    == Some(&span_id_str)
+            })
+            .expect("Span event not found");
+
+        let part_b = &event["PartB"];
+        assert_eq!(part_b["name"].as_str().unwrap(), "error-span");
+        assert!(!part_b["success"].as_bool().unwrap());
+
+        // statusMessage should be present for Error status with description
+        let status_msg = part_b
+            .get("statusMessage")
+            .expect("PartB.statusMessage should be present for error span");
+        assert_eq!(status_msg.as_str().unwrap(), "something went wrong");
+
+        // links should not be present (no links)
         assert!(
-            start_time_str.ends_with('Z'),
-            "PartB.startTime should end with 'Z', got: {start_time_str}"
+            part_b.get("links").is_none(),
+            "links should not be present when span has no links"
         );
     }
 

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -37,17 +37,13 @@
 //!
 //! | Span Attribute              | Exported Field         |
 //! |-----------------------------|------------------------|
-//! | `db.system`                 | `dbSystem`             |
 //! | `db.system.name`            | `dbSystem`             |
-//! | `db.name`                   | `dbName`               |
 //! | `db.namespace`              | `dbName`               |
-//! | `db.statement`              | `dbStatement`          |
 //! | `db.query.text`             | `dbStatement`          |
 //! | `http.request.method`       | `httpMethod`           |
 //! | `url.full`                  | `httpUrl`              |
 //! | `http.response.status_code` | `httpStatusCode`       |
 //! | `messaging.system`          | `messagingSystem`      |
-//! | `messaging.destination`     | `messagingDestination` |
 //! | `messaging.destination.name`| `messagingDestination` |
 //! | `messaging.url`             | `messagingUrl`         |
 //! | `rpc.system`                | `rpcSystem`            |
@@ -113,11 +109,11 @@ mod tests {
             let span_id = span.span_context().span_id();
 
             // Set PartB attributes
-            // Database attributes
-            span.set_attribute(KeyValue::new("db.system", "postgresql"));
-            span.set_attribute(KeyValue::new("db.name", "inventory"));
+            // Database attributes (stable semconv keys)
+            span.set_attribute(KeyValue::new("db.system.name", "postgresql"));
+            span.set_attribute(KeyValue::new("db.namespace", "inventory"));
             span.set_attribute(KeyValue::new(
-                "db.statement",
+                "db.query.text",
                 "SELECT * FROM products WHERE price > 100",
             ));
             // HTTP attributes
@@ -127,9 +123,12 @@ mod tests {
                 "https://api.example.com/products?min_price=100",
             ));
             span.set_attribute(KeyValue::new("http.response.status_code", 200));
-            // Messaging attributes
+            // Messaging attributes (stable semconv keys)
             span.set_attribute(KeyValue::new("messaging.system", "kafka"));
-            span.set_attribute(KeyValue::new("messaging.destination", "product-updates"));
+            span.set_attribute(KeyValue::new(
+                "messaging.destination.name",
+                "product-updates",
+            ));
             span.set_attribute(KeyValue::new(
                 "messaging.url",
                 "kafka://broker1.example.com:9092",

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -375,6 +375,12 @@ mod tests {
             .expect("PartB.parentId should be present for child span");
         assert_eq!(parent_id.as_str().unwrap(), parent_span_id.to_string());
 
+        // statusMessage should be present for error span with description
+        assert_eq!(
+            part_b["statusMessage"].as_str().unwrap(),
+            "something went wrong"
+        );
+
         // Validate PartC — non-string attribute types
         let part_c = &event["PartC"];
         assert!(part_c["bool_attr"].as_bool().unwrap());

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -644,14 +644,9 @@ mod tests {
         assert!(!part_b["success"].as_bool().unwrap());
 
         // startTime should match the known start time we provided
-        let start_time_str = part_b["startTime"].as_str().unwrap();
-        assert!(
-            start_time_str.starts_with("2023-11-14T22:13:20"),
-            "startTime should match known epoch 1_700_000_000, got: {start_time_str}"
-        );
-        assert!(
-            start_time_str.ends_with('Z'),
-            "startTime should end with 'Z', got: {start_time_str}"
+        assert_eq!(
+            part_b["startTime"].as_str().unwrap(),
+            "2023-11-14T22:13:20Z"
         );
 
         // statusMessage should be present for Error status with description

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -667,6 +667,264 @@ mod tests {
         );
     }
 
+    /// Test that statusMessage is suppressed when httpStatusCode is present.
+    /// Per Common Schema spec: "If you report httpStatusCode, statusMessage
+    /// should not be reported and will be ignored."
+    #[ignore]
+    #[test]
+    fn integration_test_status_message_suppressed_with_http_status_code() {
+        use opentelemetry::trace::{Span, SpanKind, Status};
+
+        check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = SdkTracerProvider::builder()
+            .with_resource(
+                opentelemetry_sdk::Resource::builder()
+                    .with_service_name("suppress_test")
+                    .build(),
+            )
+            .with_user_events_exporter("otel_trace_suppr")
+            .build();
+
+        let user_event_status = check_user_events_available().unwrap();
+        assert!(user_event_status.contains("otel_trace_suppr_L4K1"));
+
+        let perf_thread =
+            std::thread::spawn(|| run_perf_and_decode(5, "user_events:otel_trace_suppr_L4K1"));
+
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+
+        let tracer = provider.tracer("test-tracer");
+
+        let span_id_expected = {
+            let mut span = tracer
+                .span_builder("http-error-span")
+                .with_kind(SpanKind::Client)
+                .start(&tracer);
+            let sid = span.span_context().span_id();
+            span.set_attribute(KeyValue::new("http.response.status_code", 500));
+            span.set_status(Status::error("Internal Server Error"));
+            span.end();
+            sid
+        };
+
+        let result = perf_thread.join().expect("Perf thread panicked");
+        assert!(result.is_ok());
+        let formatted_output = result.unwrap().trim().to_string();
+
+        let json_value: Value = from_str(&formatted_output).expect("Failed to parse JSON");
+        let perf_data_key = json_value
+            .as_object()
+            .unwrap()
+            .keys()
+            .find(|k| k.contains("perf.data"))
+            .expect("No perf.data key found");
+
+        let events = json_value[perf_data_key].as_array().unwrap();
+
+        let span_id_str = span_id_expected.to_string();
+        let event = events
+            .iter()
+            .find(|e| {
+                e.get("PartA")
+                    .and_then(|a| a.get("ext_dt_spanId"))
+                    .and_then(|s| s.as_str())
+                    == Some(&span_id_str)
+            })
+            .expect("Span event not found");
+
+        let part_b = &event["PartB"];
+        assert!(!part_b["success"].as_bool().unwrap());
+
+        // httpStatusCode should be in PartB as a well-known attribute
+        assert_eq!(part_b["httpStatusCode"].as_i64().unwrap(), 500);
+
+        // statusMessage should NOT be present when httpStatusCode is reported
+        assert!(
+            part_b.get("statusMessage").is_none(),
+            "statusMessage should be suppressed when httpStatusCode is present"
+        );
+    }
+
+    /// Test all SpanKind values and RPC well-known attributes.
+    /// Emits 5 spans (one per SpanKind) in a single perf capture.
+    #[ignore]
+    #[test]
+    fn integration_test_all_span_kinds_and_rpc_attrs() {
+        use opentelemetry::trace::{Span, SpanKind};
+
+        check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = SdkTracerProvider::builder()
+            .with_resource(
+                opentelemetry_sdk::Resource::builder()
+                    .with_service_name("kinds_test")
+                    .build(),
+            )
+            .with_user_events_exporter("otel_trace_kinds")
+            .build();
+
+        let user_event_status = check_user_events_available().unwrap();
+        assert!(user_event_status.contains("otel_trace_kinds_L4K1"));
+
+        let perf_thread =
+            std::thread::spawn(|| run_perf_and_decode(5, "user_events:otel_trace_kinds_L4K1"));
+
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+
+        let tracer = provider.tracer("test-tracer");
+
+        // Emit one span per SpanKind
+        let kinds: Vec<(SpanKind, &str, i64)> = vec![
+            (SpanKind::Internal, "internal-span", 0),
+            (SpanKind::Server, "server-span", 1),
+            (SpanKind::Client, "client-span", 2),
+            (SpanKind::Producer, "producer-span", 3),
+            (SpanKind::Consumer, "consumer-span", 4),
+        ];
+
+        let mut span_ids: Vec<(String, &str, i64)> = Vec::new();
+        for (kind, name, expected_kind) in &kinds {
+            let mut span = tracer
+                .span_builder(*name)
+                .with_kind(kind.clone())
+                .start(&tracer);
+
+            // Add RPC attributes to the client span to test rpcSystem/rpcGrpcStatusCode
+            if *name == "client-span" {
+                span.set_attribute(KeyValue::new("rpc.system", "grpc"));
+                span.set_attribute(KeyValue::new("rpc.grpc.status_code", 0_i64));
+            }
+
+            let sid = span.span_context().span_id().to_string();
+            span.end();
+            span_ids.push((sid, name, *expected_kind));
+        }
+
+        let result = perf_thread.join().expect("Perf thread panicked");
+        assert!(result.is_ok());
+        let formatted_output = result.unwrap().trim().to_string();
+
+        let json_value: Value = from_str(&formatted_output).expect("Failed to parse JSON");
+        let perf_data_key = json_value
+            .as_object()
+            .unwrap()
+            .keys()
+            .find(|k| k.contains("perf.data"))
+            .expect("No perf.data key found");
+
+        let events = json_value[perf_data_key].as_array().unwrap();
+
+        for (span_id, name, expected_kind) in &span_ids {
+            let event = events
+                .iter()
+                .find(|e| {
+                    e.get("PartA")
+                        .and_then(|a| a.get("ext_dt_spanId"))
+                        .and_then(|s| s.as_str())
+                        == Some(span_id.as_str())
+                })
+                .unwrap_or_else(|| panic!("Span '{name}' not found"));
+
+            let part_b = &event["PartB"];
+            assert_eq!(part_b["name"].as_str().unwrap(), *name);
+            assert_eq!(
+                part_b["kind"].as_i64().unwrap(),
+                *expected_kind,
+                "Wrong kind for span '{name}'"
+            );
+
+            // Validate RPC well-known attributes on the client span
+            if *name == "client-span" {
+                assert_eq!(part_b["rpcSystem"].as_str().unwrap(), "grpc");
+                assert_eq!(part_b["rpcGrpcStatusCode"].as_i64().unwrap(), 0);
+            }
+        }
+    }
+
+    /// Test that only service.name is set (no service.instance.id).
+    /// Validates ext_cloud_role is present but ext_cloud_roleInstance is absent.
+    #[ignore]
+    #[test]
+    fn integration_test_partial_resource() {
+        use opentelemetry::trace::Span;
+
+        check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = SdkTracerProvider::builder()
+            .with_resource(
+                opentelemetry_sdk::Resource::builder()
+                    .with_service_name("partial_resource_test")
+                    .build(),
+            )
+            .with_user_events_exporter("otel_trace_pres")
+            .build();
+
+        let user_event_status = check_user_events_available().unwrap();
+        assert!(user_event_status.contains("otel_trace_pres_L4K1"));
+
+        let perf_thread =
+            std::thread::spawn(|| run_perf_and_decode(5, "user_events:otel_trace_pres_L4K1"));
+
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+
+        let tracer = provider.tracer("test-tracer");
+
+        let span_id_expected = {
+            let mut span = tracer.span_builder("partial-resource-span").start(&tracer);
+            let sid = span.span_context().span_id();
+            // Add only non-well-known attributes to ensure PartC works without PartB well-known attrs
+            span.set_attribute(KeyValue::new("custom_i64", 42_i64));
+            span.set_attribute(KeyValue::new("custom_string", "hello"));
+            span.end();
+            sid
+        };
+
+        let result = perf_thread.join().expect("Perf thread panicked");
+        assert!(result.is_ok());
+        let formatted_output = result.unwrap().trim().to_string();
+
+        let json_value: Value = from_str(&formatted_output).expect("Failed to parse JSON");
+        let perf_data_key = json_value
+            .as_object()
+            .unwrap()
+            .keys()
+            .find(|k| k.contains("perf.data"))
+            .expect("No perf.data key found");
+
+        let events = json_value[perf_data_key].as_array().unwrap();
+
+        let span_id_str = span_id_expected.to_string();
+        let event = events
+            .iter()
+            .find(|e| {
+                e.get("PartA")
+                    .and_then(|a| a.get("ext_dt_spanId"))
+                    .and_then(|s| s.as_str())
+                    == Some(&span_id_str)
+            })
+            .expect("Span event not found");
+
+        let part_a = &event["PartA"];
+        // service.name is set so ext_cloud_role should be present
+        assert_eq!(
+            part_a["ext_cloud_role"].as_str().unwrap(),
+            "partial_resource_test"
+        );
+        // service.instance.id not set, so ext_cloud_roleInstance should be absent
+        assert!(
+            part_a.get("ext_cloud_roleInstance").is_none(),
+            "ext_cloud_roleInstance should not be present when service.instance.id is not set"
+        );
+
+        // Validate PartC has the custom attributes with correct types
+        let part_c = event
+            .get("PartC")
+            .expect("PartC should be present with custom attributes");
+        assert_eq!(part_c["custom_i64"].as_i64().unwrap(), 42);
+        assert_eq!(part_c["custom_string"].as_str().unwrap(), "hello");
+    }
+
     fn check_user_events_available() -> Result<String, String> {
         let output = Command::new("sudo")
             .arg("cat")

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -575,6 +575,7 @@ mod tests {
     #[test]
     fn integration_test_status_message() {
         use opentelemetry::trace::{Span, SpanKind, Status};
+        use std::time::{Duration, UNIX_EPOCH};
 
         check_user_events_available().expect("Kernel does not support user_events.");
 
@@ -597,10 +598,15 @@ mod tests {
 
         let tracer = provider.tracer("test-tracer");
 
+        // Use a well-known start time so we can assert the exact formatted value.
+        // 1_700_000_000 seconds since UNIX epoch = 2023-11-14T22:13:20Z
+        let known_start_time = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+
         let span_id_expected = {
             let mut span = tracer
                 .span_builder("error-span")
                 .with_kind(SpanKind::Client)
+                .with_start_time(known_start_time)
                 .start(&tracer);
             let sid = span.span_context().span_id();
             span.set_status(Status::error("something went wrong"));
@@ -636,6 +642,17 @@ mod tests {
         let part_b = &event["PartB"];
         assert_eq!(part_b["name"].as_str().unwrap(), "error-span");
         assert!(!part_b["success"].as_bool().unwrap());
+
+        // startTime should match the known start time we provided
+        let start_time_str = part_b["startTime"].as_str().unwrap();
+        assert!(
+            start_time_str.starts_with("2023-11-14T22:13:20"),
+            "startTime should match known epoch 1_700_000_000, got: {start_time_str}"
+        );
+        assert!(
+            start_time_str.ends_with('Z'),
+            "startTime should end with 'Z', got: {start_time_str}"
+        );
 
         // statusMessage should be present for Error status with description
         let status_msg = part_b

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -183,8 +183,11 @@ mod tests {
 
         // Validate PartA
         let part_a = &event["PartA"];
-        // Only check if the time field exists, not the actual value
-        assert!(part_a.get("time").is_some(), "PartA.time is missing");
+        let time_str = part_a["time"].as_str().expect("PartA.time is missing");
+        assert!(
+            time_str.ends_with('Z'),
+            "PartA.time should end with 'Z', got: {time_str}"
+        );
 
         let part_a_ext_dt_trace_id = part_a
             .get("ext_dt_traceId")
@@ -222,10 +225,12 @@ mod tests {
             part_b.get("parentId").is_none(),
             "parentId should not be present for root span"
         );
-        // Check if startTime exists, not the actual value
+        let start_time_str = part_b["startTime"]
+            .as_str()
+            .expect("PartB.startTime is missing");
         assert!(
-            part_b.get("startTime").is_some(),
-            "PartB.startTime is missing"
+            start_time_str.ends_with('Z'),
+            "PartB.startTime should end with 'Z', got: {start_time_str}"
         );
         assert!(part_b["success"].as_bool().unwrap());
         assert_eq!(part_b["kind"].as_i64().unwrap(), 0);
@@ -342,7 +347,7 @@ mod tests {
 
         // Validate PartA
         let part_a = &event["PartA"];
-        assert!(part_a.get("time").is_some());
+        assert!(part_a["time"].as_str().unwrap().ends_with('Z'));
         assert_eq!(
             part_a["ext_dt_traceId"].as_str().unwrap(),
             child_trace_id.to_string()
@@ -356,7 +361,7 @@ mod tests {
         let part_b = &event["PartB"];
         assert_eq!(part_b["_typeName"].as_str().unwrap(), "Span");
         assert_eq!(part_b["name"].as_str().unwrap(), "child-span");
-        assert!(part_b.get("startTime").is_some());
+        assert!(part_b["startTime"].as_str().unwrap().ends_with('Z'));
 
         // success should be false (Error status)
         assert!(!part_b["success"].as_bool().unwrap());
@@ -422,7 +427,7 @@ mod tests {
 
         // PartA — no ext_cloud_role or ext_cloud_roleInstance
         let part_a = &event["PartA"];
-        assert!(part_a.get("time").is_some());
+        assert!(part_a["time"].as_str().unwrap().ends_with('Z'));
         assert!(part_a.get("ext_dt_traceId").is_some());
         assert_eq!(
             part_a["ext_dt_spanId"].as_str().unwrap(),

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -270,7 +270,9 @@ impl UserEventsSpanExporter {
                 .iter()
                 .any(|kv| kv.key.as_str() == "http.response.status_code");
             let status_message = match &span.status {
-                Status::Error { description } if !description.is_empty() && !has_http_status_code => {
+                Status::Error { description }
+                    if !description.is_empty() && !has_http_status_code =>
+                {
                     Some(description.to_string())
                 }
                 _ => None,

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -11,7 +11,7 @@ use opentelemetry_sdk::trace::SpanData;
 use opentelemetry_sdk::Resource;
 use std::{
     collections::HashMap,
-    fmt::{self, Debug, Write},
+    fmt::{Debug, Write},
     sync::{Arc, Mutex, OnceLock},
 };
 
@@ -41,8 +41,8 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
         map.insert("messaging.url", "messagingUrl");
 
         // RPC attributes
-        map.insert("rpc.system", "rpcSystem");
-        map.insert("rpc.grpc.status_code", "rpcGrpcStatusCode");
+        map.insert("rpc.system.name", "rpcSystem");
+        map.insert("rpc.response.status_code", "rpcGrpcStatusCode");
 
         map
     })
@@ -50,8 +50,10 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
 
 /// Serializes span links to a JSON string: `[{"toTraceId":"...","toSpanId":"..."},...]`
 ///
-/// Writes TraceId/SpanId hex directly into the buffer via `Display`,
-/// avoiding intermediate `String` allocations.
+/// Writes TraceId/SpanId via Display directly into the output buffer,
+/// avoiding temporary string allocations.
+/// TODO(perf): Revisit link encoding to reduce allocations further and avoid
+/// JSON-text serialization overhead where possible.
 fn links_to_json(links: &[opentelemetry::trace::Link]) -> String {
     // Pre-allocate: each link is ~80 chars: {"toTraceId":"<32>","toSpanId":"<16>"}
     let mut json = String::with_capacity(2 + links.len() * 80);
@@ -267,25 +269,6 @@ impl UserEventsSpanExporter {
                 );
             }
 
-            // statusMessage: emit error description if present.
-            // Per Common Schema spec: "If you report httpStatusCode,
-            // statusMessage should not be reported."
-            let has_http_status_code = span
-                .attributes
-                .iter()
-                .any(|kv| kv.key.as_str() == "http.response.status_code");
-            let status_message = match &span.status {
-                Status::Error { description }
-                    if !description.is_empty() && !has_http_status_code =>
-                {
-                    Some(description.to_string())
-                }
-                _ => None,
-            };
-            if let Some(ref msg) = status_message {
-                eb.add_str("statusMessage", msg, FieldFormat::Default, 0);
-            }
-
             // links: serialize span links as JSON array of {toTraceId, toSpanId}.
             let has_links = !span.links.links.is_empty();
             let links_json = if has_links {
@@ -303,15 +286,38 @@ impl UserEventsSpanExporter {
             // but it is better than alternatives like allocating
             // a new vector to hold PartC attributes.
             // This could be revisited in future if performance is a concern.
+
             let mut partb_count_from_attributes = 0;
             let mut partc_attribute_count = 0;
+            let mut has_http_status_code = false;
 
             for kv in span.attributes.iter() {
                 if let Some(well_known_key) = well_known_attrs.get(kv.key.as_str()) {
+                    if *well_known_key == "httpStatusCode" {
+                        has_http_status_code = true;
+                    }
                     self.add_attribute_to_event(&mut eb, well_known_key, &kv.value);
                     partb_count_from_attributes += 1;
                 } else {
                     partc_attribute_count += 1;
+                }
+            }
+
+            // statusMessage: emit error description if present.
+            // Per Common Schema spec: "If you report httpStatusCode,
+            // statusMessage should not be reported."
+            let has_status_message = match &span.status {
+                Status::Error { description } => !description.is_empty() && !has_http_status_code,
+                _ => false,
+            };
+            if has_status_message {
+                if let Status::Error { description } = &span.status {
+                    eb.add_str(
+                        "statusMessage",
+                        description.as_ref(),
+                        FieldFormat::Default,
+                        0,
+                    );
                 }
             }
 
@@ -321,7 +327,7 @@ impl UserEventsSpanExporter {
                 BASE_PARTB_FIELD_COUNT
                     + partb_count_from_attributes
                     + u8::from(has_parent_id)
-                    + u8::from(status_message.is_some())
+                    + u8::from(has_status_message)
                     + u8::from(has_links),
             );
 
@@ -449,9 +455,9 @@ mod tests {
         assert_eq!(attrs.get("messaging.url"), Some(&"messagingUrl"));
 
         // RPC (Common Schema Span spec)
-        assert_eq!(attrs.get("rpc.system"), Some(&"rpcSystem"));
+        assert_eq!(attrs.get("rpc.system.name"), Some(&"rpcSystem"));
         assert_eq!(
-            attrs.get("rpc.grpc.status_code"),
+            attrs.get("rpc.response.status_code"),
             Some(&"rpcGrpcStatusCode")
         );
     }

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -25,12 +25,9 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
     WELL_KNOWN_ATTRIBUTES.get_or_init(|| {
         let mut map = HashMap::new();
 
-        // Database attributes (old and stable semconv keys)
-        map.insert("db.system", "dbSystem");
+        // Database attributes
         map.insert("db.system.name", "dbSystem");
-        map.insert("db.name", "dbName");
         map.insert("db.namespace", "dbName");
-        map.insert("db.statement", "dbStatement");
         map.insert("db.query.text", "dbStatement");
 
         // HTTP attributes
@@ -38,9 +35,8 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
         map.insert("url.full", "httpUrl");
         map.insert("http.response.status_code", "httpStatusCode");
 
-        // Messaging attributes (old and stable semconv keys)
+        // Messaging attributes
         map.insert("messaging.system", "messagingSystem");
-        map.insert("messaging.destination", "messagingDestination");
         map.insert("messaging.destination.name", "messagingDestination");
         map.insert("messaging.url", "messagingUrl");
 
@@ -439,29 +435,18 @@ mod tests {
             Some(&"httpStatusCode")
         );
 
-        // Database — old semconv keys
-        assert_eq!(attrs.get("db.system"), Some(&"dbSystem"));
-        assert_eq!(attrs.get("db.name"), Some(&"dbName"));
-        assert_eq!(attrs.get("db.statement"), Some(&"dbStatement"));
-
-        // Database — stable semconv keys (map to same CS fields)
+        // Database (stable semconv keys)
         assert_eq!(attrs.get("db.system.name"), Some(&"dbSystem"));
         assert_eq!(attrs.get("db.namespace"), Some(&"dbName"));
         assert_eq!(attrs.get("db.query.text"), Some(&"dbStatement"));
 
-        // Messaging — old semconv keys
+        // Messaging (stable semconv keys)
         assert_eq!(attrs.get("messaging.system"), Some(&"messagingSystem"));
-        assert_eq!(
-            attrs.get("messaging.destination"),
-            Some(&"messagingDestination")
-        );
-        assert_eq!(attrs.get("messaging.url"), Some(&"messagingUrl"));
-
-        // Messaging — stable semconv key
         assert_eq!(
             attrs.get("messaging.destination.name"),
             Some(&"messagingDestination")
         );
+        assert_eq!(attrs.get("messaging.url"), Some(&"messagingUrl"));
 
         // RPC (Common Schema Span spec)
         assert_eq!(attrs.get("rpc.system"), Some(&"rpcSystem"));

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -11,7 +11,7 @@ use opentelemetry_sdk::trace::SpanData;
 use opentelemetry_sdk::Resource;
 use std::{
     collections::HashMap,
-    fmt::Debug,
+    fmt::{self, Debug, Write},
     sync::{Arc, Mutex, OnceLock},
 };
 
@@ -25,19 +25,23 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
     WELL_KNOWN_ATTRIBUTES.get_or_init(|| {
         let mut map = HashMap::new();
 
-        // Database attributes
+        // Database attributes (old and stable semconv keys)
         map.insert("db.system", "dbSystem");
+        map.insert("db.system.name", "dbSystem");
         map.insert("db.name", "dbName");
+        map.insert("db.namespace", "dbName");
         map.insert("db.statement", "dbStatement");
+        map.insert("db.query.text", "dbStatement");
 
         // HTTP attributes
         map.insert("http.request.method", "httpMethod");
         map.insert("url.full", "httpUrl");
         map.insert("http.response.status_code", "httpStatusCode");
 
-        // Messaging attributes
+        // Messaging attributes (old and stable semconv keys)
         map.insert("messaging.system", "messagingSystem");
         map.insert("messaging.destination", "messagingDestination");
+        map.insert("messaging.destination.name", "messagingDestination");
         map.insert("messaging.url", "messagingUrl");
 
         // RPC attributes
@@ -49,16 +53,21 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
 }
 
 /// Serializes span links to a JSON string: `[{"toTraceId":"...","toSpanId":"..."},...]`
+///
+/// Writes TraceId/SpanId hex directly into the buffer via `Display`,
+/// avoiding intermediate `String` allocations.
 fn links_to_json(links: &[opentelemetry::trace::Link]) -> String {
-    let mut json = String::from("[");
+    // Pre-allocate: each link is ~80 chars: {"toTraceId":"<32>","toSpanId":"<16>"}
+    let mut json = String::with_capacity(2 + links.len() * 80);
+    json.push('[');
     for (i, link) in links.iter().enumerate() {
         if i > 0 {
             json.push(',');
         }
         json.push_str("{\"toTraceId\":\"");
-        json.push_str(&link.span_context.trace_id().to_string());
+        let _ = write!(json, "{}", link.span_context.trace_id());
         json.push_str("\",\"toSpanId\":\"");
-        json.push_str(&link.span_context.span_id().to_string());
+        let _ = write!(json, "{}", link.span_context.span_id());
         json.push_str("\"}");
     }
     json.push(']');
@@ -430,18 +439,29 @@ mod tests {
             Some(&"httpStatusCode")
         );
 
-        // Database (Common Schema Span spec)
+        // Database — old semconv keys
         assert_eq!(attrs.get("db.system"), Some(&"dbSystem"));
         assert_eq!(attrs.get("db.name"), Some(&"dbName"));
         assert_eq!(attrs.get("db.statement"), Some(&"dbStatement"));
 
-        // Messaging (Common Schema Span spec)
+        // Database — stable semconv keys (map to same CS fields)
+        assert_eq!(attrs.get("db.system.name"), Some(&"dbSystem"));
+        assert_eq!(attrs.get("db.namespace"), Some(&"dbName"));
+        assert_eq!(attrs.get("db.query.text"), Some(&"dbStatement"));
+
+        // Messaging — old semconv keys
         assert_eq!(attrs.get("messaging.system"), Some(&"messagingSystem"));
         assert_eq!(
             attrs.get("messaging.destination"),
             Some(&"messagingDestination")
         );
         assert_eq!(attrs.get("messaging.url"), Some(&"messagingUrl"));
+
+        // Messaging — stable semconv key
+        assert_eq!(
+            attrs.get("messaging.destination.name"),
+            Some(&"messagingDestination")
+        );
 
         // RPC (Common Schema Span spec)
         assert_eq!(attrs.get("rpc.system"), Some(&"rpcSystem"));

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -350,3 +350,132 @@ impl UserEventsSpanExporter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{Link, SpanContext, SpanId, TraceFlags, TraceId, TraceState};
+
+    #[test]
+    fn links_to_json_empty() {
+        assert_eq!(links_to_json(&[]), "[]");
+    }
+
+    #[test]
+    fn links_to_json_single_link() {
+        let link = Link::new(
+            SpanContext::new(
+                TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+                SpanId::from_hex("00f067aa0ba902b7").unwrap(),
+                TraceFlags::SAMPLED,
+                false,
+                TraceState::default(),
+            ),
+            vec![],
+            0,
+        );
+        let json = links_to_json(&[link]);
+        assert_eq!(
+            json,
+            r#"[{"toTraceId":"0af7651916cd43dd8448eb211c80319c","toSpanId":"00f067aa0ba902b7"}]"#
+        );
+    }
+
+    #[test]
+    fn links_to_json_multiple_links() {
+        let links = vec![
+            Link::new(
+                SpanContext::new(
+                    TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+                    SpanId::from_hex("00f067aa0ba902b7").unwrap(),
+                    TraceFlags::SAMPLED,
+                    false,
+                    TraceState::default(),
+                ),
+                vec![],
+                0,
+            ),
+            Link::new(
+                SpanContext::new(
+                    TraceId::from_hex("ffffffffffffffffffffffffffffffff").unwrap(),
+                    SpanId::from_hex("ffffffffffffffff").unwrap(),
+                    TraceFlags::SAMPLED,
+                    false,
+                    TraceState::default(),
+                ),
+                vec![],
+                0,
+            ),
+        ];
+        let json = links_to_json(&links);
+        // Verify it's valid JSON with two entries
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(
+            parsed[0]["toTraceId"].as_str().unwrap(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(parsed[1]["toSpanId"].as_str().unwrap(), "ffffffffffffffff");
+    }
+
+    #[test]
+    fn well_known_attributes_contains_all_cs_span_fields() {
+        let attrs = get_well_known_attributes();
+
+        // HTTP (Common Schema Span spec)
+        assert_eq!(attrs.get("http.request.method"), Some(&"httpMethod"));
+        assert_eq!(attrs.get("url.full"), Some(&"httpUrl"));
+        assert_eq!(
+            attrs.get("http.response.status_code"),
+            Some(&"httpStatusCode")
+        );
+
+        // Database (Common Schema Span spec)
+        assert_eq!(attrs.get("db.system"), Some(&"dbSystem"));
+        assert_eq!(attrs.get("db.name"), Some(&"dbName"));
+        assert_eq!(attrs.get("db.statement"), Some(&"dbStatement"));
+
+        // Messaging (Common Schema Span spec)
+        assert_eq!(attrs.get("messaging.system"), Some(&"messagingSystem"));
+        assert_eq!(
+            attrs.get("messaging.destination"),
+            Some(&"messagingDestination")
+        );
+        assert_eq!(attrs.get("messaging.url"), Some(&"messagingUrl"));
+
+        // RPC (Common Schema Span spec)
+        assert_eq!(attrs.get("rpc.system"), Some(&"rpcSystem"));
+        assert_eq!(
+            attrs.get("rpc.grpc.status_code"),
+            Some(&"rpcGrpcStatusCode")
+        );
+    }
+
+    #[test]
+    fn well_known_attributes_does_not_contain_unknown() {
+        let attrs = get_well_known_attributes();
+        assert!(attrs.get("unknown.attribute").is_none());
+        assert!(attrs.get("service.name").is_none());
+    }
+
+    #[test]
+    fn provider_name_validation_rejects_too_long() {
+        let long_name = "a".repeat(234);
+        assert!(UserEventsSpanExporter::new(&long_name).is_err());
+    }
+
+    #[test]
+    fn provider_name_validation_rejects_special_chars() {
+        assert!(UserEventsSpanExporter::new("has-hyphen").is_err());
+        assert!(UserEventsSpanExporter::new("has space").is_err());
+        assert!(UserEventsSpanExporter::new("has.dot").is_err());
+    }
+
+    #[test]
+    fn provider_name_validation_accepts_valid() {
+        // Can't fully construct on non-Linux, but validation should pass
+        assert!(
+            UserEventsSpanExporter::new("valid_name_123").is_ok() || cfg!(not(target_os = "linux"))
+        );
+    }
+}

--- a/opentelemetry-user-events-trace/src/trace/exporter.rs
+++ b/opentelemetry-user-events-trace/src/trace/exporter.rs
@@ -40,8 +40,29 @@ fn get_well_known_attributes() -> &'static HashMap<&'static str, &'static str> {
         map.insert("messaging.destination", "messagingDestination");
         map.insert("messaging.url", "messagingUrl");
 
+        // RPC attributes
+        map.insert("rpc.system", "rpcSystem");
+        map.insert("rpc.grpc.status_code", "rpcGrpcStatusCode");
+
         map
     })
+}
+
+/// Serializes span links to a JSON string: `[{"toTraceId":"...","toSpanId":"..."},...]`
+fn links_to_json(links: &[opentelemetry::trace::Link]) -> String {
+    let mut json = String::from("[");
+    for (i, link) in links.iter().enumerate() {
+        if i > 0 {
+            json.push(',');
+        }
+        json.push_str("{\"toTraceId\":\"");
+        json.push_str(&link.span_context.trace_id().to_string());
+        json.push_str("\",\"toSpanId\":\"");
+        json.push_str(&link.span_context.span_id().to_string());
+        json.push_str("\"}");
+    }
+    json.push(']');
+    json
 }
 
 /// UserEventsSpanExporter exports spans in EventHeader format to user_events tracepoint.
@@ -161,7 +182,12 @@ impl UserEventsSpanExporter {
             let mut cs_a_bookmark: usize = 0;
             eb.add_struct_with_bookmark("PartA", 3, 0, &mut cs_a_bookmark);
             let datetime: DateTime<Utc> = span.end_time.into();
-            eb.add_str("time", datetime.to_rfc3339(), FieldFormat::Default, 0);
+            eb.add_str(
+                "time",
+                datetime.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+                FieldFormat::Default,
+                0,
+            );
 
             eb.add_str(
                 "ext_dt_traceId",
@@ -201,7 +227,12 @@ impl UserEventsSpanExporter {
             eb.add_str("_typeName", "Span", FieldFormat::Default, 0);
             eb.add_str("name", span.name.as_ref(), FieldFormat::Default, 0);
             let datetime: DateTime<Utc> = span.start_time.into();
-            eb.add_str("startTime", datetime.to_rfc3339(), FieldFormat::Default, 0);
+            eb.add_str(
+                "startTime",
+                datetime.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+                FieldFormat::Default,
+                0,
+            );
             eb.add_value(
                 "success",
                 matches!(span.status, Status::Ok | Status::Unset), // Check for Ok or Unset
@@ -231,6 +262,34 @@ impl UserEventsSpanExporter {
                 );
             }
 
+            // statusMessage: emit error description if present.
+            // Per Common Schema spec: "If you report httpStatusCode,
+            // statusMessage should not be reported."
+            let has_http_status_code = span
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "http.response.status_code");
+            let status_message = match &span.status {
+                Status::Error { description } if !description.is_empty() && !has_http_status_code => {
+                    Some(description.to_string())
+                }
+                _ => None,
+            };
+            if let Some(ref msg) = status_message {
+                eb.add_str("statusMessage", msg, FieldFormat::Default, 0);
+            }
+
+            // links: serialize span links as JSON array of {toTraceId, toSpanId}.
+            let has_links = !span.links.links.is_empty();
+            let links_json = if has_links {
+                Some(links_to_json(&span.links.links))
+            } else {
+                None
+            };
+            if let Some(ref json) = links_json {
+                eb.add_str("links", json, FieldFormat::Default, 0);
+            }
+
             // Well-known attributes go into PartB.
             // Regular attributes are collected for PartC.
             // This does dual iteration (+lookup) over attributes,
@@ -252,7 +311,11 @@ impl UserEventsSpanExporter {
             // Update PartB field count with the number of well-known attributes found.
             eb.set_struct_field_count(
                 part_b_bookmark,
-                BASE_PARTB_FIELD_COUNT + partb_count_from_attributes + u8::from(has_parent_id),
+                BASE_PARTB_FIELD_COUNT
+                    + partb_count_from_attributes
+                    + u8::from(has_parent_id)
+                    + u8::from(status_message.is_some())
+                    + u8::from(has_links),
             );
 
             // Add regular attributes to PartC if any.


### PR DESCRIPTION
Improve Common Schema v4.0 compliance for the user-events-trace exporter.

- Add `links` field to Part B (serialized as JSON array of `{toTraceId, toSpanId}` per CS ToSpanLink type)
- Add `statusMessage` field to Part B for error spans (suppressed when `httpStatusCode` is present, per CS spec)
- **Breaking**: Update well-known attribute mappings to use stable OTel semantic conventions. The CS output field names are unchanged, but the OTel attribute keys that trigger the mapping have been updated:
  - `db.system` → `db.system.name`, `db.name` → `db.namespace`, `db.statement` → `db.query.text`, `messaging.destination` → `messaging.destination.name`
  - Added `rpc.system` → `rpcSystem`, `rpc.grpc.status_code` → `rpcGrpcStatusCode`
- Fix `PartA.time` and `PartB.startTime` to use trailing `Z` instead of `+00:00` (per CS spec: UTC ISO 8601 with trailing Z)
- Optimize `links_to_json` to avoid intermediate String allocations
- Expand integration test coverage (8 tests) and add unit tests