### PR TITLE
perf(user-events-logs): use stack-allocated hex buffer for trace/span IDs

### DIFF
--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- Avoided two small heap allocations per log record with a trace context by
+  encoding `traceId` / `spanId` directly into stack-allocated fixed-size hex
+  buffers instead of going through `TraceId::to_string()` /
+  `SpanId::to_string()`.
+
 - Removed `futures-executor` dependency and `LogExporter` trait implementation.
   The processor now calls the exporter synchronously, avoiding potential panics
   from nested `block_on()` calls (e.g. when logging from inside an async

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -218,22 +218,10 @@ where
 
         if let Some(trace_context) = log_record.trace_context() {
             cs_a_count += 2; // for ext_dt_traceId and ext_dt_spanId
-            let trace_id_hex =
-                super::hex_buf::HexBuf::<32>::from_bytes(&trace_context.trace_id.to_bytes());
-            eb.add_str(
-                "ext_dt_traceId",
-                trace_id_hex.as_bytes(),
-                FieldFormat::Default,
-                0,
-            );
-            let span_id_hex =
-                super::hex_buf::HexBuf::<16>::from_bytes(&trace_context.span_id.to_bytes());
-            eb.add_str(
-                "ext_dt_spanId",
-                span_id_hex.as_bytes(),
-                FieldFormat::Default,
-                0,
-            );
+            let trace_id_hex = super::hex_buf::trace_id_hex(trace_context.trace_id);
+            eb.add_str("ext_dt_traceId", trace_id_hex, FieldFormat::Default, 0);
+            let span_id_hex = super::hex_buf::span_id_hex(trace_context.span_id);
+            eb.add_str("ext_dt_spanId", span_id_hex, FieldFormat::Default, 0);
         }
 
         if let Some(cloud_role) = &self.cloud_role {

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -218,15 +218,19 @@ where
 
         if let Some(trace_context) = log_record.trace_context() {
             cs_a_count += 2; // for ext_dt_traceId and ext_dt_spanId
+            let trace_id_hex =
+                super::hex_buf::HexBuf::<32>::from_bytes(&trace_context.trace_id.to_bytes());
             eb.add_str(
                 "ext_dt_traceId",
-                trace_context.trace_id.to_string(),
+                trace_id_hex.as_bytes(),
                 FieldFormat::Default,
                 0,
             );
+            let span_id_hex =
+                super::hex_buf::HexBuf::<16>::from_bytes(&trace_context.span_id.to_bytes());
             eb.add_str(
                 "ext_dt_spanId",
-                trace_context.span_id.to_string(),
+                span_id_hex.as_bytes(),
                 FieldFormat::Default,
                 0,
             );

--- a/opentelemetry-user-events-logs/src/logs/hex_buf.rs
+++ b/opentelemetry-user-events-logs/src/logs/hex_buf.rs
@@ -14,6 +14,7 @@ fn encode<const N: usize>(bytes: &[u8]) -> [u8; N] {
     debug_assert_eq!(N, bytes.len() * 2);
     let mut out = [0u8; N];
     for (i, &b) in bytes.iter().enumerate() {
+        // Split byte into two 4-bit nibbles; each nibble (0..=15) indexes HEX_CHARS.
         out[i * 2] = HEX_CHARS[(b >> 4) as usize];
         out[i * 2 + 1] = HEX_CHARS[(b & 0x0f) as usize];
     }

--- a/opentelemetry-user-events-logs/src/logs/hex_buf.rs
+++ b/opentelemetry-user-events-logs/src/logs/hex_buf.rs
@@ -1,100 +1,74 @@
-//! Zero-allocation hex string encoder for fixed-size byte arrays such as
-//! `TraceId` (16 bytes -> 32 hex chars) and `SpanId` (8 bytes -> 16 hex chars).
+//! Zero-allocation hex encoders for `TraceId` and `SpanId`.
 //!
 //! `TraceId::to_string()` / `SpanId::to_string()` each allocate a heap
 //! `String` on every call. On the export hot path that's two small heap
 //! allocations per record with a trace context, just to format already-known
-//! fixed-size data. This helper writes the hex representation directly into
-//! a stack-allocated `[u8; N]` buffer instead.
+//! fixed-size data. These helpers write the hex representation directly into
+//! a stack-allocated fixed-size byte array instead.
+
+use opentelemetry::trace::{SpanId, TraceId};
 
 const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
 
-/// Stack-allocated lowercase-hex buffer of fixed byte length `N`.
-///
-/// `N` must equal `2 * input_bytes.len()` (enforced by `debug_assert!`).
-pub(crate) struct HexBuf<const N: usize>([u8; N]);
-
-impl<const N: usize> HexBuf<N> {
-    /// Encodes `bytes` as lowercase hex into a stack buffer of length `N`.
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
-        debug_assert_eq!(
-            N,
-            bytes.len() * 2,
-            "HexBuf<N> requires N == 2 * bytes.len()"
-        );
-        let mut out = [0u8; N];
-        for (i, &b) in bytes.iter().enumerate() {
-            out[i * 2] = HEX_CHARS[(b >> 4) as usize];
-            out[i * 2 + 1] = HEX_CHARS[(b & 0x0f) as usize];
-        }
-        Self(out)
+fn encode<const N: usize>(bytes: &[u8]) -> [u8; N] {
+    debug_assert_eq!(N, bytes.len() * 2);
+    let mut out = [0u8; N];
+    for (i, &b) in bytes.iter().enumerate() {
+        out[i * 2] = HEX_CHARS[(b >> 4) as usize];
+        out[i * 2 + 1] = HEX_CHARS[(b & 0x0f) as usize];
     }
+    out
+}
 
-    /// Returns the hex representation as a byte slice.
-    ///
-    /// `eventheader_dynamic::EventBuilder::add_str` accepts any
-    /// `AsRef<[V: StringField]>`, and `u8: StringField`, so callers can pass
-    /// these bytes directly without UTF-8 validation or an `unsafe` block.
-    pub(crate) fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
+/// Encodes a `TraceId` as 32 lowercase hex chars in a stack-allocated array.
+pub(crate) fn trace_id_hex(id: TraceId) -> [u8; 32] {
+    encode(&id.to_bytes())
+}
+
+/// Encodes a `SpanId` as 16 lowercase hex chars in a stack-allocated array.
+pub(crate) fn span_id_hex(id: SpanId) -> [u8; 16] {
+    encode(&id.to_bytes())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::{SpanId, TraceId};
 
     #[test]
     fn trace_id_matches_to_string() {
-        let trace_id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
-        let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
+        let id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
         assert_eq!(
-            std::str::from_utf8(buf.as_bytes()).unwrap(),
-            trace_id.to_string()
+            std::str::from_utf8(&trace_id_hex(id)).unwrap(),
+            id.to_string()
         );
     }
 
     #[test]
     fn span_id_matches_to_string() {
-        let span_id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
-        let buf = HexBuf::<16>::from_bytes(&span_id.to_bytes());
+        let id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
         assert_eq!(
-            std::str::from_utf8(buf.as_bytes()).unwrap(),
-            span_id.to_string()
+            std::str::from_utf8(&span_id_hex(id)).unwrap(),
+            id.to_string()
         );
     }
 
     #[test]
     fn trace_id_all_zeros() {
-        let trace_id = TraceId::from_hex("00000000000000000000000000000000").unwrap();
-        let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
-        assert_eq!(
-            std::str::from_utf8(buf.as_bytes()).unwrap(),
-            "00000000000000000000000000000000"
-        );
+        let id = TraceId::from_hex("00000000000000000000000000000000").unwrap();
+        assert_eq!(&trace_id_hex(id), b"00000000000000000000000000000000");
     }
 
     #[test]
     fn trace_id_all_ff_preserves_leading_chars() {
-        let trace_id = TraceId::from_hex("ffffffffffffffffffffffffffffffff").unwrap();
-        let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
-        assert_eq!(
-            std::str::from_utf8(buf.as_bytes()).unwrap(),
-            "ffffffffffffffffffffffffffffffff"
-        );
+        let id = TraceId::from_hex("ffffffffffffffffffffffffffffffff").unwrap();
+        assert_eq!(&trace_id_hex(id), b"ffffffffffffffffffffffffffffffff");
     }
 
     #[test]
     fn span_id_with_leading_zero_byte_is_zero_padded() {
         // Regression: ensure leading zero bytes do not get truncated
         // (the original to_string() bug fixed by user-events-logs #612).
-        let span_id = SpanId::from_hex("0001020304050607").unwrap();
-        let buf = HexBuf::<16>::from_bytes(&span_id.to_bytes());
-        assert_eq!(
-            std::str::from_utf8(buf.as_bytes()).unwrap(),
-            "0001020304050607"
-        );
-        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap().len(), 16);
+        let id = SpanId::from_hex("0001020304050607").unwrap();
+        assert_eq!(&span_id_hex(id), b"0001020304050607");
     }
 }

--- a/opentelemetry-user-events-logs/src/logs/hex_buf.rs
+++ b/opentelemetry-user-events-logs/src/logs/hex_buf.rs
@@ -1,0 +1,81 @@
+//! Zero-allocation hex string encoder for fixed-size byte arrays such as
+//! `TraceId` (16 bytes -> 32 hex chars) and `SpanId` (8 bytes -> 16 hex chars).
+//!
+//! `TraceId::to_string()` / `SpanId::to_string()` each allocate a heap
+//! `String` on every call. On the export hot path that's two small heap
+//! allocations per record with a trace context, just to format already-known
+//! fixed-size data. This helper writes the hex representation directly into
+//! a stack-allocated `[u8; N]` buffer instead.
+
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+/// Stack-allocated lowercase-hex buffer of fixed byte length `N`.
+///
+/// `N` must equal `2 * input_bytes.len()` (enforced by `debug_assert!`).
+pub(crate) struct HexBuf<const N: usize>([u8; N]);
+
+impl<const N: usize> HexBuf<N> {
+    /// Encodes `bytes` as lowercase hex into a stack buffer of length `N`.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+        debug_assert_eq!(N, bytes.len() * 2, "HexBuf<N> requires N == 2 * bytes.len()");
+        let mut out = [0u8; N];
+        for (i, &b) in bytes.iter().enumerate() {
+            out[i * 2] = HEX_CHARS[(b >> 4) as usize];
+            out[i * 2 + 1] = HEX_CHARS[(b & 0x0f) as usize];
+        }
+        Self(out)
+    }
+
+    /// Returns the hex representation as a byte slice.
+    ///
+    /// `eventheader_dynamic::EventBuilder::add_str` accepts any
+    /// `AsRef<[V: StringField]>`, and `u8: StringField`, so callers can pass
+    /// these bytes directly without UTF-8 validation or an `unsafe` block.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{SpanId, TraceId};
+
+    #[test]
+    fn trace_id_matches_to_string() {
+        let trace_id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
+        let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
+        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), trace_id.to_string());
+    }
+
+    #[test]
+    fn span_id_matches_to_string() {
+        let span_id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
+        let buf = HexBuf::<16>::from_bytes(&span_id.to_bytes());
+        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), span_id.to_string());
+    }
+
+    #[test]
+    fn trace_id_all_zeros() {
+        let trace_id = TraceId::from_hex("00000000000000000000000000000000").unwrap();
+        let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
+        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), "00000000000000000000000000000000");
+    }
+
+    #[test]
+    fn trace_id_all_ff_preserves_leading_chars() {
+        let trace_id = TraceId::from_hex("ffffffffffffffffffffffffffffffff").unwrap();
+        let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
+        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), "ffffffffffffffffffffffffffffffff");
+    }
+
+    #[test]
+    fn span_id_with_leading_zero_byte_is_zero_padded() {
+        // Regression: ensure leading zero bytes do not get truncated
+        // (the original to_string() bug fixed by user-events-logs #612).
+        let span_id = SpanId::from_hex("0001020304050607").unwrap();
+        let buf = HexBuf::<16>::from_bytes(&span_id.to_bytes());
+        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), "0001020304050607");
+        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap().len(), 16);
+    }
+}

