### PR TITLE
chore(issue-templates): sync component dropdown with actual crates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -40,15 +40,22 @@ body:
       multiple: true
       options:
         - opentelemetry-aws
+        - opentelemetry-config
         - opentelemetry-contrib
         - opentelemetry-datadog
-        - opentelemetry-dynatrace
         - opentelemetry-etw-logs
+        - opentelemetry-etw-metrics
+        - opentelemetry-exporter-geneva
+        - opentelemetry-instrumentation-actix-web
+        - opentelemetry-instrumentation-tower
+        - opentelemetry-resource-detectors
         - opentelemetry-stackdriver
         - opentelemetry-user-events-logs
         - opentelemetry-user-events-metrics
-        - opentelemetry-resource-detectors
+        - opentelemetry-user-events-trace
         - N/A
+    validations:
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -29,15 +29,22 @@ body:
       multiple: true
       options:
         - opentelemetry-aws
+        - opentelemetry-config
         - opentelemetry-contrib
         - opentelemetry-datadog
-        - opentelemetry-dynatrace
         - opentelemetry-etw-logs
+        - opentelemetry-etw-metrics
+        - opentelemetry-exporter-geneva
+        - opentelemetry-instrumentation-actix-web
+        - opentelemetry-instrumentation-tower
+        - opentelemetry-resource-detectors
         - opentelemetry-stackdriver
         - opentelemetry-user-events-logs
         - opentelemetry-user-events-metrics
-        - opentelemetry-resource-detectors
+        - opentelemetry-user-events-trace
         - N/A
+    validations:
+      required: true
   - type: textarea
     id: solution
     attributes:


### PR DESCRIPTION
The component dropdown in the bug-report and feature-request issue templates is out of sync with the actual set of crates in this repo. It still lists `opentelemetry-dynatrace` (which no longer lives here) and is missing every crate added since: `opentelemetry-config`, `opentelemetry-etw-metrics`, `opentelemetry-exporter-geneva`, `opentelemetry-instrumentation-actix-web`, `opentelemetry-instrumentation-tower`, and `opentelemetry-user-events-trace`.

This PR updates both `.github/ISSUE_TEMPLATE/BUG-REPORT.yml` and `.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml` so the dropdown options match the crate set listed in `.github/component_owners.yml` exactly. The option labels are the crate folder names so they line up 1:1 with the keys in `component_owners.yml`, which lets a follow-up workflow parse the answer and route issues to the right component owners.

The field is also marked required so every triaged issue has a component on file.
