### PR TITLE
feat(resource-detectors): add host.name to HostResourceDetector

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `ContainerResourceDetector` to detect `container.id` from `/proc/self/cgroup`, with fallback to `/proc/self/mountinfo`.
+- Add host.name attribute to `HostResourceDetector`
 
 ## v0.11.0
 

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.75.0"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
+hostname = "0.4"
 
 [dev-dependencies]
 temp-env = "0.3.6"

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.75.0"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
-hostname = "0.4"
 
 [dev-dependencies]
 temp-env = "0.3.6"

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -28,7 +28,7 @@ Community supported Resource detectors implementations for applications instrume
 | ProcessResourceDetector   | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
 | OsResourceDetector        | OS_TYPE                           | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
 | HostResourceDetector      | HOST_ID                           | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
-| HostResourceDetector      | HOST_ARCH                         | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
+| HostResourceDetector      | HOST_ARCH, HOST_NAME              | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
 | K8sResourceDetector       | K8S_NAMESPACE_NAME                | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
 | K8sResourceDetector       | K8S_POD_NAME                      | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
 | ContainerResourceDetector | CONTAINER_ID                      | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/container.md |

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -18,8 +18,10 @@ use std::process::Command;
 ///
 /// - [`host.id from non-containerized systems`](https://opentelemetry.io/docs/specs/semconv/resource/host/#collecting-hostid-from-non-containerized-systems)
 /// - Host architecture (host.arch).
+/// - Host name (host.name).
 pub struct HostResourceDetector {
     host_id_detect: fn() -> Option<String>,
+    host_name_detect: fn() -> Option<String>,
 }
 
 impl ResourceDetector for HostResourceDetector {
@@ -39,6 +41,13 @@ impl ResourceDetector for HostResourceDetector {
                         opentelemetry_semantic_conventions::attribute::HOST_ARCH,
                         ARCH,
                     )),
+                    // Get host.name
+                    (self.host_name_detect)().map(|host_name| {
+                        KeyValue::new(
+                            opentelemetry_semantic_conventions::attribute::HOST_NAME,
+                            host_name,
+                        )
+                    }),
                 ]
                 .into_iter()
                 .flatten(),
@@ -81,9 +90,20 @@ fn host_id_detect() -> Option<String> {
     None
 }
 
+fn host_name_detect() -> Option<String> {
+    hostname::get()
+        .ok()?
+        .into_string()
+        .ok()
+        .filter(|name| !name.is_empty())
+}
+
 impl Default for HostResourceDetector {
     fn default() -> Self {
-        Self { host_id_detect }
+        Self {
+            host_id_detect,
+            host_name_detect,
+        }
     }
 }
 
@@ -97,7 +117,7 @@ mod tests {
     #[test]
     fn test_host_resource_detector_linux() {
         let resource = HostResourceDetector::default().detect();
-        assert_eq!(resource.len(), 2);
+        assert_eq!(resource.len(), 3);
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ID
@@ -106,6 +126,11 @@ mod tests {
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ARCH
+            ))
+            .is_some());
+        assert!(resource
+            .get(&Key::from_static_str(
+                opentelemetry_semantic_conventions::attribute::HOST_NAME
             ))
             .is_some())
     }
@@ -114,7 +139,7 @@ mod tests {
     #[test]
     fn test_host_resource_detector_macos() {
         let resource = HostResourceDetector::default().detect();
-        assert_eq!(resource.len(), 2);
+        assert_eq!(resource.len(), 3);
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ID
@@ -124,7 +149,41 @@ mod tests {
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ARCH
             ))
+            .is_some());
+        assert!(resource
+            .get(&Key::from_static_str(
+                opentelemetry_semantic_conventions::attribute::HOST_NAME
+            ))
             .is_some())