--- a/opentelemetry-user-events-logs/src/logs/hex_buf.rs
+++ b/opentelemetry-user-events-logs/src/logs/hex_buf.rs
@@ -17,7 +17,11 @@ pub(crate) struct HexBuf<const N: usize>([u8; N]);
 impl<const N: usize> HexBuf<N> {
     /// Encodes `bytes` as lowercase hex into a stack buffer of length `N`.
     pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
-        debug_assert_eq!(N, bytes.len() * 2, "HexBuf<N> requires N == 2 * bytes.len()");
+        debug_assert_eq!(
+            N,
+            bytes.len() * 2,
+            "HexBuf<N> requires N == 2 * bytes.len()"
+        );
         let mut out = [0u8; N];
         for (i, &b) in bytes.iter().enumerate() {
             out[i * 2] = HEX_CHARS[(b >> 4) as usize];
@@ -45,28 +49,40 @@ mod tests {
     fn trace_id_matches_to_string() {
         let trace_id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
         let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
-        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), trace_id.to_string());
+        assert_eq!(
+            std::str::from_utf8(buf.as_bytes()).unwrap(),
+            trace_id.to_string()
+        );
     }
 
     #[test]
     fn span_id_matches_to_string() {
         let span_id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
         let buf = HexBuf::<16>::from_bytes(&span_id.to_bytes());
-        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), span_id.to_string());
+        assert_eq!(
+            std::str::from_utf8(buf.as_bytes()).unwrap(),
+            span_id.to_string()
+        );
     }
 
     #[test]
     fn trace_id_all_zeros() {
         let trace_id = TraceId::from_hex("00000000000000000000000000000000").unwrap();
         let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
-        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), "00000000000000000000000000000000");
+        assert_eq!(
+            std::str::from_utf8(buf.as_bytes()).unwrap(),
+            "00000000000000000000000000000000"
+        );
     }
 
     #[test]
     fn trace_id_all_ff_preserves_leading_chars() {
         let trace_id = TraceId::from_hex("ffffffffffffffffffffffffffffffff").unwrap();
         let buf = HexBuf::<32>::from_bytes(&trace_id.to_bytes());
-        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), "ffffffffffffffffffffffffffffffff");
+        assert_eq!(
+            std::str::from_utf8(buf.as_bytes()).unwrap(),
+            "ffffffffffffffffffffffffffffffff"
+        );
     }
 
     #[test]
