### PR TITLE
chore(aws): updating opentelemetry-aws crate owner

### DIFF
--- a/opentelemetry-aws/README.md
+++ b/opentelemetry-aws/README.md
@@ -7,7 +7,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     | beta      |
-| Owners        | [Jonathan Lee](https://github.com/jj22ee) |
+| Owners        | [Jonathan Lee](https://github.com/jj22ee), [Chinmay Chahar](https://github.com/chinmaychahar) |
 
 Additional types for exporting [`OpenTelemetry`] data to AWS.
 


### PR DESCRIPTION
## Summary

- Updating ownership of the `opentelemetry-aws` crate

As discussed in #609.