### PR TITLE
test: Simplify ETW integration tests setup for all signals by using one_collect

### DIFF
--- a/opentelemetry-etw-logs/Cargo.toml
+++ b/opentelemetry-etw-logs/Cargo.toml
@@ -35,8 +35,7 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 criterion = "0.8"
 
 [target.'cfg(windows)'.dev-dependencies]
-ferrisetw = "1.2"
-windows = { version = "0.62", features = ["Win32_System_Diagnostics_Etw"] }
+one_collect = "0.1.34532"
 
 [features]
 internal-logs = [

--- a/opentelemetry-etw-logs/src/lib.rs
+++ b/opentelemetry-etw-logs/src/lib.rs
@@ -72,13 +72,20 @@ pub use processor::ProcessorBuilder;
 
 #[cfg(all(test, target_os = "windows"))]
 mod integration_tests {
+    use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
     use std::time::Duration;
 
-    use ferrisetw::schema_locator::SchemaLocator;
-    use ferrisetw::trace::UserTrace;
-    use ferrisetw::EventRecord;
+    use one_collect::etw::tdh::TdhDecoder;
+    use one_collect::etw::{EtwSession, LEVEL_VERBOSE};
+    use one_collect::event::os::windows::WindowsEventExtension;
+    use one_collect::event::Event;
+    use one_collect::Guid;
 
     use tracelogging_dynamic as tld;
 
@@ -88,14 +95,13 @@ mod integration_tests {
     use opentelemetry_sdk::Resource;
 
     // -----------------------------------------------------------------------
-    // TDH-based ETW event property parser
+    // ETW event property capture via one_collect
     //
-    // ferrisetw's Parser cannot handle TraceLogging struct properties (PartA,
-    // PartB, ext_dt, etc.) — it returns UnimplementedType("structure").
-    // We use TDH APIs directly to enumerate all event properties from the
-    // schema (TRACE_EVENT_INFO) and read their values from the raw data
-    // buffer, producing a flat HashMap keyed by dotted paths like
-    // "PartA.ext_cloud.role" or "PartB.body".
+    // one_collect's TdhDecoder resolves TraceLogging struct properties (PartA,
+    // PartB, ext_dt, etc.) into a flat EventFormat whose nested fields are
+    // flattened with dotted names ("PartA.ext_cloud.role", "PartB.body").
+    // We walk that schema and read each leaf value from the event payload,
+    // producing a flat HashMap keyed by those dotted paths.
     // -----------------------------------------------------------------------
 
     /// Captured event with all properties parsed into named fields.
@@ -155,181 +161,111 @@ mod integration_tests {
         }
     }
 
-    /// Parse all event properties using Windows TDH APIs.
+    /// Build a flat property map from a decoded TraceLogging event.
     ///
-    /// Walks the TRACE_EVENT_INFO property array (which mirrors the
-    /// TraceLogging metadata) and reads leaf values from the user data
-    /// buffer. Struct entries (PartA, PartB, ext_dt, etc.) occupy 0 bytes
-    /// in the data and are used only to build dotted path names.
-    ///
-    /// # Safety
-    /// `er` must point to a valid EVENT_RECORD for the duration of the call.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn parse_event_properties(
-        er: *const windows::Win32::System::Diagnostics::Etw::EVENT_RECORD,
+    /// one_collect's `TdhDecoder` produces an `EventFormat` whose nested
+    /// struct fields are already flattened with dotted names. We resolve
+    /// each leaf field's bytes (handling variable-length skip chains via
+    /// `try_get_field_data_closure`) into a `HashMap` keyed by dotted path.
+    fn build_properties(
+        decoded: &one_collect::etw::tdh::TdhDecodedEvent<'_>,
     ) -> HashMap<String, Vec<u8>> {
-        use windows::Win32::System::Diagnostics::Etw::{
-            TdhGetEventInformation, EVENT_PROPERTY_INFO, TRACE_EVENT_INFO,
-        };
+        let format = decoded.event_data.format();
+        let payload = decoded.event_data.event_data();
 
         let mut result = HashMap::new();
-
-        // Query required buffer size
-        let mut buf_size = 0u32;
-        let _ = TdhGetEventInformation(er, None, None, &mut buf_size);
-        if buf_size == 0 {
-            return result;
-        }
-
-        // Allocate and retrieve TRACE_EVENT_INFO
-        let mut buf = vec![0u8; buf_size as usize];
-        let tei_ptr = buf.as_mut_ptr() as *mut TRACE_EVENT_INFO;
-        let status = TdhGetEventInformation(er, None, Some(tei_ptr), &mut buf_size);
-        if status != 0 {
-            return result;
-        }
-
-        let tei = &*tei_ptr;
-        let top_level_count = tei.TopLevelPropertyCount as usize;
-        let prop_count = tei.PropertyCount as usize;
-
-        let props = std::slice::from_raw_parts(tei.EventPropertyInfoArray.as_ptr(), prop_count);
-
-        // User data buffer (leaf values only; struct headers are 0 bytes)
-        let data: &[u8] = if (*er).UserData.is_null() || (*er).UserDataLength == 0 {
-            &[]
-        } else {
-            std::slice::from_raw_parts((*er).UserData as *const u8, (*er).UserDataLength as usize)
-        };
-
-        let base = buf.as_ptr();
-        let mut data_pos = 0usize;
-
-        // Recursive DFS: TDH lists top-level properties at [0..TopLevelPropertyCount).
-        // Struct entries use StructStartIndex/NumOfStructMembers to reference their
-        // children elsewhere in the array. The data buffer follows DFS order.
-        fn visit(
-            props: &[EVENT_PROPERTY_INFO],
-            indices: &[usize],
-            prefix: &str,
-            base: *const u8,
-            data: &[u8],
-            data_pos: &mut usize,
-            result: &mut HashMap<String, Vec<u8>>,
-        ) {
-            for &idx in indices {
-                let prop = &props[idx];
-                let name = unsafe { read_wide_string_at(base, prop.NameOffset as usize) };
-                let is_struct = (prop.Flags.0 & 0x1) != 0;
-                let full_path = if prefix.is_empty() {
-                    name.clone()
-                } else {
-                    format!("{prefix}.{name}")
-                };
-
-                if is_struct {
-                    let start = unsafe { prop.Anonymous1.structType.StructStartIndex } as usize;
-                    let count = unsafe { prop.Anonymous1.structType.NumOfStructMembers } as usize;
-                    let child_indices: Vec<usize> = (start..start + count).collect();
-                    visit(
-                        props,
-                        &child_indices,
-                        &full_path,
-                        base,
-                        data,
-                        data_pos,
-                        result,
-                    );
-                } else {
-                    let in_type = unsafe { prop.Anonymous1.nonStructType.InType };
-                    let (value, size) = read_leaf_value(data, *data_pos, in_type);
-                    result.insert(full_path, value);
-                    *data_pos += size;
-                }
+        for field in format.fields() {
+            if let Some(mut get_data) = format.try_get_field_data_closure(&field.name) {
+                result.insert(field.name.clone(), get_data(payload).to_vec());
             }
         }
-
-        let top_level_indices: Vec<usize> = (0..top_level_count).collect();
-        visit(
-            props,
-            &top_level_indices,
-            "",
-            base,
-            data,
-            &mut data_pos,
-            &mut result,
-        );
-
         result
     }
 
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn read_wide_string_at(base: *const u8, offset: usize) -> String {
-        let ptr = base.add(offset) as *const u16;
-        let mut len = 0;
-        while *ptr.add(len) != 0 {
-            len += 1;
-        }
-        String::from_utf16_lossy(std::slice::from_raw_parts(ptr, len))
-    }
-
-    /// Read a leaf value from the data buffer based on its TDH InType.
+    /// Handle to a running ETW capture session backed by one_collect.
     ///
-    /// Returns (raw_bytes, total_bytes_consumed_from_buffer).
-    fn read_leaf_value(data: &[u8], pos: usize, in_type: u16) -> (Vec<u8>, usize) {
-        match in_type {
-            // Counted types: u16 byte-length prefix + data bytes
-            // 1=UnicodeString, 2=AnsiString, 14=Binary,
-            // 300=CountedString(UTF-16), 301=CountedAnsiString(UTF-8)
-            1 | 2 | 14 | 300 | 301 => {
-                let byte_len = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
-                (data[pos + 2..pos + 2 + byte_len].to_vec(), 2 + byte_len)
+    /// `one_collect::etw::EtwSession::parse_until` blocks the calling thread
+    /// and runs event callbacks on it, so the session is driven on a
+    /// dedicated worker thread. Dropping (or explicitly `stop`-ping) the
+    /// handle signals that thread to stop and joins it.
+    struct EtwTrace {
+        stop: Arc<AtomicBool>,
+        worker: Mutex<Option<thread::JoinHandle<()>>>,
+    }
+
+    impl EtwTrace {
+        fn stop(&self) -> thread::Result<()> {
+            self.stop.store(true, Ordering::Relaxed);
+            match self.worker.lock().unwrap().take() {
+                Some(worker) => worker.join(),
+                None => Ok(()),
             }
-            // Fixed-size types
-            3 | 4 => (data[pos..pos + 1].to_vec(), 1), // Int8 / UInt8
-            5 | 6 => (data[pos..pos + 2].to_vec(), 2), // Int16 / UInt16
-            7 | 8 | 13 => (data[pos..pos + 4].to_vec(), 4), // Int32 / UInt32 / Bool32
-            9 | 10 => (data[pos..pos + 8].to_vec(), 8), // Int64 / UInt64
-            11 => (data[pos..pos + 4].to_vec(), 4),    // Float32
-            12 => (data[pos..pos + 8].to_vec(), 8),    // Float64
-            _ => panic!("Unsupported TDH InType: {in_type}"),
         }
     }
 
-    /// Start a ferrisetw UserTrace session for the given provider name.
-    fn start_etw_trace(
-        provider_name: &str,
-    ) -> (ferrisetw::trace::UserTrace, mpsc::Receiver<CapturedEvent>) {
-        use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
+    impl Drop for EtwTrace {
+        fn drop(&mut self) {
+            let _ = self.stop();
+        }
+    }
 
-        let guid_bytes = tld::Guid::from_name(provider_name).to_utf8_bytes();
-        let guid_str = std::str::from_utf8(&guid_bytes).unwrap();
+    /// Start a one_collect ETW capture session for the given provider name.
+    fn start_etw_trace(provider_name: &str) -> (EtwTrace, mpsc::Receiver<CapturedEvent>) {
+        // TraceLogging derives the provider GUID from the provider name; mirror
+        // that here so we subscribe to the same GUID the exporter registers.
+        let guid = Guid::from_u128(tld::Guid::from_name(provider_name).to_u128());
 
         let (tx, rx) = mpsc::sync_channel::<CapturedEvent>(16);
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_worker = stop.clone();
+        let session_name = format!("{provider_name}_session");
 
-        let etw_provider = ferrisetw::provider::Provider::by_guid(guid_str)
-            .add_callback(
-                move |record: &EventRecord, _schema_locator: &SchemaLocator| {
-                    let er_ptr = record as *const EventRecord as *const EVENT_RECORD;
-                    let properties = unsafe { parse_event_properties(er_ptr) };
+        let worker = thread::spawn(move || {
+            let mut session = EtwSession::new();
+            let ancillary = session.ancillary_data();
+            let decoder = Rc::new(RefCell::new(TdhDecoder::new()));
 
+            // Wide event: capture every event from the provider (any ID), at
+            // verbose level with all keywords enabled.
+            let mut event =
+                Event::for_etw(0, "Event".to_string(), guid, LEVEL_VERBOSE, u64::MAX);
+            event.set_id_wild_card_flag();
+
+            event.add_callback(move |_data| {
+                let ancillary = ancillary.borrow();
+                let record = match ancillary.record() {
+                    Some(record) => record,
+                    None => return Ok(()),
+                };
+
+                let mut decoder = decoder.borrow_mut();
+                if let Ok(decoded) = decoder.decode(record) {
+                    let descriptor = record.EventHeader.EventDescriptor;
                     let captured = CapturedEvent {
-                        event_name: record.event_name(),
-                        level: record.level(),
-                        keyword: record.keyword(),
-                        properties,
+                        event_name: decoded.event_name.unwrap_or_default().to_string(),
+                        level: descriptor.Level,
+                        keyword: descriptor.Keyword,
+                        properties: build_properties(&decoded),
                     };
                     let _ = tx.try_send(captured);
-                },
-            )
-            .build();
+                }
 
-        let trace = UserTrace::new()
-            .enable(etw_provider)
-            .start_and_process()
-            .unwrap();
+                Ok(())
+            });
 
-        (trace, rx)
+            session.add_event(event, None);
+
+            let _ = session
+                .parse_until(&session_name, move || stop_worker.load(Ordering::Relaxed));
+        });
+
+        (
+            EtwTrace {
+                stop,
+                worker: Mutex::new(Some(worker)),
+            },
+            rx,
+        )
     }
 
     /// Receive a captured event with the given event name, within a timeout.
@@ -353,7 +289,7 @@ mod integration_tests {
     //
     // These tests emit logs via the public OTel Logger API
     // (SdkLoggerProvider → Logger → Processor → ETW) and capture the
-    // resulting ETW events with ferrisetw for payload validation.
+    // resulting ETW events with one_collect for payload validation.
     // -----------------------------------------------------------------------
 
     /// Full test: validates PartA, PartB, and PartC with multiple attribute types.

--- a/opentelemetry-etw-logs/src/lib.rs
+++ b/opentelemetry-etw-logs/src/lib.rs
@@ -227,8 +227,7 @@ mod integration_tests {
 
             // Wide event: capture every event from the provider (any ID), at
             // verbose level with all keywords enabled.
-            let mut event =
-                Event::for_etw(0, "Event".to_string(), guid, LEVEL_VERBOSE, u64::MAX);
+            let mut event = Event::for_etw(0, "Event".to_string(), guid, LEVEL_VERBOSE, u64::MAX);
             event.set_id_wild_card_flag();
 
             event.add_callback(move |_data| {
@@ -255,8 +254,7 @@ mod integration_tests {
 
             session.add_event(event, None);
 
-            let _ = session
-                .parse_until(&session_name, move || stop_worker.load(Ordering::Relaxed));
+            let _ = session.parse_until(&session_name, move || stop_worker.load(Ordering::Relaxed));
         });
 
         (

--- a/opentelemetry-etw-metrics/Cargo.toml
+++ b/opentelemetry-etw-metrics/Cargo.toml
@@ -24,8 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "st
 opentelemetry-proto = { workspace = true, features = ["gen-tonic", "metrics", "gen-tonic-messages"] }
 
 [target.'cfg(windows)'.dev-dependencies]
-ferrisetw = "1.2"
-windows = { version = "0.62", features = ["Win32_System_Diagnostics_Etw"] }
+one_collect = "0.1.34532"
 
 [features]
 internal-logs = ["tracing", "opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]

--- a/opentelemetry-etw-metrics/tests/integration.rs
+++ b/opentelemetry-etw-metrics/tests/integration.rs
@@ -103,8 +103,9 @@ fn start_etw_trace() -> (EtwTrace, mpsc::Receiver<ExportMetricsServiceRequest>) 
 
         session.add_event(event, None);
 
-        let _ = session
-            .parse_until("etw-metrics-int-test", move || stop_worker.load(Ordering::Relaxed));
+        let _ = session.parse_until("etw-metrics-int-test", move || {
+            stop_worker.load(Ordering::Relaxed)
+        });
     });
 
     (

--- a/opentelemetry-etw-metrics/tests/integration.rs
+++ b/opentelemetry-etw-metrics/tests/integration.rs
@@ -1,9 +1,9 @@
 //! ETW metrics end-to-end integration test.
 //!
 //! Exercises the public `MetricsExporter` pipeline, starts a real ETW
-//! `UserTrace` session via `ferrisetw`, reads `EVENT_RECORD.UserData`
-//! directly (the exporter emits manifested events with a `raw_data` payload,
-//! so the user buffer is the raw OTLP protobuf), decodes each event as
+//! capture session via `one_collect`, reads the raw event payload
+//! (the exporter emits manifested events with a `raw_data` payload, so the
+//! user buffer is the raw OTLP protobuf), decodes each event as
 //! `ExportMetricsServiceRequest`, and asserts the OTLP shape for every
 //! supported instrument type (Counter, UpDownCounter, Gauge, Histogram).
 //!
@@ -21,12 +21,16 @@
 #![cfg(target_os = "windows")]
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
-use ferrisetw::schema_locator::SchemaLocator;
-use ferrisetw::trace::UserTrace;
-use ferrisetw::EventRecord;
+use one_collect::etw::{EtwSession, LEVEL_VERBOSE};
+use one_collect::event::os::windows::WindowsEventExtension;
+use one_collect::event::Event;
+use one_collect::Guid;
 
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::KeyValue;
@@ -38,43 +42,78 @@ use opentelemetry_proto::tonic::metrics::v1::{metric::Data as MetricData, Metric
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::Resource;
 use prost::Message;
-use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
 
 // Must match the provider GUID statically registered in src/etw/mod.rs.
-const PROVIDER_GUID: &str = "EDC24920-E004-40F6-A8E1-0E6E48F39D84";
+// GUID EDC24920-E004-40F6-A8E1-0E6E48F39D84.
+const PROVIDER_GUID: u128 = 0xEDC2_4920_E004_40F6_A8E1_0E6E_48F3_9D84;
 
-fn start_etw_trace() -> (UserTrace, mpsc::Receiver<ExportMetricsServiceRequest>) {
+/// Handle to a running ETW capture session backed by one_collect.
+///
+/// `one_collect::etw::EtwSession::parse_until` blocks the calling thread
+/// and runs event callbacks on it, so the session is driven on a dedicated
+/// worker thread. Dropping (or explicitly `stop`-ping) the handle signals
+/// that thread to stop and joins it.
+struct EtwTrace {
+    stop: Arc<AtomicBool>,
+    worker: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl EtwTrace {
+    fn stop(&self) -> thread::Result<()> {
+        self.stop.store(true, Ordering::Relaxed);
+        match self.worker.lock().unwrap().take() {
+            Some(worker) => worker.join(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for EtwTrace {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+fn start_etw_trace() -> (EtwTrace, mpsc::Receiver<ExportMetricsServiceRequest>) {
     let (tx, rx) = mpsc::sync_channel::<ExportMetricsServiceRequest>(64);
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_worker = stop.clone();
 
-    let provider = ferrisetw::provider::Provider::by_guid(PROVIDER_GUID)
-        .add_callback(
-            move |record: &EventRecord, _schema_locator: &SchemaLocator| {
-                let er_ptr = record as *const EventRecord as *const EVENT_RECORD;
-                // SAFETY: ferrisetw::EventRecord is layout-compatible with
-                // windows EVENT_RECORD and is valid for the callback's lifetime.
-                let user_data: &[u8] = unsafe {
-                    if (*er_ptr).UserData.is_null() || (*er_ptr).UserDataLength == 0 {
-                        &[]
-                    } else {
-                        std::slice::from_raw_parts(
-                            (*er_ptr).UserData as *const u8,
-                            (*er_ptr).UserDataLength as usize,
-                        )
-                    }
-                };
-                if let Ok(req) = ExportMetricsServiceRequest::decode(user_data) {
-                    let _ = tx.try_send(req);
-                }
-            },
-        )
-        .build();
+    let worker = thread::spawn(move || {
+        let mut session = EtwSession::new();
 
-    let trace = UserTrace::new()
-        .enable(provider)
-        .start_and_process()
-        .expect("failed to start ETW UserTrace (admin privileges required)");
+        // Wide event: capture every event from the provider (any ID). The
+        // exporter emits a raw OTLP protobuf payload as the user buffer, so
+        // `data.event_data()` is the bytes we decode directly.
+        let mut event = Event::for_etw(
+            0,
+            "Event".to_string(),
+            Guid::from_u128(PROVIDER_GUID),
+            LEVEL_VERBOSE,
+            u64::MAX,
+        );
+        event.set_id_wild_card_flag();
 
-    (trace, rx)
+        event.add_callback(move |data| {
+            if let Ok(req) = ExportMetricsServiceRequest::decode(data.event_data()) {
+                let _ = tx.try_send(req);
+            }
+            Ok(())
+        });
+
+        session.add_event(event, None);
+
+        let _ = session
+            .parse_until("etw-metrics-int-test", move || stop_worker.load(Ordering::Relaxed));
+    });
+
+    (
+        EtwTrace {
+            stop,
+            worker: Mutex::new(Some(worker)),
+        },
+        rx,
+    )
 }
 
 /// Wait up to 5s for the first event, then drain anything that arrives within

--- a/opentelemetry-etw-traces/Cargo.toml
+++ b/opentelemetry-etw-traces/Cargo.toml
@@ -25,8 +25,7 @@ serde_json = { version = "1.0.113", optional = true }
 opentelemetry_sdk = { workspace = true, features = ["trace", "testing"] }
 
 [target.'cfg(windows)'.dev-dependencies]
-ferrisetw = "1.2"
-windows = { version = "0.57", features = ["Win32_System_Diagnostics_Etw"] }
+one_collect = "0.1.34532"
 
 [features]
 internal-logs = [

--- a/opentelemetry-etw-traces/src/lib.rs
+++ b/opentelemetry-etw-traces/src/lib.rs
@@ -56,13 +56,20 @@ pub use processor::ProcessorBuilder;
 
 #[cfg(all(test, target_os = "windows"))]
 mod integration_tests {
+    use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
     use std::time::Duration;
 
-    use ferrisetw::schema_locator::SchemaLocator;
-    use ferrisetw::trace::UserTrace;
-    use ferrisetw::EventRecord;
+    use one_collect::etw::tdh::TdhDecoder;
+    use one_collect::etw::{EtwSession, LEVEL_VERBOSE};
+    use one_collect::event::os::windows::WindowsEventExtension;
+    use one_collect::event::Event;
+    use one_collect::Guid;
 
     use tracelogging_dynamic as tld;
 
@@ -72,14 +79,13 @@ mod integration_tests {
     use opentelemetry_sdk::Resource;
 
     // -----------------------------------------------------------------------
-    // TDH-based ETW event property parser
+    // ETW event property capture via one_collect
     //
-    // ferrisetw's Parser cannot handle TraceLogging struct properties (PartA,
-    // PartB, ext_dt, etc.) — it returns UnimplementedType("structure").
-    // We use TDH APIs directly to enumerate all event properties from the
-    // schema (TRACE_EVENT_INFO) and read their values from the raw data
-    // buffer, producing a flat HashMap keyed by dotted paths like
-    // "PartA.ext_cloud.role" or "PartB.name".
+    // one_collect's TdhDecoder resolves TraceLogging struct properties (PartA,
+    // PartB, ext_dt, etc.) into a flat EventFormat whose nested fields are
+    // flattened with dotted names ("PartA.ext_cloud.role", "PartB.name").
+    // We walk that schema and read each leaf value from the event payload,
+    // producing a flat HashMap keyed by those dotted paths.
     // -----------------------------------------------------------------------
 
     /// Captured event with all properties parsed into named fields.
@@ -131,181 +137,110 @@ mod integration_tests {
         }
     }
 
-    /// Parse all event properties using Windows TDH APIs.
+    /// Build a flat property map from a decoded TraceLogging event.
     ///
-    /// Walks the TRACE_EVENT_INFO property array (which mirrors the
-    /// TraceLogging metadata) and reads leaf values from the user data
-    /// buffer. Struct entries (PartA, PartB, ext_dt, etc.) occupy 0 bytes
-    /// in the data and are used only to build dotted path names.
-    ///
-    /// # Safety
-    /// `er` must point to a valid EVENT_RECORD for the duration of the call.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn parse_event_properties(
-        er: *const windows::Win32::System::Diagnostics::Etw::EVENT_RECORD,
+    /// one_collect's `TdhDecoder` produces an `EventFormat` whose nested
+    /// struct fields are already flattened with dotted names. We resolve
+    /// each leaf field's bytes (handling variable-length skip chains via
+    /// `try_get_field_data_closure`) into a `HashMap` keyed by dotted path.
+    fn build_properties(
+        decoded: &one_collect::etw::tdh::TdhDecodedEvent<'_>,
     ) -> HashMap<String, Vec<u8>> {
-        use windows::Win32::System::Diagnostics::Etw::{
-            TdhGetEventInformation, EVENT_PROPERTY_INFO, TRACE_EVENT_INFO,
-        };
+        let format = decoded.event_data.format();
+        let payload = decoded.event_data.event_data();
 
         let mut result = HashMap::new();
-
-        // Query required buffer size
-        let mut buf_size = 0u32;
-        let _ = TdhGetEventInformation(er, None, None, &mut buf_size);
-        if buf_size == 0 {
-            return result;
-        }
-
-        // Allocate and retrieve TRACE_EVENT_INFO
-        let mut buf = vec![0u8; buf_size as usize];
-        let tei_ptr = buf.as_mut_ptr() as *mut TRACE_EVENT_INFO;
-        let status = TdhGetEventInformation(er, None, Some(tei_ptr), &mut buf_size);
-        if status != 0 {
-            return result;
-        }
-
-        let tei = &*tei_ptr;
-        let top_level_count = tei.TopLevelPropertyCount as usize;
-        let prop_count = tei.PropertyCount as usize;
-
-        let props = std::slice::from_raw_parts(tei.EventPropertyInfoArray.as_ptr(), prop_count);
-
-        // User data buffer (leaf values only; struct headers are 0 bytes)
-        let data: &[u8] = if (*er).UserData.is_null() || (*er).UserDataLength == 0 {
-            &[]
-        } else {
-            std::slice::from_raw_parts((*er).UserData as *const u8, (*er).UserDataLength as usize)
-        };
-
-        let base = buf.as_ptr();
-        let mut data_pos = 0usize;
-
-        // Recursive DFS: TDH lists top-level properties at [0..TopLevelPropertyCount).
-        // Struct entries use StructStartIndex/NumOfStructMembers to reference their
-        // children elsewhere in the array. The data buffer follows DFS order.
-        fn visit(
-            props: &[EVENT_PROPERTY_INFO],
-            indices: &[usize],
-            prefix: &str,
-            base: *const u8,
-            data: &[u8],
-            data_pos: &mut usize,
-            result: &mut HashMap<String, Vec<u8>>,
-        ) {
-            for &idx in indices {
-                let prop = &props[idx];
-                let name = unsafe { read_wide_string_at(base, prop.NameOffset as usize) };
-                let is_struct = (prop.Flags.0 & 0x1) != 0;
-                let full_path = if prefix.is_empty() {
-                    name.clone()
-                } else {
-                    format!("{prefix}.{name}")
-                };
-
-                if is_struct {
-                    let start = unsafe { prop.Anonymous1.structType.StructStartIndex } as usize;
-                    let count = unsafe { prop.Anonymous1.structType.NumOfStructMembers } as usize;
-                    let child_indices: Vec<usize> = (start..start + count).collect();
-                    visit(
-                        props,
-                        &child_indices,
-                        &full_path,
-                        base,
-                        data,
-                        data_pos,
-                        result,
-                    );
-                } else {
-                    let in_type = unsafe { prop.Anonymous1.nonStructType.InType };
-                    let (value, size) = read_leaf_value(data, *data_pos, in_type);
-                    result.insert(full_path, value);
-                    *data_pos += size;
-                }
+        for field in format.fields() {
+            if let Some(mut get_data) = format.try_get_field_data_closure(&field.name) {
+                result.insert(field.name.clone(), get_data(payload).to_vec());
             }
         }
-
-        let top_level_indices: Vec<usize> = (0..top_level_count).collect();
-        visit(
-            props,
-            &top_level_indices,
-            "",
-            base,
-            data,
-            &mut data_pos,
-            &mut result,
-        );
-
         result
     }
 
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn read_wide_string_at(base: *const u8, offset: usize) -> String {
-        let ptr = base.add(offset) as *const u16;
-        let mut len = 0;
-        while *ptr.add(len) != 0 {
-            len += 1;
-        }
-        String::from_utf16_lossy(std::slice::from_raw_parts(ptr, len))
-    }
-
-    /// Read a leaf value from the data buffer based on its TDH InType.
+    /// Handle to a running ETW capture session backed by one_collect.
     ///
-    /// Returns (raw_bytes, total_bytes_consumed_from_buffer).
-    fn read_leaf_value(data: &[u8], pos: usize, in_type: u16) -> (Vec<u8>, usize) {
-        match in_type {
-            // Counted types: u16 byte-length prefix + data bytes
-            // 1=UnicodeString, 2=AnsiString, 14=Binary,
-            // 300=CountedString(UTF-16), 301=CountedAnsiString(UTF-8)
-            1 | 2 | 14 | 300 | 301 => {
-                let byte_len = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
-                (data[pos + 2..pos + 2 + byte_len].to_vec(), 2 + byte_len)
+    /// `one_collect::etw::EtwSession::parse_until` blocks the calling thread
+    /// and runs event callbacks on it, so the session is driven on a
+    /// dedicated worker thread. Dropping (or explicitly `stop`-ping) the
+    /// handle signals that thread to stop and joins it.
+    struct EtwTrace {
+        stop: Arc<AtomicBool>,
+        worker: Mutex<Option<thread::JoinHandle<()>>>,
+    }
+
+    impl EtwTrace {
+        fn stop(&self) -> thread::Result<()> {
+            self.stop.store(true, Ordering::Relaxed);
+            match self.worker.lock().unwrap().take() {
+                Some(worker) => worker.join(),
+                None => Ok(()),
             }
-            // Fixed-size types
-            3 | 4 => (data[pos..pos + 1].to_vec(), 1), // Int8 / UInt8
-            5 | 6 => (data[pos..pos + 2].to_vec(), 2), // Int16 / UInt16
-            7 | 8 | 13 => (data[pos..pos + 4].to_vec(), 4), // Int32 / UInt32 / Bool32
-            9 | 10 => (data[pos..pos + 8].to_vec(), 8), // Int64 / UInt64
-            11 => (data[pos..pos + 4].to_vec(), 4),    // Float32
-            12 => (data[pos..pos + 8].to_vec(), 8),    // Float64
-            17 => (data[pos..pos + 8].to_vec(), 8),    // FILETIME
-            _ => panic!("Unsupported TDH InType: {in_type}"),
         }
     }
 
-    /// Start a ferrisetw UserTrace session for the given provider name.
-    fn start_etw_trace(
-        provider_name: &str,
-    ) -> (ferrisetw::trace::UserTrace, mpsc::Receiver<CapturedEvent>) {
-        use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
+    impl Drop for EtwTrace {
+        fn drop(&mut self) {
+            let _ = self.stop();
+        }
+    }
 
-        let guid_bytes = tld::Guid::from_name(provider_name).to_utf8_bytes();
-        let guid_str = std::str::from_utf8(&guid_bytes).unwrap();
+    /// Start a one_collect ETW capture session for the given provider name.
+    fn start_etw_trace(provider_name: &str) -> (EtwTrace, mpsc::Receiver<CapturedEvent>) {
+        // TraceLogging derives the provider GUID from the provider name; mirror
+        // that here so we subscribe to the same GUID the exporter registers.
+        let guid = Guid::from_u128(tld::Guid::from_name(provider_name).to_u128());
 
         let (tx, rx) = mpsc::sync_channel::<CapturedEvent>(16);
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_worker = stop.clone();
+        let session_name = format!("{provider_name}_session");
 
-        let etw_provider = ferrisetw::provider::Provider::by_guid(guid_str)
-            .add_callback(
-                move |record: &EventRecord, _schema_locator: &SchemaLocator| {
-                    let er_ptr = record as *const EventRecord as *const EVENT_RECORD;
-                    let properties = unsafe { parse_event_properties(er_ptr) };
+        let worker = thread::spawn(move || {
+            let mut session = EtwSession::new();
+            let ancillary = session.ancillary_data();
+            let decoder = Rc::new(RefCell::new(TdhDecoder::new()));
 
+            // Wide event: capture every event from the provider (any ID), at
+            // verbose level with all keywords enabled.
+            let mut event =
+                Event::for_etw(0, "Event".to_string(), guid, LEVEL_VERBOSE, u64::MAX);
+            event.set_id_wild_card_flag();
+
+            event.add_callback(move |_data| {
+                let ancillary = ancillary.borrow();
+                let record = match ancillary.record() {
+                    Some(record) => record,
+                    None => return Ok(()),
+                };
+
+                let mut decoder = decoder.borrow_mut();
+                if let Ok(decoded) = decoder.decode(record) {
+                    let descriptor = record.EventHeader.EventDescriptor;
                     let captured = CapturedEvent {
-                        event_name: record.event_name(),
-                        keyword: record.keyword(),
-                        properties,
+                        event_name: decoded.event_name.unwrap_or_default().to_string(),
+                        keyword: descriptor.Keyword,
+                        properties: build_properties(&decoded),
                     };
                     let _ = tx.try_send(captured);
-                },
-            )
-            .build();
+                }
 
-        let trace = UserTrace::new()
-            .enable(etw_provider)
-            .start_and_process()
-            .unwrap();
+                Ok(())
+            });
 
-        (trace, rx)
+            session.add_event(event, None);
+
+            let _ = session
+                .parse_until(&session_name, move || stop_worker.load(Ordering::Relaxed));
+        });
+
+        (
+            EtwTrace {
+                stop,
+                worker: Mutex::new(Some(worker)),
+            },
+            rx,
+        )
     }
 
     /// Receive a captured event with the given event name, within a timeout.
@@ -329,7 +264,7 @@ mod integration_tests {
     //
     // These tests emit spans via the public OTel Tracer API
     // (SdkTracerProvider → Tracer → Processor → ETW) and capture the
-    // resulting ETW events with ferrisetw for payload validation.
+    // resulting ETW events with one_collect for payload validation.
     // -----------------------------------------------------------------------
 
     /// Full test: validates PartA, PartB (incl. well-known attributes), and PartC.

--- a/opentelemetry-etw-traces/src/lib.rs
+++ b/opentelemetry-etw-traces/src/lib.rs
@@ -203,8 +203,7 @@ mod integration_tests {
 
             // Wide event: capture every event from the provider (any ID), at
             // verbose level with all keywords enabled.
-            let mut event =
-                Event::for_etw(0, "Event".to_string(), guid, LEVEL_VERBOSE, u64::MAX);
+            let mut event = Event::for_etw(0, "Event".to_string(), guid, LEVEL_VERBOSE, u64::MAX);
             event.set_id_wild_card_flag();
 
             event.add_callback(move |_data| {
@@ -230,8 +229,7 @@ mod integration_tests {
 
             session.add_event(event, None);
 
-            let _ = session
-                .parse_until(&session_name, move || stop_worker.load(Ordering::Relaxed));
+            let _ = session.parse_until(&session_name, move || stop_worker.load(Ordering::Relaxed));
         });
 
         (


### PR DESCRIPTION
## Changes
- `one_collect` repo already has the Tracelogging decoding support needed. It's better to rely on `one_collect` instead of doing that manually in the tests.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
