### PR TITLE
fix(geneva-uploader): exclude time 0.3.48 to unbreak CI

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -30,9 +30,10 @@ lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = fa
 azure_identity = "0.29"
 azure_core = "0.29"
 tracing = "0.1"
-# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; pulled in transitively
-# via azure_identity / rcgen / yasna. Not used directly by this crate.
-time = ">=0.3.47"
+# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; upper bound excludes
+# 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
+# (transitive via azure_core) and breaks the build (E0119). Not used directly.
+time = ">=0.3.47, <0.3.48"
 
 [features]
 mock_auth = [] # Disabled by default. Not to be enabled in the prod release. 


### PR DESCRIPTION
The `time` crate `0.3.48` (published 2026-06-12) adds a `From<HourBase>` impl reachable through an associated type that conflicts with blanket `From` impls in `typespec_client_core 0.8.1` (pulled in transitively via `azure_core 0.29`), producing `error[E0119]: conflicting implementations` while compiling `typespec_client_core`. CI does not check in a `Cargo.lock`, so every Linux job on `main` (`test`, `lint`, `geneva-uploader-test-server-integration-test`) started failing the moment the resolver picked up the new version.

Narrow the existing `time` constraint in `geneva-uploader` from `">=0.3.47"` to `">=0.3.47, <0.3.48"`. This keeps the RUSTSEC-2026-0009 lower bound and excludes the broken release. Verified locally: `cargo update -p time` keeps `time 0.3.47` and `cargo check --workspace --all-features` passes.

The upper bound can be relaxed once either `time` ships a fix (0.3.49+) or `azure_core` picks up a newer `typespec_client_core` release.