### PR TITLE
fix(ci): unblock cargo-deny advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,3 +24,11 @@ license-files = [
 [advisories]
 unmaintained = "none"
 yanked = "allow"
+ignore = [
+    # http-types is unmaintained; no patched version available.
+    # Reaches the graph transitively only via opentelemetry-datadog's optional
+    # `surf-client` feature (surf -> http-client -> http-types). The datadog
+    # exporter is planned for removal (see #609), at which point this entry
+    # can be dropped.
+    "RUSTSEC-2026-0174",
+]

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -29,6 +29,6 @@ workspace = true
 
 [dev-dependencies]
 otlp_builder = { path = "examples/otlp_builder" }
-wiremock = "=0.5.22"
+wiremock = "0.6"
 base64 = "0.22"
 chrono = "0.4"

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -2368,7 +2368,7 @@ mod tests {
                 let reqs = mock_server.received_requests().await.unwrap();
                 let posts: Vec<String> = reqs
                     .iter()
-                    .filter(|r| r.method == Method::Post)
+                    .filter(|r| r.method == Method::POST)
                     .map(|r| r.url.to_string())
                     .collect();
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"
 openssl = { version = "0.10", features = ["vendored"] }
 tempfile = "3.5"
-wiremock = "=0.5.22"
+wiremock = "0.6"
 futures = "0.3"
 num_cpus = "1.16"
 lz4_flex = { version = "0.11" }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -26,7 +26,7 @@ num_cpus = "1.15.0"
 num-format = "0.4.4"
 sysinfo = { version = "0.38", optional = true }
 tokio = { version = "1", features = ["full", "test-util"] }
-wiremock = "=0.5.22"
+wiremock = "0.6"
 futures = "0.3"
 
 opentelemetry-appender-tracing = { version = "0.32" }


### PR DESCRIPTION
Fixes #

## Changes

The `cargo-deny` CI check has been failing on PRs due to RUSTSEC-2026-0174 against `http-types` (unmaintained, no patched version, INFO-level notice). Two distinct paths brought it into the dependency graph:

1. Dev path (preventable): `wiremock 0.5` -> `http-types`, used as a dev-dependency by `geneva-uploader`, `geneva-uploader-ffi`, and `stress`.
2. Runtime path (datadog only): `opentelemetry-datadog` optional `surf-client` feature -> `surf` -> `http-client` -> `http-types`.

- Bump `wiremock` from `=0.5.22` to `0.6` in `geneva-uploader`, `geneva-uploader-ffi`, and `stress`. `wiremock 0.6` drops the `http-types` dependency entirely. Adjusted one test in `geneva-uploader-ffi` for the new `http::Method::POST` variant casing.
- Add a single advisory ignore for `RUSTSEC-2026-0174` in `deny.toml` for the remaining datadog/surf path. Comment notes that this entry can be removed once the datadog exporter is removed (#609).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