@@ -75,7 +91,10 @@ mod tests {
         // (the original to_string() bug fixed by user-events-logs #612).
         let span_id = SpanId::from_hex("0001020304050607").unwrap();
         let buf = HexBuf::<16>::from_bytes(&span_id.to_bytes());
-        assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap(), "0001020304050607");
+        assert_eq!(
+            std::str::from_utf8(buf.as_bytes()).unwrap(),
+            "0001020304050607"
+        );
         assert_eq!(std::str::from_utf8(buf.as_bytes()).unwrap().len(), 16);
     }
 }

--- a/opentelemetry-user-events-logs/src/logs/mod.rs
+++ b/opentelemetry-user-events-logs/src/logs/mod.rs
@@ -1,4 +1,5 @@
 mod exporter;
+mod hex_buf;
 mod processor;
 
 #[cfg(feature = "experimental_eventname_callback")]


### PR DESCRIPTION
Replaces the two `TraceId::to_string()` / `SpanId::to_string()` heap allocations on the PartA hot path with a small stack-allocated `HexBuf<const N>` helper. No behavior change; existing CI integration test (`opentelemetry-user-events-logs/src/lib.rs`) validates the encoded `trace_id` / `span_id` byte-for-byte.

The same helper can be reused for other ETW/user_events exporters (etw-logs, user-events-trace, etw-traces) in follow-ups.