### PR TITLE
docs: clarify code-based config takes precedence over env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,7 @@ For users that want to implement their own exporters. It's RECOMMENDED to wrap a
 
 ### Priority of configurations
 
-OpenTelemetry supports multiple ways to configure the API, SDK and other components. The priority of configurations is as follows:
-
-- Environment variables
-- Compiling time configurations provided in the source code
+OpenTelemetry supports multiple ways to configure the API, SDK and other components. When the same setting is provided through more than one mechanism, code-based configuration (e.g. `with_xxx` builder methods) takes precedence over environment variables. New components added under this repo MUST follow this priority.
 
 ## Style Guide
 


### PR DESCRIPTION
Updates CONTRIBUTING.md to reflect the decision in open-telemetry/opentelemetry-rust#1225: when a setting is provided both via `with_xxx` and an environment variable, the code-based value wins. Users who want env-var-based runtime configuration should leave the corresponding `with_xxx` calls out of their code.

The existing wording still listed env vars as higher priority, which is the opposite of the agreed direction.

Companion to open-telemetry/opentelemetry-rust#3556.