### PR TITLE
chore(owners): add owners for opentelemetry-etw-traces and opentelemetry-exporter-geneva

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -45,6 +45,7 @@ body:
         - opentelemetry-datadog
         - opentelemetry-etw-logs
         - opentelemetry-etw-metrics
+        - opentelemetry-etw-traces
         - opentelemetry-exporter-geneva
         - opentelemetry-instrumentation-actix-web
         - opentelemetry-instrumentation-tower

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -34,6 +34,7 @@ body:
         - opentelemetry-datadog
         - opentelemetry-etw-logs
         - opentelemetry-etw-metrics
+        - opentelemetry-etw-traces
         - opentelemetry-exporter-geneva
         - opentelemetry-instrumentation-actix-web
         - opentelemetry-instrumentation-tower

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -38,8 +38,13 @@ components:
     - mattbodd
     - psandana
 
-  # opentelemetry-exporter-geneva/:
-  #   # TBD - seeking owners
+  opentelemetry-etw-traces/:
+    - jevidako
+    - urosjovanovic
+
+  opentelemetry-exporter-geneva/:
+    - lalitb
+    - utpilla
 
   # opentelemetry-instrumentation-actix-web/:
   #   # TBD - seeking owners


### PR DESCRIPTION
Adds component owners for two crates that were missing entries in `.github/component_owners.yml`, and adds `opentelemetry-etw-traces` to the issue-template component dropdowns.

- `opentelemetry-etw-traces`: @jevidako, @urosjovanovic
- `opentelemetry-exporter-geneva`: @lalitb, @utpilla