### PR TITLE
chore(stackdriver): deprecate opentelemetry-stackdriver crate

### DIFF
--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+- **DEPRECATED**: This crate is now deprecated and will be removed from this
+  repository in a future release. The crate has been unmaintained, and no
+  committed maintainer stepped up in response to
+  [issue #609](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609).
+  Users should migrate to OTLP — Google Cloud supports OTLP ingestion directly,
+  and the OpenTelemetry Collector ships a `googlecloud` exporter.
+
 ## v0.29.0
 
 Released 2026-May-13

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "opentelemetry-stackdriver"
 version = "0.29.0"
-description = "A Rust opentelemetry exporter that uploads traces to Google Stackdriver trace."
+description = "[DEPRECATED] A Rust opentelemetry exporter that uploads traces to Google Stackdriver trace. Use OTLP with Google Cloud's OTLP-compatible ingestion or the OpenTelemetry Collector's `googlecloud` exporter instead."
 documentation = "https://docs.rs/opentelemetry-stackdriver/"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/proto"]
 rust-version = "1.75.0"
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [dependencies]
 gcp_auth = { version = "0.12", optional = true }

--- a/opentelemetry-stackdriver/README.md
+++ b/opentelemetry-stackdriver/README.md
@@ -4,10 +4,20 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-| Status        |           |
-| ------------- |-----------|
-| Stability     | alpha     |
-| Owners        | TBD       |
+> **⚠️ DEPRECATED** — This crate is deprecated and will be removed from this
+> repository. It has been unmaintained, and no committed maintainer stepped up
+> in response to [issue #609]. Users should migrate to OTLP — Google Cloud
+> supports OTLP ingestion directly, and the OpenTelemetry Collector ships a
+> [`googlecloud` exporter]. The last release of this crate on crates.io will
+> remain available, but no further releases are planned.
+>
+> [issue #609]: https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609
+> [`googlecloud` exporter]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
+
+| Status        |                |
+| ------------- |----------------|
+| Stability     | deprecated     |
+| Owners        | _unmaintained_ |
 
 This crate provides an `opentelemetry` exporter for use with Google Stackdriver trace. It uses gRPC to send tracing spans.
 Contributions are welcome.

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -1,3 +1,13 @@
+//! # OpenTelemetry Stackdriver Exporter
+//!
+//! > **⚠️ DEPRECATED** — This crate is deprecated and will be removed from the
+//! > `opentelemetry-rust-contrib` repository. The crate has been unmaintained
+//! > and no committed maintainer stepped up in response to
+//! > [issue #609](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609).
+//! > Users should migrate to OTLP — Google Cloud supports OTLP ingestion
+//! > directly, and the OpenTelemetry Collector ships a `googlecloud` exporter.
+//! > The last release of this crate on crates.io will remain available, but no
+//! > further releases are planned.
 #![cfg(not(doctest))]
 // unfortunately the proto code includes comments from the google proto files
 // that are interpreted as "doc tests" and will fail to build.
@@ -9,6 +19,10 @@
     rustdoc::bare_urls,
     rustdoc::broken_intra_doc_links,
     rustdoc::invalid_rust_codeblocks
+)]
+#![deprecated(
+    since = "0.30.0",
+    note = "The `opentelemetry-stackdriver` crate is deprecated and will be removed from `opentelemetry-rust-contrib`. Migrate to OTLP (Google Cloud supports OTLP ingestion, and the OpenTelemetry Collector ships a `googlecloud` exporter). See https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/609 for context."
 )]
 
 use std::{


### PR DESCRIPTION
Marks the `opentelemetry-stackdriver` crate as deprecated, following the maintainer search in #609.

The crate has been unmaintained (README listed `Owners: TBD`), and no committed maintainer from Google Cloud or the community stepped up in response to #609. Unlike `opentelemetry-datadog`, there is no first-party replacement crate, but Google Cloud supports OTLP ingestion directly, and the OpenTelemetry Collector ships a [`googlecloud` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter). Users should migrate to OTLP.

The last release on crates.io will remain available; no further releases are planned, and the crate will be removed from this repository in a future PR.

## Changes

- `Cargo.toml`: prefixed `[DEPRECATED]` to `description` and added `[badges] maintenance = { status = "deprecated" }` for crates.io.
- `src/lib.rs`: added a deprecation banner to the crate-level rustdoc and `#![deprecated]` so downstream users see a compiler warning. (Crate already has `#![allow(deprecated)]` for proto noise, so no internal warnings.)
- `README.md`: added a prominent deprecation notice, flipped `Stability` to `deprecated`, marked `Owners` as unmaintained.
- `CHANGELOG.md`: added a `vNext` entry recording the deprecation.

Follows the same pattern as #636 (datadog deprecation) and the upstream jaeger-propagator deprecation (open-telemetry/opentelemetry-rust#3493).

Refs #609
