### PR TITLE
feat(resource-detectors): Add container resource detector

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Added
+
+- Add `ContainerResourceDetector` to detect `container.id` from `/proc/self/cgroup`, with fallback to `/proc/self/mountinfo`.
+
 ## v0.11.0
 
 Released 2026-May-13

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -25,10 +25,10 @@ Community supported Resource detectors implementations for applications instrume
 
 | Detector                | Implemented Resources             | OS Supported | Semantic Conventions                                                                      |
 |-------------------------|-----------------------------------|--------------|-------------------------------------------------------------------------------------------|
-| ProcessResourceDetector | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
-| OsResourceDetector      | OS_TYPE                           | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
-| HostResourceDetector    | HOST_ID                           | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
-| HostResourceDetector    | HOST_ARCH                         | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
-| K8sResourceDetector     | K8S_NAMESPACE_NAME                | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
-| K8sResourceDetector     | K8S_POD_NAME                      | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
-| ContainerResourceDetector | CONTAINER_ID                    | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/container.md |
+| ProcessResourceDetector   | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
+| OsResourceDetector        | OS_TYPE                           | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
+| HostResourceDetector      | HOST_ID                           | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
+| HostResourceDetector      | HOST_ARCH                         | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
+| K8sResourceDetector       | K8S_NAMESPACE_NAME                | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
+| K8sResourceDetector       | K8S_POD_NAME                      | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
+| ContainerResourceDetector | CONTAINER_ID                      | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/container.md |

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -31,3 +31,4 @@ Community supported Resource detectors implementations for applications instrume
 | HostResourceDetector    | HOST_ARCH                         | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
 | K8sResourceDetector     | K8S_NAMESPACE_NAME                | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
 | K8sResourceDetector     | K8S_POD_NAME                      | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
