### PR TITLE
Update otel-arrow reference to use controller extension hooks

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
-otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57", optional = true }
+otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
+otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7", optional = true }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
-otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82", optional = true }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "591a9c12c0b36025f9f7a899eb840d4fee913ffd" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "591a9c12c0b36025f9f7a899eb840d4fee913ffd", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70", optional = true }
+otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
+otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
+otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -39,7 +39,7 @@ mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
 default = []
 
 [dev-dependencies]
-otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
+otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
+otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -39,7 +39,7 @@ mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
 default = []
 
 [dev-dependencies]
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
+otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -39,7 +39,7 @@ mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
 default = []
 
 [dev-dependencies]
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "591a9c12c0b36025f9f7a899eb840d4fee913ffd" }
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -39,7 +39,7 @@ mock_auth = [] # Disabled by default. Not to be enabled in the prod release.
 default = []
 
 [dev-dependencies]
-otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "591a9c12c0b36025f9f7a899eb840d4fee913ffd" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = ["l
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 futures = "0.3"
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { version = "0.31" }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = ["l
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 futures = "0.3"
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
+otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { version = "0.31" }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = ["l
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 futures = "0.3"
-otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
+otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { version = "0.31" }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = ["l
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0" }
 futures = "0.3"
-otap-df-pdata-views = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "591a9c12c0b36025f9f7a899eb840d4fee913ffd" }
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { version = "0.31" }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "591a9c12c0b36025f9f7a899eb840d4fee913ffd" }
 prost = "0.14"
 
 [features]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
+otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
 prost = "0.14"
 
 [features]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "ad75eb24835758f3a396a001bae94ee12bcdce57" }
+otap-df-pdata = { git = "https://github.com/sjmsft/otel-arrow", rev = "4573a39c239a479b3a22292e9f107c3285afcd82" }
 prost = "0.14"
 
 [features]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "15371dc7" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "fabbe70" }
 prost = "0.14"
 
 [features]


### PR DESCRIPTION
Fixes # Update otel-arrow reference to use controller extension hooks
Design discussion issue (if applicable) #
NA
## Changes

Update otel-arrow reference to commit https://github.com/sjmsft/otel-arrow/commit/591a9c12c0b36025f9f7a899eb840d4fee913ffd

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
