### PR TITLE
feat: [Geneva uploader] add optional rustls TLS backend

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Forwarded `tls-native` (default) and `tls-rustls` feature flags from `geneva-uploader`. Build with `--no-default-features --features tls-rustls` to use the pure-Rust TLS backend (required for FIPS / OpenSSL-free deployments that install a custom `rustls::crypto::CryptoProvider`).
+
 ## [0.5.0] - 2026-04-13
 
 ### Changed

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
+geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
 otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7", optional = true }
@@ -21,6 +21,14 @@ tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 
 [features]
+# TLS backend selection is forwarded to geneva-uploader. `tls-native` (default)
+# matches the pre-existing behavior; enable `tls-rustls` for an OpenSSL-free build
+# (e.g. when pairing with a `rustls::crypto::CryptoProvider` such as rustls-symcrypt).
+# The features are additive, mirroring the inner crate; if both are enabled,
+# `tls-rustls` takes precedence at runtime.
+default = ["tls-native"]
+tls-native = ["geneva-uploader/tls-native"]
+tls-rustls = ["geneva-uploader/tls-rustls"]
 mock_auth = ["geneva-uploader/mock_auth"]
 otlp_bytes = ["dep:otap-df-pdata"]
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- New `tls-rustls` feature flag enables a pure-Rust TLS backend (rustls + p12-keystore) as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. Consumers that need FIPS-validated cryptography can install a custom `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start, and the rustls backend will use it automatically.
+
 ## [0.5.0] - 2026-04-13
 
 ### Changed

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- New `tls-rustls` feature flag enables a pure-Rust TLS backend (rustls + p12-keystore) as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. Consumers that need FIPS-validated cryptography can install a custom `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start, and the rustls backend will use it automatically.
+- New `tls-rustls` feature flag enables a pure-Rust TLS backend (rustls + p12-keystore) as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. No built-in crypto provider (e.g. ring) is compiled in; consumers **must** install a `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start. The uploader returns a clear error if no provider is found.
 
 ## [0.5.0] - 2026-04-13
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -32,9 +32,13 @@ url = "2.2"
 md-5 = "0.11.0"
 hex = "0.4"
 lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
-# Azure Identity dependencies - using public crates.io versions
-azure_identity = "0.29"
-azure_core = "0.29"
+# Azure Identity dependencies - using public crates.io versions.
+# Default features are disabled so the consumer-selected TLS backend (see
+# `tls-native` / `tls-rustls` below) chooses whether to pull in `native-tls`
+# through azure_core. Otherwise azure_core 0.29's defaults include
+# `reqwest_native_tls`, which links native-tls unconditionally.
+azure_identity = { version = "0.29", default-features = false }
+azure_core = { version = "0.29", default-features = false, features = ["reqwest", "reqwest_gzip", "reqwest_deflate"] }
 tracing = "0.1"
 # Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; pulled in transitively
 # via azure_identity / rcgen / yasna. Not used directly by this crate.
@@ -47,7 +51,12 @@ mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
 # install a `rustls::crypto::CryptoProvider` (e.g. SymCrypt) at process start to satisfy
 # FIPS / OpenSSL-free deployments. The features are additive: enabling both (e.g. via
 # `--all-features`) compiles successfully and `tls-rustls` is used at runtime.
-tls-native = ["dep:native-tls", "reqwest/native-tls", "reqwest/native-tls-alpn"]
+tls-native = [
+    "dep:native-tls",
+    "reqwest/native-tls",
+    "reqwest/native-tls-alpn",
+    "azure_core/reqwest_native_tls",
+]
 tls-rustls = [
     "dep:rustls",
     "dep:rustls-pemfile",

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -47,10 +47,11 @@ time = ">=0.3.47"
 [features]
 mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
 # TLS backends. At least one must be enabled. `tls-native` is the default and matches the
-# pre-existing behavior. `tls-rustls` swaps to a pure-Rust TLS stack, which lets consumers
-# install a `rustls::crypto::CryptoProvider` (e.g. SymCrypt) at process start to satisfy
-# FIPS / OpenSSL-free deployments. The features are additive: enabling both (e.g. via
-# `--all-features`) compiles successfully and `tls-rustls` is used at runtime.
+# pre-existing behavior. `tls-rustls` swaps to a pure-Rust TLS stack without compiling in a
+# default crypto provider (ring); consumers must install a `rustls::crypto::CryptoProvider`
+# (e.g. SymCrypt) at process start to satisfy FIPS / OpenSSL-free deployments. The features
+# are additive: enabling both (e.g. via `--all-features`) compiles successfully and
+# `tls-rustls` is used at runtime.
 tls-native = [
     "dep:native-tls",
     "reqwest/native-tls",
@@ -62,7 +63,7 @@ tls-rustls = [
     "dep:rustls-pemfile",
     "dep:rustls-native-certs",
     "dep:p12-keystore",
-    "reqwest/rustls-tls-native-roots",
+    "reqwest/rustls-tls-native-roots-no-provider",
 ]
 default = ["tls-native"]
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -74,6 +74,7 @@ otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "1
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"
+rustls = { version = "0.23", features = ["ring"] }
 openssl = { version = "0.10", features = ["vendored"] }
 tempfile = "3.5"
 wiremock = "0.6"

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -16,10 +16,16 @@ base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 uuid = { version = "1.0", features = ["v4"] }
-# TODO - support both native-tls and rustls
-# http2 feature is required by hyper-util even when using http1_only()
-reqwest = { version = "0.12", features = ["native-tls", "native-tls-alpn", "http2"], default-features = false}
-native-tls = "0.2"
+# TLS backend is selected via the `tls-native` (default) or `tls-rustls` feature flags below.
+# Both features are additive, like reqwest's own TLS features; if both are enabled
+# (e.g. via `--all-features`), `tls-rustls` takes precedence.
+# http2 feature is required by hyper-util even when using http1_only().
+reqwest = { version = "0.12", features = ["http2"], default-features = false }
+native-tls = { version = "0.2", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
+rustls-pemfile = { version = "2", optional = true }
+rustls-native-certs = { version = "0.8", optional = true }
+p12-keystore = { version = "0.2", optional = true }
 thiserror = "2.0"
 chrono = "0.4"
 url = "2.2"
@@ -35,8 +41,21 @@ tracing = "0.1"
 time = ">=0.3.47"
 
 [features]
-mock_auth = [] # Disabled by default. Not to be enabled in the prod release. 
-default = []
+mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
+# TLS backends. At least one must be enabled. `tls-native` is the default and matches the
+# pre-existing behavior. `tls-rustls` swaps to a pure-Rust TLS stack, which lets consumers
+# install a `rustls::crypto::CryptoProvider` (e.g. SymCrypt) at process start to satisfy
+# FIPS / OpenSSL-free deployments. The features are additive: enabling both (e.g. via
+# `--all-features`) compiles successfully and `tls-rustls` is used at runtime.
+tls-native = ["dep:native-tls", "reqwest/native-tls", "reqwest/native-tls-alpn"]
+tls-rustls = [
+    "dep:rustls",
+    "dep:rustls-pemfile",
+    "dep:rustls-native-certs",
+    "dep:p12-keystore",
+    "reqwest/rustls-tls-native-roots",
+]
+default = ["tls-native"]
 
 [dev-dependencies]
 geneva-test-server = { path = "../geneva-test-server", features = ["testing"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/README.md
@@ -64,3 +64,43 @@ a stable C ABI.  It provides two encoding paths that mirror the Rust paths above
   no intermediate copy.
 
 See `../geneva-uploader-ffi/README.md` for details.
+
+## TLS backends
+
+`geneva-uploader` supports two mutually-exclusive TLS backends, selected at
+compile time via Cargo features:
+
+- **`tls-native`** *(default)* — uses [`native-tls`] (which links against the
+  system OpenSSL/SChannel/Secure Transport). This is the historical behavior
+  and requires no additional setup.
+- **`tls-rustls`** — uses pure-Rust [`rustls`] together with [`p12-keystore`]
+  for parsing the PKCS#12 client certificate. Pick this when you need to ship
+  a binary without an OpenSSL runtime dependency, or when you want to plug in a
+  FIPS-validated `CryptoProvider` such as
+  [`rustls-symcrypt`](https://crates.io/crates/rustls-symcrypt). Install your
+  provider once at process startup:
+
+  ```rust,ignore
+  rustls_symcrypt::default_symcrypt_provider()
+      .install_default()
+      .expect("failed to install SymCrypt CryptoProvider");
+  ```
+
+  If no provider is installed, the rustls bundled provider (selected via
+  reqwest's `rustls-tls-native-roots` feature) is used as a fallback.
+
+To switch backends, disable defaults and select the desired feature:
+
+```toml
+[dependencies]
+geneva-uploader = { version = "*", default-features = false, features = ["tls-rustls"] }
+```
+
+Both backends use the system trust store for server verification and pin the
+TLS version to 1.2 (matching Geneva's required protocol). The two feature flags
+are additive — if both are enabled simultaneously (e.g. via `--all-features`),
+`tls-rustls` takes precedence at runtime.
+
+[`native-tls`]: https://crates.io/crates/native-tls
+[`rustls`]: https://crates.io/crates/rustls
+[`p12-keystore`]: https://crates.io/crates/p12-keystore

--- a/opentelemetry-exporter-geneva/geneva-uploader/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/README.md
@@ -76,17 +76,17 @@ See `../geneva-uploader-ffi/README.md` for details.
   for parsing the PKCS#12 client certificate. Pick this when you need to ship
   a binary without an OpenSSL runtime dependency, or when you want to plug in a
   FIPS-validated `CryptoProvider` such as
-  [`rustls-symcrypt`](https://crates.io/crates/rustls-symcrypt). Install your
-  provider once at process startup:
+  [`rustls-symcrypt`](https://crates.io/crates/rustls-symcrypt).
+
+  **A `CryptoProvider` must be installed at process startup** — no built-in
+  provider is compiled in, so the uploader will return an error if none is
+  found. Install your provider once before creating a `GenevaClient`:
 
   ```rust,ignore
   rustls_symcrypt::default_symcrypt_provider()
       .install_default()
       .expect("failed to install SymCrypt CryptoProvider");
   ```
-
-  If no provider is installed, the rustls bundled provider (selected via
-  reqwest's `rustls-tls-native-roots` feature) is used as a fallback.
 
 To switch backends, disable defaults and select the desired feature:
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/README.md
@@ -67,8 +67,7 @@ See `../geneva-uploader-ffi/README.md` for details.
 
 ## TLS backends
 
-`geneva-uploader` supports two mutually-exclusive TLS backends, selected at
-compile time via Cargo features:
+`geneva-uploader` supports two TLS backends, selected at compile time via Cargo features (the flags are additive; if both are enabled, `tls-rustls` is used):
 
 - **`tls-native`** *(default)* — uses [`native-tls`] (which links against the
   system OpenSSL/SChannel/Secure Transport). This is the historical behavior

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
@@ -6,12 +6,12 @@ The diagram below illustrates how the `GenevaConfigClient` is initialized with a
 sequenceDiagram
     participant App as User
     participant Client as GenevaConfigClient
-    participant TLS as native_tls
+    participant TLS as TLS backend<br/>(native-tls or rustls)
     participant GCS as Geneva Config Service
 
     App->>Client: new(GenevaConfigClientConfig)
     Client->>TLS: Load PKCS#12 cert
-    TLS-->>Client: native_tls::TlsConnector
+    TLS-->>Client: configured TLS connector / ClientConfig
     Client->>Client: Build reqwest::Client with mTLS
 
     App->>Client: get_ingestion_info()

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, info};
 use uuid::Uuid;
 
 use chrono::{DateTime, Utc};
+#[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
 use native_tls::{Identity, Protocol};
 use std::fmt;
 use std::fmt::Write;
@@ -25,6 +26,15 @@ use azure_identity::{
     ManagedIdentityCredential, ManagedIdentityCredentialOptions, UserAssignedId,
     WorkloadIdentityCredential,
 };
+
+// Compile-time guard: at least one TLS backend must be selected. Cargo features are
+// additive, so we cannot reject the both-enabled case (e.g. `--all-features`); instead
+// `tls-rustls` takes precedence when both are on. This matches reqwest's own pattern of
+// allowing `native-tls`, `rustls-tls`, etc. to coexist.
+#[cfg(not(any(feature = "tls-native", feature = "tls-rustls")))]
+compile_error!(
+    "geneva-uploader requires at least one TLS backend feature: `tls-native` or `tls-rustls`."
+);
 
 /// Authentication methods for the Geneva Config Client.
 ///
@@ -296,36 +306,62 @@ impl GenevaConfigClient {
                     );
                     GenevaConfigClientError::Certificate(e.to_string())
                 })?;
-                let identity = Identity::from_pkcs12(&p12_bytes, password).map_err(|e| {
-                    debug!(
-                        name: "config_client.new.certificate_parse_error",
-                        target: "geneva-uploader",
-                        error = %e,
-                        "Failed to parse PKCS#12 certificate"
-                    );
-                    GenevaConfigClientError::Certificate(e.to_string())
-                })?;
-                // TODO - use use_native_tls instead of preconfigured_tls once we no longer need
-                // TLS 1.2 as the exclusive protocol.
-                let tls_connector = configure_tls_connector(
-                    native_tls::TlsConnector::builder(),
-                    identity,
-                    #[cfg(test)]
-                    config.test_root_ca_pem.as_deref(),
-                    #[cfg(not(test))]
-                    None,
-                )?
-                .build()
-                .map_err(|e| {
-                    debug!(
-                        name: "config_client.new.tls_connector_error",
-                        target: "geneva-uploader",
-                        error = %e,
-                        "Failed to build TLS connector"
-                    );
-                    GenevaConfigClientError::Certificate(e.to_string())
-                })?;
-                client_builder = client_builder.use_preconfigured_tls(tls_connector);
+
+                #[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
+                {
+                    let identity = Identity::from_pkcs12(&p12_bytes, password).map_err(|e| {
+                        debug!(
+                            name: "config_client.new.certificate_parse_error",
+                            target: "geneva-uploader",
+                            error = %e,
+                            "Failed to parse PKCS#12 certificate"
+                        );
+                        GenevaConfigClientError::Certificate(e.to_string())
+                    })?;
+                    // TODO - use use_native_tls instead of preconfigured_tls once we no longer
+                    // need TLS 1.2 as the exclusive protocol.
+                    let tls_connector = configure_native_tls_connector(
+                        native_tls::TlsConnector::builder(),
+                        identity,
+                        #[cfg(test)]
+                        config.test_root_ca_pem.as_deref(),
+                        #[cfg(not(test))]
+                        None,
+                    )?
+                    .build()
+                    .map_err(|e| {
+                        debug!(
+                            name: "config_client.new.tls_connector_error",
+                            target: "geneva-uploader",
+                            error = %e,
+                            "Failed to build TLS connector"
+                        );
+                        GenevaConfigClientError::Certificate(e.to_string())
+                    })?;
+                    client_builder = client_builder.use_preconfigured_tls(tls_connector);
+                }
+
+                #[cfg(feature = "tls-rustls")]
+                {
+                    let tls_config = build_rustls_client_config(
+                        &p12_bytes,
+                        password,
+                        #[cfg(test)]
+                        config.test_root_ca_pem.as_deref(),
+                        #[cfg(not(test))]
+                        None,
+                    )
+                    .map_err(|e| {
+                        debug!(
+                            name: "config_client.new.tls_connector_error",
+                            target: "geneva-uploader",
+                            error = %e,
+                            "Failed to build rustls client config"
+                        );
+                        e
+                    })?;
+                    client_builder = client_builder.use_preconfigured_tls(tls_config);
+                }
             }
             AuthMethod::WorkloadIdentity { .. } => {
                 info!(
@@ -1045,7 +1081,8 @@ fn extract_endpoint_from_token(token: &str) -> Result<String> {
     ))
 }
 
-fn configure_tls_connector(
+#[cfg(all(feature = "tls-native", not(feature = "tls-rustls")))]
+fn configure_native_tls_connector(
     mut builder: native_tls::TlsConnectorBuilder,
     identity: native_tls::Identity,
     _test_root_ca_pem: Option<&[u8]>,
@@ -1063,4 +1100,79 @@ fn configure_tls_connector(
     }
 
     Ok(builder)
+}
+
+#[cfg(feature = "tls-rustls")]
+fn build_rustls_client_config(
+    p12_bytes: &[u8],
+    password: &str,
+    _test_root_ca_pem: Option<&[u8]>,
+) -> Result<rustls::ClientConfig> {
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use rustls::RootCertStore;
+
+    // Parse the PKCS#12 keystore to extract the client cert chain + private key.
+    let keystore = p12_keystore::KeyStore::from_pkcs12(p12_bytes, password).map_err(|e| {
+        debug!(
+            name: "config_client.new.certificate_parse_error",
+            target: "geneva-uploader",
+            error = %e,
+            "Failed to parse PKCS#12 certificate"
+        );
+        GenevaConfigClientError::Certificate(e.to_string())
+    })?;
+    let (_alias, key_chain) = keystore.private_key_chain().ok_or_else(|| {
+        GenevaConfigClientError::Certificate(
+            "PKCS#12 file contains no private key chain".to_string(),
+        )
+    })?;
+    // p12-keystore guarantees private keys are encoded in PKCS#8 (per its docs).
+    let client_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_chain.key().to_vec()));
+    let client_chain: Vec<CertificateDer<'static>> = key_chain
+        .chain()
+        .iter()
+        .map(|c| CertificateDer::from(c.as_der().to_vec()))
+        .collect();
+    if client_chain.is_empty() {
+        return Err(GenevaConfigClientError::Certificate(
+            "PKCS#12 file contains no certificate chain".to_string(),
+        ));
+    }
+
+    // Build the trust store from the system's native CAs (parity with native-tls).
+    let mut roots = RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    for err in native.errors {
+        debug!(
+            name: "config_client.new.native_root_load_error",
+            target: "geneva-uploader",
+            error = %err,
+            "Failed to load a native root certificate"
+        );
+    }
+    for cert in native.certs {
+        // Ignore individual cert add errors - rustls is strict about parsing.
+        let _ = roots.add(cert);
+    }
+
+    #[cfg(test)]
+    if let Some(root_ca_pem) = _test_root_ca_pem {
+        let mut reader = std::io::BufReader::new(root_ca_pem);
+        for cert in rustls_pemfile::certs(&mut reader) {
+            let cert = cert.map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
+            roots
+                .add(cert)
+                .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
+        }
+    }
+
+    // Pin to TLS 1.2 (matches the native-tls path). The CryptoProvider is selected from the
+    // process-wide default if one was installed (e.g. rustls-symcrypt::default_symcrypt_provider),
+    // otherwise from the provider compiled into rustls via reqwest's `rustls-tls-native-roots`.
+    let config = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS12])
+        .with_root_certificates(roots)
+        .with_client_auth_cert(client_chain, client_key)
+        .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
+
+    Ok(config)
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1150,9 +1150,22 @@ fn build_rustls_client_config(
             "Failed to load a native root certificate"
         );
     }
+    let mut added_roots = 0usize;
     for cert in native.certs {
-        // Ignore individual cert add errors - rustls is strict about parsing.
-        let _ = roots.add(cert);
+        match roots.add(cert) {
+            Ok(()) => added_roots += 1,
+            Err(e) => debug!(
+                name: "config_client.new.native_root_add_error",
+                target: "geneva-uploader",
+                error = %e,
+                "Failed to add a native root certificate"
+            ),
+        }
+    }
+    if added_roots == 0 {
+        return Err(GenevaConfigClientError::Certificate(
+            "No usable native root certificates were loaded".to_string(),
+        ));
     }
 
     #[cfg(test)]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1182,14 +1182,16 @@ fn build_rustls_client_config(
     // Require an explicitly installed CryptoProvider (e.g. rustls-symcrypt for FIPS).
     // No built-in fallback provider is compiled in (`reqwest/rustls-tls-native-roots-no-provider`),
     // so callers must install one at process startup via `CryptoProvider::install_default()`.
-    let provider = rustls::crypto::CryptoProvider::get_default().cloned().ok_or_else(|| {
-        GenevaConfigClientError::Certificate(
-            "No rustls CryptoProvider installed. Call CryptoProvider::install_default() \
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .ok_or_else(|| {
+            GenevaConfigClientError::Certificate(
+                "No rustls CryptoProvider installed. Call CryptoProvider::install_default() \
              at process startup (e.g. rustls_symcrypt::default_symcrypt_provider()\
              .install_default())."
-                .to_string(),
-        )
-    })?;
+                    .to_string(),
+            )
+        })?;
 
     let config = rustls::ClientConfig::builder_with_provider(provider)
         .with_protocol_versions(&[&rustls::version::TLS12])

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1179,10 +1179,21 @@ fn build_rustls_client_config(
         }
     }
 
-    // Pin to TLS 1.2 (matches the native-tls path). The CryptoProvider is selected from the
-    // process-wide default if one was installed (e.g. rustls-symcrypt::default_symcrypt_provider),
-    // otherwise from the provider compiled into rustls via reqwest's `rustls-tls-native-roots`.
-    let config = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS12])
+    // Require an explicitly installed CryptoProvider (e.g. rustls-symcrypt for FIPS).
+    // No built-in fallback provider is compiled in (`reqwest/rustls-tls-native-roots-no-provider`),
+    // so callers must install one at process startup via `CryptoProvider::install_default()`.
+    let provider = rustls::crypto::CryptoProvider::get_default().cloned().ok_or_else(|| {
+        GenevaConfigClientError::Certificate(
+            "No rustls CryptoProvider installed. Call CryptoProvider::install_default() \
+             at process startup (e.g. rustls_symcrypt::default_symcrypt_provider()\
+             .install_default())."
+                .to_string(),
+        )
+    })?;
+
+    let config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS12])
+        .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?
         .with_root_certificates(roots)
         .with_client_auth_cert(client_chain, client_key)
         .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -33,6 +33,13 @@ mod tests {
     // Tests that mutate IDENTITY_ENDPOINT / IDENTITY_HEADER must hold this lock.
     static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
+    /// Install a rustls CryptoProvider for tests that use certificate auth.
+    /// In production, callers must install their own provider (e.g. rustls-symcrypt).
+    #[cfg(feature = "tls-rustls")]
+    fn ensure_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
     struct EnvVarGuard {
         previous: Vec<(&'static str, Option<String>)>,
     }
@@ -380,6 +387,8 @@ mod tests {
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn get_ingestion_info_mocked() {
+        #[cfg(feature = "tls-rustls")]
+        ensure_crypto_provider();
         let mock_server = MockServer::start().await;
         let (mock_response, jwt_endpoint, valid_token) = config_service_response();
 
@@ -551,6 +560,8 @@ mod tests {
 
     #[tokio::test]
     async fn tls_rejects_untrusted_runtime_generated_ca() {
+        #[cfg(feature = "tls-rustls")]
+        ensure_crypto_provider();
         let tls_material = generate_ca_signed_tls_material();
         let (response_body, _, _) = config_service_response();
         let tls_server = spawn_tls_config_service(
@@ -592,6 +603,8 @@ mod tests {
 
     #[tokio::test]
     async fn tls_accepts_runtime_generated_ca() {
+        #[cfg(feature = "tls-rustls")]
+        ensure_crypto_provider();
         let tls_material = generate_ca_signed_tls_material();
         let (response_body, jwt_endpoint, valid_token) = config_service_response();
         let tls_server = spawn_tls_config_service(
@@ -640,6 +653,8 @@ mod tests {
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn error_handling_with_non_success_status() {
+        #[cfg(feature = "tls-rustls")]
+        ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -685,6 +700,8 @@ mod tests {
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn missing_ingestion_gateway_info() {
+        #[cfg(feature = "tls-rustls")]
+        ensure_crypto_provider();
         let mock_server = MockServer::start().await;
 
         // Response without IngestionGatewayInfo
@@ -735,6 +752,8 @@ mod tests {
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn invalid_certificate_path() {
+        #[cfg(feature = "tls-rustls")]
+        ensure_crypto_provider();
         let config = GenevaConfigClientConfig {
             endpoint: "https://example.com".to_string(),
             environment: "env".to_string(),

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Forwarded `tls-native` (default) and `tls-rustls` feature flags from `geneva-uploader`. Build with `--no-default-features --features tls-rustls` to use the pure-Rust TLS backend (required for FIPS / OpenSSL-free deployments that install a custom `rustls::crypto::CryptoProvider`).
+
 ## [0.5.0] - 2026-04-13
 
 ### Changed

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -12,9 +12,19 @@ license = "Apache-2.0"
 [dependencies]
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["logs", "trace"] }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
-geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
+geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 futures = "0.3"
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
+
+[features]
+# TLS backend selection is forwarded to geneva-uploader. `tls-native` (default)
+# matches the pre-existing behavior; enable `tls-rustls` for an OpenSSL-free build
+# (e.g. when pairing with a `rustls::crypto::CryptoProvider` such as rustls-symcrypt).
+# The features are additive, mirroring the inner crate; if both are enabled,
+# `tls-rustls` takes precedence at runtime.
+default = ["tls-native"]
+tls-native = ["geneva-uploader/tls-native"]
+tls-rustls = ["geneva-uploader/tls-rustls"]
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { version = "0.31" }


### PR DESCRIPTION
## Summary

Adds a `tls-rustls` Cargo feature to `geneva-uploader` (and forwards it through `geneva-uploader-ffi` and `opentelemetry-exporter-geneva`) that swaps `native-tls` for `rustls` + `p12-keystore`. The default feature set (`tls-native`) preserves existing behavior bit-for-bit.

The new backend honors any `rustls::crypto::CryptoProvider` installed at process startup, which lets consumers drop their OpenSSL runtime dependency entirely and use FIPS-validated cryptography without rebuilding the uploader.

## Changes

- **`geneva-uploader`** — new additive `tls-native` (default) and `tls-rustls` feature flags. When `tls-rustls` is selected, the config-service client builds its `reqwest::Client` with the rustls TLS backend and parses the PKCS#12 keystore via `p12-keystore`, installing the resulting certs/key directly into the rustls `ClientConfig`. If both flags are enabled (e.g. `--all-features`), `tls-rustls` takes precedence at runtime.
- **`azure_core` / `azure_identity` defaults disabled** — the 0.29 `azure_core` default feature set includes `reqwest_native_tls`, which is additive and would force `native-tls` onto the shared `reqwest` dependency even in a `tls-rustls`-only build. `reqwest_native_tls` is now re-enabled only when `tls-native` is on, so `--no-default-features --features tls-rustls` is genuinely `native-tls`-free.
- **`geneva-uploader-ffi`** and **`opentelemetry-exporter-geneva`** — expose matching `tls-native` (default) / `tls-rustls` features that forward to `geneva-uploader`.
- CHANGELOG entries and a README/inline-doc note describing the new feature and the `CryptoProvider` install requirement when using `tls-rustls`.

## Testing

- `cargo check -p geneva-uploader` (default `tls-native`) — passes.
- `cargo check -p geneva-uploader --no-default-features --features tls-rustls` — passes; resolves rustls/p12-keystore and no longer pulls `native-tls` into the build graph.

## Compatibility

- Default builds are unchanged; consumers who do nothing keep the existing `native-tls`/OpenSSL backend.
- Opting into `tls-rustls` requires consumers to install a `rustls::crypto::CryptoProvider` (e.g. `rustls::crypto::aws_lc_rs::default_provider().install_default()` or `rustls-symcrypt`) before constructing a `GenevaClient`; this is documented in the README and CHANGELOG.