+| ContainerResourceDetector | CONTAINER_ID                    | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/container.md |

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn extracts_shorter_hex_id_from_mountinfo() {
-        // Valid hex ID shorter shorter than 64 chars.
+        // Valid hex ID shorter than 64 chars.
         let content = "\
 2304 1573 254:1 /docker/containers/abcdef1234567890abcdef1234567890/hostname /etc/hostname rw - ext4 /dev/vda1 rw
 ";

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -8,9 +8,9 @@ use opentelemetry_sdk::resource::{Resource, ResourceDetector};
 use std::fs::read_to_string;
 
 #[cfg(target_os = "linux")]
-const CGROUP_V1_PATH: &str = "/proc/self/cgroup";
+const CGROUP_PATH: &str = "/proc/self/cgroup";
 #[cfg(target_os = "linux")]
-const CGROUP_V2_PATH: &str = "/proc/self/mountinfo";
+const MOUNTINFO_PATH: &str = "/proc/self/mountinfo";
 
 /// Min and max container ID lengths.
 #[cfg(any(target_os = "linux", test))]
@@ -37,13 +37,13 @@ impl ResourceDetector for ContainerResourceDetector {
 
 #[cfg(target_os = "linux")]
 fn detect_container_id() -> Option<String> {
-    if let Ok(content) = read_to_string(CGROUP_V1_PATH) {
+    if let Ok(content) = read_to_string(CGROUP_PATH) {
         if let Some(id) = content.lines().find_map(extract_container_id_from_cgroup) {
             return Some(id.to_string());
         }
     }
 
-    if let Ok(content) = read_to_string(CGROUP_V2_PATH) {
+    if let Ok(content) = read_to_string(MOUNTINFO_PATH) {
         if let Some(id) = extract_container_id_from_mountinfo(&content) {
             return Some(id.to_string());
         }

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -18,8 +18,12 @@ const MIN_CONTAINER_ID_LENGTH: usize = 32;
 #[cfg(any(target_os = "linux", test))]
 const MAX_CONTAINER_ID_LENGTH: usize = 64;
 
-/// Detects `container.id` from `/proc/self/cgroup` (cgroup v1), falling back to
-/// `/proc/self/mountinfo` (cgroup v2). Returns an empty [`Resource`] when no ID is found.
+/// Detects `container.id` from `/proc/self/cgroup`, falling back to `/proc/self/mountinfo`.
+///
+/// Returns an empty [`Resource`] when no ID is found.
+///
+/// This detector is meant for use on Linux only. It will no-op and return an empty
+/// [`Resource`] on all other platforms.
 pub struct ContainerResourceDetector;
 
 impl ResourceDetector for ContainerResourceDetector {

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -1,6 +1,6 @@
 //! Container resource detector
 //!
-//! Detects the container ID using files under `proc`
+//! Detects `container.id` using `/proc/self/cgroup`, falling back to `/proc/self/mountinfo`.
 
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::{Resource, ResourceDetector};

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -4,9 +4,12 @@
 
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::{Resource, ResourceDetector};
+#[cfg(target_os = "linux")]
 use std::fs::read_to_string;
 
+#[cfg(target_os = "linux")]
 const CGROUP_V1_PATH: &str = "/proc/self/cgroup";
+#[cfg(target_os = "linux")]
 const CGROUP_V2_PATH: &str = "/proc/self/mountinfo";
 
 /// Length of a container ID in the cgroup v2 mount path.
@@ -29,6 +32,7 @@ impl ResourceDetector for ContainerResourceDetector {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn detect_container_id() -> Option<String> {
     if let Ok(content) = read_to_string(CGROUP_V1_PATH) {
         if let Some(id) = content.lines().find_map(extract_container_id_from_cgroup) {
@@ -45,8 +49,14 @@ fn detect_container_id() -> Option<String> {
     None
 }
 
+#[cfg(not(target_os = "linux"))]
+fn detect_container_id() -> Option<String> {
+    None
+}
+
 /// Extracts a container ID from a `/proc/self/cgroup` line. The ID is the final path
 /// segment, with runtime prefixes and dot-separated suffixes removed.
+#[cfg(any(target_os = "linux", test))]
 fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
     let last_segment = line[line.rfind('/')? + 1..].trim();
 
@@ -66,6 +76,7 @@ fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
 
 /// Extracts a container ID from a `/proc/self/mountinfo` `hostname` line. The ID is
 /// the segment after `containers` or `overlay-containers`.
+#[cfg(any(target_os = "linux", test))]
 fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
     let line = content.lines().find(|line| line.contains("hostname"))?;
 

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -1,0 +1,175 @@
+//! Container resource detector
+//!
+//! Detects the container ID from the cgroup files under `/proc`
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::resource::{Resource, ResourceDetector};
+use std::fs::read_to_string;
+
+const CGROUP_V1_PATH: &str = "/proc/self/cgroup";
+const CGROUP_V2_PATH: &str = "/proc/self/mountinfo";
+
+/// Length of a container ID in the cgroup v2 mount path.
+const CONTAINER_ID_LENGTH: usize = 64;
+
+/// Detects `container.id` from `/proc/self/cgroup` (cgroup v1), falling back to
+/// `/proc/self/mountinfo` (cgroup v2). Returns an empty [`Resource`] when no ID is found.
+pub struct ContainerResourceDetector;
+
+impl ResourceDetector for ContainerResourceDetector {
+    fn detect(&self) -> Resource {
+        Resource::builder_empty()
+            .with_attributes(detect_container_id().map(|container_id| {
+                KeyValue::new(
+                    opentelemetry_semantic_conventions::attribute::CONTAINER_ID,
+                    container_id,
+                )
+            }))
+            .build()
+    }
+}
+
+fn detect_container_id() -> Option<String> {
+    if let Ok(content) = read_to_string(CGROUP_V1_PATH) {
+        if let Some(id) = content.lines().find_map(extract_container_id_from_cgroup) {
+            return Some(id.to_string());
+        }
+    }
+
+    if let Ok(content) = read_to_string(CGROUP_V2_PATH) {
+        if let Some(id) = extract_container_id_from_mountinfo(&content) {
+            return Some(id.to_string());
+        }
+    }
+
+    None
+}
+
+/// Extracts a container ID from a `/proc/self/cgroup` line. The ID is the final path
+/// segment, with runtime prefixes and dot-separated suffixes removed.
+fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
+    let last_segment = line[line.rfind('/')? + 1..].trim();
+
+    let candidate = match last_segment.rfind([':', '-']) {
+        Some(index) => &last_segment[index + 1..],
+        None => last_segment,
+    };
+
+    let candidate = candidate.split('.').next().unwrap_or(candidate);
+
+    if !candidate.is_empty() && candidate.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+/// Extracts a container ID from a `/proc/self/mountinfo` `hostname` line. The ID is
+/// the segment after `containers` or `overlay-containers`.
+fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
+    let line = content.lines().find(|line| line.contains("hostname"))?;
+
+    line.split('/')
+        .collect::<Vec<_>>()
+        .windows(2)
+        .find_map(|pair| match pair {
+            [marker, id]
+                if matches!(*marker, "containers" | "overlay-containers")
+                    && id.len() == CONTAINER_ID_LENGTH =>
+            {
+                Some(*id)
+            }
+            _ => None,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_id_from_cgroup_v1_lines() {
+        let cases = [
+            // Prefix only.
+            (
+                "13:name=systemd:/podruntime/docker/kubepods/docker-dc579f8a8319c8cf7d38e1adf263bc08d23",
+                Some("dc579f8a8319c8cf7d38e1adf263bc08d23"),
+            ),
+            // Prefix and suffix.
+            (
+                "11:devices:/kubepods.slice/crio-dc679f8a8319c8cf7d38e1adf263bc08d23.scope",
+                Some("dc679f8a8319c8cf7d38e1adf263bc08d23"),
+            ),
+            // No prefix, no suffix.
+            (
+                "1:name=systemd:/pod/d86d75589bf6cc254f3e2cc29debdf85dde404998aa128997a819ff991827356",
+                Some("d86d75589bf6cc254f3e2cc29debdf85dde404998aa128997a819ff991827356"),
+            ),
+            // ID follows the last colon.
+            (
+                "0::/kubepods/burstable/podABC/cri-containerd:e857a4bf04e0a6b0d3b1b9f3d6e2c1a0f9e8d7c6b5a4938271605f4e3d2c1b0a",
+                Some("e857a4bf04e0a6b0d3b1b9f3d6e2c1a0f9e8d7c6b5a4938271605f4e3d2c1b0a"),
+            ),
+        ];
+
+        for (line, expected) in cases {
+            assert_eq!(
+                extract_container_id_from_cgroup(line),
+                expected,
+                "line: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_non_container_cgroup_lines() {
+        // A bare root path, a line without any path, and a non-hex segment.
+        assert_eq!(extract_container_id_from_cgroup("0::/"), None);
+        assert_eq!(extract_container_id_from_cgroup("2:cpu:nopath"), None);
+        assert_eq!(
+            extract_container_id_from_cgroup("3:cpuset:/system.slice/sshd.service"),
+            None
+        );
+    }
+
+    #[test]
+    fn extracts_id_from_mountinfo() {
+        let content = "\
+1573 1471 0:286 / / rw,relatime master:533 - overlay overlay rw
+1579 1573 0:290 / /dev rw,nosuid - tmpfs tmpfs rw
+1580 1579 0:291 / /dev/pts rw,nosuid,noexec - devpts devpts rw
+2304 1573 254:1 /docker/containers/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef/hostname /etc/hostname rw,relatime - ext4 /dev/vda1 rw
+";
+        assert_eq!(
+            extract_container_id_from_mountinfo(content),
+            Some("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+        );
+    }
+
+    #[test]
+    fn extracts_id_from_mountinfo_overlay_containers() {
+        let content = "\
+2304 1573 254:1 /containers/storage/overlay-containers/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890/userdata/hostname /etc/hostname rw - ext4 /dev/vda1 rw
+";
+        assert_eq!(
+            extract_container_id_from_mountinfo(content),
+            Some("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+        );
+    }
+
+    #[test]
+    fn returns_none_when_mountinfo_has_no_container_id() {
+        let content = "\
+1573 1471 0:286 / / rw,relatime - overlay overlay rw
+1579 1573 0:290 / /dev rw,nosuid - tmpfs tmpfs rw
+";
+        assert_eq!(extract_container_id_from_mountinfo(content), None);
+    }
+
+    #[test]
+    fn detect_does_not_panic() {
+        // On the host running the tests there may or may not be a container ID;
+        // either way detection must not panic.
+        let _ = ContainerResourceDetector.detect();
+    }
+}

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -91,7 +91,8 @@ fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
         .find_map(|pair| match pair {
             [marker, id]
                 if matches!(*marker, "containers" | "overlay-containers")
-                    && id.len() == MAX_CONTAINER_ID_LENGTH =>
+                    && id.len() == MAX_CONTAINER_ID_LENGTH
+                    && id.bytes().all(|b| b.is_ascii_hexdigit()) =>
             {
                 Some(*id)
             }
@@ -193,6 +194,14 @@ mod tests {
         let content = "\
 1573 1471 0:286 / / rw,relatime - overlay overlay rw
 1579 1573 0:290 / /dev rw,nosuid - tmpfs tmpfs rw
+";
+        assert_eq!(extract_container_id_from_mountinfo(content), None);
+    }
+
+    #[test]
+    fn ignores_non_hex_mountinfo_segment() {
+        let content = "\
+2304 1573 254:1 /docker/containers/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/hostname /etc/hostname rw - ext4 /dev/vda1 rw
 ";
         assert_eq!(extract_container_id_from_mountinfo(content), None);
     }

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -89,15 +89,19 @@ fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
 }
 
 /// Extracts a container ID from a single `/proc/self/mountinfo` line. The ID is the
-/// segment after `containers` or `overlay-containers` on the `hostname` line.
+/// segment after `containers` or `overlay-containers` on the `/etc/hostname` mount point line.
 #[cfg(any(target_os = "linux", test))]
 fn extract_container_id_from_mountinfo_line(line: &str) -> Option<&str> {
-    if !line.contains("hostname") {
+    // Root and mount point precede the " - " separator and are indexed 3 and 4 when split by whitespace.
+    let mut fields = line.split(" - ").next()?.split_whitespace();
+    let root = fields.nth(3)?;
+    let mount_point = fields.next()?;
+    if mount_point != "/etc/hostname" {
         return None;
     }
 
     let mut prev = "";
-    for segment in line.split('/') {
+    for segment in root.split('/') {
         if matches!(prev, "containers" | "overlay-containers") && is_valid_container_id(segment) {
             return Some(segment);
         }

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -79,11 +79,21 @@ fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
     }
 }
 
-/// Extracts a container ID from a `/proc/self/mountinfo` `hostname` line. The ID is
-/// the segment after `containers` or `overlay-containers`.
+/// Extracts a container ID from `/proc/self/mountinfo`
 #[cfg(any(target_os = "linux", test))]
 fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
-    let line = content.lines().find(|line| line.contains("hostname"))?;
+    content
+        .lines()
+        .find_map(extract_container_id_from_mountinfo_line)
+}
+
+/// Extracts a container ID from a single `/proc/self/mountinfo` line. The ID is the
+/// segment after `containers` or `overlay-containers` on the `hostname` line.
+#[cfg(any(target_os = "linux", test))]
+fn extract_container_id_from_mountinfo_line(line: &str) -> Option<&str> {
+    if !line.contains("hostname") {
+        return None;
+    }
 
     line.split('/')
         .collect::<Vec<_>>()
@@ -196,6 +206,18 @@ mod tests {
 1579 1573 0:290 / /dev rw,nosuid - tmpfs tmpfs rw
 ";
         assert_eq!(extract_container_id_from_mountinfo(content), None);
+    }
+
+    #[test]
+    fn extracts_id_from_later_mountinfo_line() {
+        let content = "\
+1234 1111 0:50 /etc/hostname /etc/hostname rw,relatime - tmpfs tmpfs rw
+2304 1573 254:1 /docker/containers/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef/hostname /etc/hostname rw - ext4 /dev/vda1 rw
+";
+        assert_eq!(
+            extract_container_id_from_mountinfo(content),
+            Some("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+        );
     }
 
     #[test]

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -75,7 +75,9 @@ fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
         None => last_segment,
     };
 
-    let candidate = candidate.split('.').next().unwrap_or(candidate);
+    let candidate = candidate
+        .split_once('.')
+        .map_or(candidate, |(before, _)| before);
 
     is_valid_container_id(candidate).then_some(candidate)
 }

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -57,6 +57,13 @@ fn detect_container_id() -> Option<String> {
     None
 }
 
+/// Checks if `candidate` is a hex string between 32 and 64 chars.
+#[cfg(any(target_os = "linux", test))]
+fn is_valid_container_id(candidate: &str) -> bool {
+    (MIN_CONTAINER_ID_LENGTH..=MAX_CONTAINER_ID_LENGTH).contains(&candidate.len())
+        && candidate.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// Extracts a container ID from a `/proc/self/cgroup` line. The ID is the final path
 /// segment, with runtime prefixes and dot-separated suffixes removed.
 #[cfg(any(target_os = "linux", test))]
@@ -70,13 +77,7 @@ fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
 
     let candidate = candidate.split('.').next().unwrap_or(candidate);
 
-    if (MIN_CONTAINER_ID_LENGTH..=MAX_CONTAINER_ID_LENGTH).contains(&candidate.len())
-        && candidate.bytes().all(|b| b.is_ascii_hexdigit())
-    {
-        Some(candidate)
-    } else {
-        None
-    }
+    is_valid_container_id(candidate).then_some(candidate)
 }
 
 /// Extracts a container ID from `/proc/self/mountinfo`
@@ -101,8 +102,7 @@ fn extract_container_id_from_mountinfo_line(line: &str) -> Option<&str> {
         .find_map(|pair| match pair {
             [marker, id]
                 if matches!(*marker, "containers" | "overlay-containers")
-                    && id.len() == MAX_CONTAINER_ID_LENGTH
-                    && id.bytes().all(|b| b.is_ascii_hexdigit()) =>
+                    && is_valid_container_id(id) =>
             {
                 Some(*id)
             }
@@ -217,6 +217,18 @@ mod tests {
         assert_eq!(
             extract_container_id_from_mountinfo(content),
             Some("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+        );
+    }
+
+    #[test]
+    fn extracts_shorter_hex_id_from_mountinfo() {
+        // Valid hex ID shorter shorter than 64 chars.
+        let content = "\
+2304 1573 254:1 /docker/containers/abcdef1234567890abcdef1234567890/hostname /etc/hostname rw - ext4 /dev/vda1 rw
+";
+        assert_eq!(
+            extract_container_id_from_mountinfo(content),
+            Some("abcdef1234567890abcdef1234567890")
         );
     }
 

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -1,6 +1,6 @@
 //! Container resource detector
 //!
-//! Detects the container ID from the cgroup files under `/proc`
+//! Detects the container ID using files under `proc`
 
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::{Resource, ResourceDetector};

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -93,7 +93,7 @@ fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
 #[cfg(any(target_os = "linux", test))]
 fn extract_container_id_from_mountinfo_line(line: &str) -> Option<&str> {
     // Root and mount point precede the " - " separator and are indexed 3 and 4 when split by whitespace.
-    let mut fields = line.split(" - ").next()?.split_whitespace();
+    let mut fields = line.split_once(" - ")?.0.split_whitespace();
     let root = fields.nth(3)?;
     let mount_point = fields.next()?;
     if mount_point != "/etc/hostname" {

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -12,8 +12,11 @@ const CGROUP_V1_PATH: &str = "/proc/self/cgroup";
 #[cfg(target_os = "linux")]
 const CGROUP_V2_PATH: &str = "/proc/self/mountinfo";
 
-/// Length of a container ID in the cgroup v2 mount path.
-const CONTAINER_ID_LENGTH: usize = 64;
+/// Min and max container ID lengths.
+#[cfg(any(target_os = "linux", test))]
+const MIN_CONTAINER_ID_LENGTH: usize = 32;
+#[cfg(any(target_os = "linux", test))]
+const MAX_CONTAINER_ID_LENGTH: usize = 64;
 
 /// Detects `container.id` from `/proc/self/cgroup` (cgroup v1), falling back to
 /// `/proc/self/mountinfo` (cgroup v2). Returns an empty [`Resource`] when no ID is found.
@@ -67,7 +70,9 @@ fn extract_container_id_from_cgroup(line: &str) -> Option<&str> {
 
     let candidate = candidate.split('.').next().unwrap_or(candidate);
 
-    if !candidate.is_empty() && candidate.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if (MIN_CONTAINER_ID_LENGTH..=MAX_CONTAINER_ID_LENGTH).contains(&candidate.len())
+        && candidate.bytes().all(|b| b.is_ascii_hexdigit())
+    {
         Some(candidate)
     } else {
         None
@@ -86,7 +91,7 @@ fn extract_container_id_from_mountinfo(content: &str) -> Option<&str> {
         .find_map(|pair| match pair {
             [marker, id]
                 if matches!(*marker, "containers" | "overlay-containers")
-                    && id.len() == CONTAINER_ID_LENGTH =>
+                    && id.len() == MAX_CONTAINER_ID_LENGTH =>
             {
                 Some(*id)
             }
@@ -139,6 +144,21 @@ mod tests {
         assert_eq!(extract_container_id_from_cgroup("2:cpu:nopath"), None);
         assert_eq!(
             extract_container_id_from_cgroup("3:cpuset:/system.slice/sshd.service"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_range_hex_segments() {
+        // Too short.
+        assert_eq!(
+            extract_container_id_from_cgroup("5:pids:/user.slice/user-1000.slice/session-2.scope"),
+            None
+        );
+        // Too long.
+        let too_long = "a".repeat(MAX_CONTAINER_ID_LENGTH + 1);
+        assert_eq!(
+            extract_container_id_from_cgroup(&format!("0::/docker/{too_long}")),
             None
         );
     }

--- a/opentelemetry-resource-detectors/src/container.rs
+++ b/opentelemetry-resource-detectors/src/container.rs
@@ -96,18 +96,15 @@ fn extract_container_id_from_mountinfo_line(line: &str) -> Option<&str> {
         return None;
     }
 
-    line.split('/')
-        .collect::<Vec<_>>()
-        .windows(2)
-        .find_map(|pair| match pair {
-            [marker, id]
-                if matches!(*marker, "containers" | "overlay-containers")
-                    && is_valid_container_id(id) =>
-            {
-                Some(*id)
-            }
-            _ => None,
-        })
+    let mut prev = "";
+    for segment in line.split('/') {
+        if matches!(prev, "containers" | "overlay-containers") && is_valid_container_id(segment) {
+            return Some(segment);
+        }
+        prev = segment;
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/opentelemetry-resource-detectors/src/lib.rs
+++ b/opentelemetry-resource-detectors/src/lib.rs
@@ -7,11 +7,14 @@
 //! - [`ProcessResourceDetector`] - detect process information.
 //! - [`HostResourceDetector`] - detect unique host ID.
 //! - [`K8sResourceDetector`] - detect Kubernetes information.
+//! - [`ContainerResourceDetector`] - detect container ID.
+mod container;
 mod host;
 mod k8s;
 mod os;
 mod process;
 
+pub use container::ContainerResourceDetector;
 pub use host::HostResourceDetector;
 pub use k8s::K8sResourceDetector;
 pub use os::OsResourceDetector;


### PR DESCRIPTION
Fixes #649

## Changes

Adds `ContainerResourceDetector` to `opentelemetry-resource-detectors`, which populates the `container.id` resource attribute from the process control group files:

- It reads `/proc/self/cgroup` first (cgroup v1)
- Falls back to `/proc/self/mountinfo` (cgroup v2)
- Yields an empty `Resource` when no ID is found. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
