### PR TITLE
chore(datadog): deprecate opentelemetry-datadog crate

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## vNext
 
+- **DEPRECATED**: This crate is now deprecated and will be removed from this
+  repository in a future release. Datadog ships a first-party integration,
+  [`dd-trace-rs`](https://github.com/DataDog/dd-trace-rs), built on top of
+  `opentelemetry_sdk`. New users should adopt `dd-trace-rs`, and existing users
+  are encouraged to migrate. See
+  [issue #609](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609)
+  for context.
+
 ## v0.20.0
 
 Released 2026-May-13

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-datadog"
 version = "0.20.0"
-description = "Datadog exporters and propagators for OpenTelemetry"
+description = "[DEPRECATED] Datadog exporters and propagators for OpenTelemetry. Use https://github.com/DataDog/dd-trace-rs instead."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog"
 readme = "README.md"
@@ -10,6 +10,9 @@ keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-datadog/README.md
+++ b/opentelemetry-datadog/README.md
@@ -4,10 +4,21 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
+> **⚠️ DEPRECATED** — This crate is deprecated and will be removed from this
+> repository. Datadog now ships [`dd-trace-rs`], a first-party integration
+> built on top of `opentelemetry_sdk`. New users should adopt `dd-trace-rs`,
+> and existing users are encouraged to migrate. The last release of this crate
+> on crates.io will remain available, but no further releases are planned.
+>
+> See [issue #609] for context.
+>
+> [`dd-trace-rs`]: https://github.com/DataDog/dd-trace-rs
+> [issue #609]: https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609
+
 | Status        |                                            |
 | ------------- |--------------------------------------------|
-| Stability     | beta                                       |
-| Owners        | [Anton Grübel](https://github.com/gruebel) |
+| Stability     | deprecated                                 |
+| Owners        | _unmaintained_                             |
 
 Community supported vendor integrations for applications instrumented with [`OpenTelemetry`].
 

--- a/opentelemetry-datadog/benches/datadog_exporter.rs
+++ b/opentelemetry-datadog/benches/datadog_exporter.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;

--- a/opentelemetry-datadog/examples/agent_sampling.rs
+++ b/opentelemetry-datadog/examples/agent_sampling.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use opentelemetry::{
     global,
     trace::{Span, TraceContextExt, Tracer, TracerProvider},

--- a/opentelemetry-datadog/examples/datadog.rs
+++ b/opentelemetry-datadog/examples/datadog.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use opentelemetry::{
     global,
     trace::{Span, TraceContextExt, Tracer, TracerProvider},

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -1,5 +1,15 @@
 //! # OpenTelemetry Datadog Exporter
 //!
+//! > **⚠️ DEPRECATED** — This crate is deprecated and will be removed from the
+//! > `opentelemetry-rust-contrib` repository. Datadog now ships
+//! > [`dd-trace-rs`](https://github.com/DataDog/dd-trace-rs), a first-party
+//! > integration built on top of `opentelemetry_sdk`. New users should adopt
+//! > `dd-trace-rs`, and existing users are encouraged to migrate. The last
+//! > release of this crate on crates.io will remain available, but no further
+//! > releases are planned. See
+//! > [issue #609](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609)
+//! > for context.
+//!
 //! An OpenTelemetry datadog exporter implementation
 //!
 //! See the [Datadog Docs](https://docs.datadoghq.com/agent/) for information on how to run the datadog-agent
@@ -153,6 +163,11 @@
 //!     let _ = provider.shutdown(); // sending remaining spans before exit
 //!
 //! ```
+#![deprecated(
+    since = "0.21.0",
+    note = "The `opentelemetry-datadog` crate is deprecated and will be removed from `opentelemetry-rust-contrib`. Use https://github.com/DataDog/dd-trace-rs instead. See https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609 for context."
+)]
+#![allow(deprecated)]
 
 mod exporter;
 


### PR DESCRIPTION
Marks the `opentelemetry-datadog` crate as deprecated, as agreed in the SIG meeting and discussion on #609.

Datadog now ships [`dd-trace-rs`](https://github.com/DataDog/dd-trace-rs), a first-party integration built on top of `opentelemetry_sdk`. Existing users are encouraged to migrate, and new users should adopt `dd-trace-rs` directly. The last release on crates.io will remain available; no further releases are planned, and the crate will be removed from this repository in a future PR (~1 month per the timeline in #609).

## Changes

- `Cargo.toml`: prefixed `[DEPRECATED]` to `description` and added `[badges] maintenance = { status = "deprecated" }` for crates.io.
- `src/lib.rs`: added a deprecation banner to the crate-level rustdoc and `#![deprecated]` + `#![allow(deprecated)]` attributes so downstream users see a compiler warning.
- `README.md`: added a prominent deprecation notice, flipped `Stability` to `deprecated`, and marked `Owners` as unmaintained.
- `CHANGELOG.md`: added a `vNext` entry recording the deprecation.
- `examples/` and `benches/`: added `#![allow(deprecated)]` so `cargo clippy --all-targets -Dwarnings` (used by `scripts/lint.sh`) stays clean.

Follows the same pattern as the jaeger-propagator deprecation in the main repo (open-telemetry/opentelemetry-rust#3493).

Refs #609