+    }
+
+    #[test]
+    fn test_host_name_detected() {
+        let detector = HostResourceDetector {
+            host_id_detect: || None,
+            host_name_detect: || Some("opentelemetry-test".to_string()),
+        };
+        let resource = detector.detect();
+        assert_eq!(
+            resource.get(&Key::from_static_str(
+                opentelemetry_semantic_conventions::attribute::HOST_NAME
+            )),
+            Some(Value::from("opentelemetry-test"))
+        )
+    }
+
+    #[test]
+    fn test_host_name_absent_when_none() {
+        let detector = HostResourceDetector {
+            host_id_detect: || None,
+            host_name_detect: || None,
+        };
+        assert!(detector
+            .detect()
+            .get(&Key::from_static_str(
+                opentelemetry_semantic_conventions::attribute::HOST_NAME
+            ))
+            .is_none())
     }
 
     #[test]

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -9,7 +9,6 @@ use std::env::consts::ARCH;
 use std::fs::read_to_string;
 #[cfg(target_os = "linux")]
 use std::path::Path;
-#[cfg(target_os = "macos")]
 use std::process::Command;
 
 /// Detect host information.
@@ -91,11 +90,9 @@ fn host_id_detect() -> Option<String> {
 }
 
 fn host_name_detect() -> Option<String> {
-    hostname::get()
-        .ok()?
-        .into_string()
-        .ok()
-        .filter(|name| !name.is_empty())
+    let output = Command::new("hostname").output().ok()?.stdout;
+    let name = String::from_utf8(output).ok()?.trim().to_string();
+    (!name.is_empty()).then_some(name)
 }
 
 impl Default for HostResourceDetector {

--- a/opentelemetry-resource-detectors/src/host.rs
+++ b/opentelemetry-resource-detectors/src/host.rs
@@ -114,7 +114,8 @@ mod tests {
     #[test]
     fn test_host_resource_detector_linux() {
         let resource = HostResourceDetector::default().detect();
-        assert_eq!(resource.len(), 3);
+        // host.id + host.arch are always present; host.name is best-effort
+        assert!(matches!(resource.len(), 2 | 3));
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ID
@@ -123,11 +124,6 @@ mod tests {
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ARCH
-            ))
-            .is_some());
-        assert!(resource
-            .get(&Key::from_static_str(
-                opentelemetry_semantic_conventions::attribute::HOST_NAME
             ))
             .is_some())
     }
@@ -136,7 +132,8 @@ mod tests {
     #[test]
     fn test_host_resource_detector_macos() {
         let resource = HostResourceDetector::default().detect();
-        assert_eq!(resource.len(), 3);
+        // host.id + host.arch are always present; host.name is best-effort
+        assert!(matches!(resource.len(), 2 | 3));
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ID
@@ -145,11 +142,6 @@ mod tests {
         assert!(resource
             .get(&Key::from_static_str(
                 opentelemetry_semantic_conventions::attribute::HOST_ARCH
-            ))
-            .is_some());
-        assert!(resource
-            .get(&Key::from_static_str(
-                opentelemetry_semantic_conventions::attribute::HOST_NAME
             ))
             .is_some())
     }


### PR DESCRIPTION
Fixes #639

## Changes

This PR updates the `HostResourceDetector` to collect the spec recommended `host.name` attribute. This matches implementations in [Go](https://github.com/open-telemetry/opentelemetry-go/blob/35e8690c4bf0d060d6df097e2fa7d316d73373f6/sdk/resource/builtin.go#L61-L64), [Python](https://github.com/open-telemetry/opentelemetry-python/blob/39ff55d3093ec7f218dad2709645824ace971e2d/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py#L451-L463), and [JS](https://github.com/open-telemetry/opentelemetry-js/blob/71d195c508320295f1892aaed1ee2f1971ffb470/packages/opentelemetry-resources/src/detectors/platform/node/HostDetector.ts#L21-L31)

Since there is not a standard library alternative, I used the [hostname crate](https://crates.io/crates/hostname) as its the most straightforward way to access the hostname on windows/linux/mac. If we're reluctant to take on the dependency we can discuss other options.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* ~~[ ] Changes in public API reviewed (if applicable)~~