### PR TITLE
test: Add end-to-end integration test for opentelemetry-etw-metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
         toolchain: stable
     - name: Run ETW integration tests (logs)
       run: cargo test --manifest-path opentelemetry-etw-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Run ETW integration tests (metrics)
+      run: cargo test --manifest-path opentelemetry-etw-metrics/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
   lint:
     strategy:
       matrix:

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -23,6 +23,10 @@ criterion = { workspace = true, features = ["html_reports"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "std", "fmt"] }
 opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics", "gen-tonic-messages"] }
 
+[target.'cfg(windows)'.dev-dependencies]
+ferrisetw = "1.2"
+windows = { version = "0.62", features = ["Win32_System_Diagnostics_Etw"] }
+
 [features]
 internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
 default = ["internal-logs"]

--- a/opentelemetry-etw-metrics/tests/integration.rs
+++ b/opentelemetry-etw-metrics/tests/integration.rs
@@ -1,0 +1,331 @@
+//! ETW metrics end-to-end integration test.
+//!
+//! Exercises the public `MetricsExporter` pipeline, starts a real ETW
+//! `UserTrace` session via `ferrisetw`, reads `EVENT_RECORD.UserData`
+//! directly (the exporter emits manifested events with a `raw_data` payload,
+//! so the user buffer is the raw OTLP protobuf), decodes each event as
+//! `ExportMetricsServiceRequest`, and asserts the OTLP shape for every
+//! supported instrument type (Counter, UpDownCounter, Gauge, Histogram).
+//!
+//! Run locally (requires admin privileges to start an ETW session):
+//!
+//! ```text
+//! cargo test --manifest-path opentelemetry-etw-metrics/Cargo.toml --all-features \
+//!     -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! Single-test design: the ETW provider in this crate is registered through
+//! a static `std::sync::Once`, so only one register/unregister cycle is
+//! supported per process. All instrument coverage lives in one test.
+
+#![cfg(target_os = "windows")]
+
+use std::collections::HashMap;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use ferrisetw::schema_locator::SchemaLocator;
+use ferrisetw::trace::UserTrace;
+use ferrisetw::EventRecord;
+
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry::KeyValue;
+use opentelemetry_etw_metrics::MetricsExporter;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueValue;
+use opentelemetry_proto::tonic::common::v1::KeyValue as ProtoKeyValue;
+use opentelemetry_proto::tonic::metrics::v1::{metric::Data as MetricData, Metric as ProtoMetric};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::Resource;
+use prost::Message;
+use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
+
+// Must match the provider GUID statically registered in src/etw/mod.rs.
+const PROVIDER_GUID: &str = "EDC24920-E004-40F6-A8E1-0E6E48F39D84";
+
+fn start_etw_trace() -> (UserTrace, mpsc::Receiver<ExportMetricsServiceRequest>) {
+    let (tx, rx) = mpsc::sync_channel::<ExportMetricsServiceRequest>(64);
+
+    let provider = ferrisetw::provider::Provider::by_guid(PROVIDER_GUID)
+        .add_callback(
+            move |record: &EventRecord, _schema_locator: &SchemaLocator| {
+                let er_ptr = record as *const EventRecord as *const EVENT_RECORD;
+                // SAFETY: ferrisetw::EventRecord is layout-compatible with
+                // windows EVENT_RECORD and is valid for the callback's lifetime.
+                let user_data: &[u8] = unsafe {
+                    if (*er_ptr).UserData.is_null() || (*er_ptr).UserDataLength == 0 {
+                        &[]
+                    } else {
+                        std::slice::from_raw_parts(
+                            (*er_ptr).UserData as *const u8,
+                            (*er_ptr).UserDataLength as usize,
+                        )
+                    }
+                };
+                if let Ok(req) = ExportMetricsServiceRequest::decode(user_data) {
+                    let _ = tx.try_send(req);
+                }
+            },
+        )
+        .build();
+
+    let trace = UserTrace::new()
+        .enable(provider)
+        .start_and_process()
+        .expect("failed to start ETW UserTrace (admin privileges required)");
+
+    (trace, rx)
+}
+
+/// Wait up to 5s for the first event, then drain anything that arrives within
+/// a 200 ms tail window. Bounded by an overall 5 s deadline.
+fn drain_events(
+    rx: &mpsc::Receiver<ExportMetricsServiceRequest>,
+) -> Vec<ExportMetricsServiceRequest> {
+    let mut out = Vec::new();
+    let overall_deadline = Instant::now() + Duration::from_secs(5);
+    if let Ok(first) = rx.recv_timeout(Duration::from_secs(5)) {
+        out.push(first);
+    }
+    loop {
+        let remaining = overall_deadline.saturating_duration_since(Instant::now());
+        let wait = remaining.min(Duration::from_millis(200));
+        if wait.is_zero() {
+            break;
+        }
+        match rx.recv_timeout(wait) {
+            Ok(r) => out.push(r),
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+fn attr_string(attrs: &[ProtoKeyValue], key: &str) -> String {
+    let a = attrs
+        .iter()
+        .find(|a| a.key == key)
+        .unwrap_or_else(|| panic!("attribute '{key}' not found"));
+    match a.value.as_ref().and_then(|v| v.value.as_ref()) {
+        Some(AnyValueValue::StringValue(s)) => s.clone(),
+        _ => panic!("attribute '{key}' is not a string"),
+    }
+}
+
+#[ignore = "Requires admin privileges to start ETW trace session"]
+#[test]
+fn integration_test_all_instruments() {
+    let (trace, rx) = start_etw_trace();
+
+    // Allow ETW consumer thread to attach before any events are emitted.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let exporter = MetricsExporter::new();
+    let reader = PeriodicReader::builder(exporter).build();
+    let provider = SdkMeterProvider::builder()
+        .with_resource(
+            Resource::builder_empty()
+                .with_attributes(vec![KeyValue::new("service.name", "etw-metrics-int-test")])
+                .build(),
+        )
+        .with_reader(reader)
+        .build();
+    let meter = provider.meter("etw-metric-test");
+
+    // Counter (u64) — two attribute sets => two events.
+    let counter = meter
+        .u64_counter("test_counter_u64")
+        .with_description("counter test desc")
+        .with_unit("counter_unit")
+        .build();
+    counter.add(1, &[KeyValue::new("k", "a")]);
+    counter.add(2, &[KeyValue::new("k", "b")]);
+
+    // UpDownCounter (i64) — aggregated: k=a => +5, k=b => -3.
+    let udc = meter
+        .i64_up_down_counter("test_updown_i64")
+        .with_description("updown test desc")
+        .with_unit("updown_unit")
+        .build();
+    udc.add(10, &[KeyValue::new("k", "a")]);
+    udc.add(-5, &[KeyValue::new("k", "a")]);
+    udc.add(-3, &[KeyValue::new("k", "b")]);
+
+    // Gauge (u64) — single attribute set => one event with value 42.
+    let gauge = meter
+        .u64_gauge("test_gauge_u64")
+        .with_description("gauge test desc")
+        .with_unit("gauge_unit")
+        .build();
+    gauge.record(42, &[KeyValue::new("k", "a")]);
+
+    // Histogram (f64) — three observations on one attribute set:
+    // count=3, sum=16.0, min=1.0, max=10.0.
+    let hist = meter
+        .f64_histogram("test_hist_f64")
+        .with_description("hist test desc")
+        .with_unit("hist_unit")
+        .build();
+    let h_attrs = [KeyValue::new("k", "a")];
+    hist.record(1.0, &h_attrs);
+    hist.record(5.0, &h_attrs);
+    hist.record(10.0, &h_attrs);
+
+    // Shutdown forces a final export and unregisters the ETW provider.
+    provider.shutdown().expect("provider.shutdown failed");
+
+    let events = drain_events(&rx);
+    // Always stop the trace, even if assertions panic below.
+    let _ = trace.stop();
+
+    assert!(
+        !events.is_empty(),
+        "expected at least one ETW event after shutdown"
+    );
+
+    // Each exported event carries exactly one resource_metrics/scope_metrics/metric.
+    // Bucket the decoded metrics by name.
+    let mut by_metric: HashMap<&str, Vec<&ProtoMetric>> = HashMap::new();
+    for req in &events {
+        for rm in &req.resource_metrics {
+            let svc = rm.resource.as_ref().and_then(|r| {
+                r.attributes
+                    .iter()
+                    .find(|a| a.key == "service.name")
+                    .and_then(|a| a.value.as_ref())
+                    .and_then(|v| v.value.as_ref())
+                    .and_then(|v| match v {
+                        AnyValueValue::StringValue(s) => Some(s.as_str()),
+                        _ => None,
+                    })
+            });
+            assert_eq!(svc, Some("etw-metrics-int-test"));
+            for sm in &rm.scope_metrics {
+                assert_eq!(
+                    sm.scope.as_ref().map(|s| s.name.as_str()),
+                    Some("etw-metric-test")
+                );
+                for m in &sm.metrics {
+                    by_metric.entry(m.name.as_str()).or_default().push(m);
+                }
+            }
+        }
+    }
+
+    // Counter assertions.
+    {
+        let metrics = by_metric
+            .remove("test_counter_u64")
+            .expect("counter metric missing");
+        assert_eq!(
+            metrics.len(),
+            2,
+            "counter expected 2 events (one per attribute set)"
+        );
+        let mut points: Vec<(i64, String)> = metrics
+            .iter()
+            .map(|m| {
+                let sum = match m.data.as_ref().expect("counter has data") {
+                    MetricData::Sum(s) => s,
+                    _ => panic!("counter must be encoded as Sum"),
+                };
+                assert!(sum.is_monotonic, "counter Sum must be monotonic");
+                assert_eq!(sum.data_points.len(), 1);
+                let dp = &sum.data_points[0];
+                let v = match dp.value.as_ref().expect("dp value missing") {
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => {
+                        *v
+                    }
+                    other => panic!("counter value must be int, got {other:?}"),
+                };
+                assert_eq!(m.description, "counter test desc");
+                assert_eq!(m.unit, "counter_unit");
+                (v, attr_string(&dp.attributes, "k"))
+            })
+            .collect();
+        points.sort();
+        assert_eq!(points, vec![(1, "a".into()), (2, "b".into())]);
+    }
+
+    // UpDownCounter assertions.
+    {
+        let metrics = by_metric
+            .remove("test_updown_i64")
+            .expect("updown metric missing");
+        assert_eq!(metrics.len(), 2);
+        let mut points: Vec<(i64, String)> = metrics
+            .iter()
+            .map(|m| {
+                let sum = match m.data.as_ref().expect("updown has data") {
+                    MetricData::Sum(s) => s,
+                    _ => panic!("updowncounter must be encoded as Sum"),
+                };
+                assert!(!sum.is_monotonic, "updowncounter Sum must be non-monotonic");
+                assert_eq!(sum.data_points.len(), 1);
+                let dp = &sum.data_points[0];
+                let v = match dp.value.as_ref().expect("dp value missing") {
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => {
+                        *v
+                    }
+                    other => panic!("updown value must be int, got {other:?}"),
+                };
+                (v, attr_string(&dp.attributes, "k"))
+            })
+            .collect();
+        points.sort();
+        assert_eq!(points, vec![(-3, "b".into()), (5, "a".into())]);
+    }
+
+    // Gauge assertions.
+    {
+        let metrics = by_metric
+            .remove("test_gauge_u64")
+            .expect("gauge metric missing");
+        assert_eq!(metrics.len(), 1);
+        let m = metrics[0];
+        let gauge = match m.data.as_ref().expect("gauge has data") {
+            MetricData::Gauge(g) => g,
+            _ => panic!("gauge must be encoded as Gauge"),
+        };
+        assert_eq!(gauge.data_points.len(), 1);
+        let dp = &gauge.data_points[0];
+        let v = match dp.value.as_ref().expect("dp value missing") {
+            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v,
+            other => panic!("gauge value must be int, got {other:?}"),
+        };
+        assert_eq!(v, 42);
+        assert_eq!(attr_string(&dp.attributes, "k"), "a");
+        assert_eq!(m.description, "gauge test desc");
+        assert_eq!(m.unit, "gauge_unit");
+    }
+
+    // Histogram assertions.
+    {
+        let metrics = by_metric
+            .remove("test_hist_f64")
+            .expect("histogram metric missing");
+        assert_eq!(metrics.len(), 1);
+        let m = metrics[0];
+        let hist = match m.data.as_ref().expect("hist has data") {
+            MetricData::Histogram(h) => h,
+            _ => panic!("histogram must be encoded as Histogram"),
+        };
+        assert_eq!(hist.data_points.len(), 1);
+        let dp = &hist.data_points[0];
+        assert_eq!(dp.count, 3);
+        assert_eq!(dp.sum, Some(16.0));
+        assert_eq!(dp.min, Some(1.0));
+        assert_eq!(dp.max, Some(10.0));
+        assert_eq!(dp.bucket_counts.len(), dp.explicit_bounds.len() + 1);
+        assert_eq!(dp.bucket_counts.iter().sum::<u64>(), dp.count);
+        assert_eq!(attr_string(&dp.attributes, "k"), "a");
+        assert_eq!(m.description, "hist test desc");
+        assert_eq!(m.unit, "hist_unit");
+    }
+
+    assert!(
+        by_metric.is_empty(),
+        "unexpected extra metrics: {:?}",
+        by_metric.keys().collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Adds a real end-to-end integration test for `opentelemetry-etw-metrics`, closing the largest remaining test gap among the ETW/user_events exporter crates.

The test starts a real ETW `UserTrace` session via `ferrisetw`, reads `EVENT_RECORD.UserData` directly (the exporter writes the OTLP payload using `raw_data`, so the user buffer is the raw protobuf), decodes each event as `ExportMetricsServiceRequest`, and asserts the OTLP shape for every supported instrument: Counter (monotonic Sum), UpDownCounter (non-monotonic Sum), Gauge, and Histogram (count/sum/min/max + bucket invariants). Resource `service.name` and scope name are asserted on every event.

The harness mirrors the existing `opentelemetry-etw-logs` integration tests (same `ferrisetw` + raw `EVENT_RECORD` approach) and the OTLP-decode pattern used by `opentelemetry-user-events-metrics`.

A single comprehensive test is used because the ETW provider in this crate is registered via a static `std::sync::Once`, so only one register/unregister cycle is possible per process. The test lives under `tests/` (separate integration binary) to avoid colliding with the existing `emit_metrics_that_combined_exceed_etw_max_event_size` unit test which also calls `etw::register()`.

CI: added a new "Run ETW integration tests (metrics)" step to the existing `etw-integration-test` job on `windows-latest`. The job already runs with `--ignored --test-threads=1`; the new test is gated on `target_os = "windows"` and `#[ignore]` so it only runs in that job.