### PR TITLE
fix(ci): bump codecov-action to v6.0.2 to fix GPG signature failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
       - name: cargo llvm-cov
         run: cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           fail_ci_if_error: true
   cargo-machete:


### PR DESCRIPTION
The `coverage` CI job has been failing since 2026-06-09 with:

```
==> Could not verify signature. Please contact Codecov if problem continues
##[error]Process completed with exit code 1.
```

The failure is silent in the CI summary because the `coverage` job has `continue-on-error: true`, but coverage data has not been uploading.

## Root cause

`codecov/codecov-action@v6.0.1`'s upload script downloads its GPG public key from `https://keybase.io/codecovsecurity/pgp_keys.asc`, which is now returning `404 SELF-SIGNED PUBLIC KEY NOT FOUND` due to a Keybase account migration issue. The script uses `curl -s` without `--fail`, so the 404 body is piped into `gpg`, the key import fails (`gpg: no valid OpenPGP data found`), and the later signature verification fails.

Tracked upstream in codecov/codecov-action#1955. Codecov has deleted the broken `codecovsecurity` keybase account and migrated to a new `codecovsecops` account.

## Fix

Bump `codecov/codecov-action` from `v6.0.1` to `v6.0.2`. Per the [v6.0.2 release notes](https://github.com/codecov/codecov-action/releases/tag/v6.0.2), it is an exact copy of `v7.0.0` made specifically to ease upgrades from the v6 line — no breaking changes.
