### PR TITLE
test: Simplify user_events integrations tests setup for logs and traces by using `one_collect` and `tracepoint_decode`

### DIFF
--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -27,6 +27,14 @@ ctrlc = "3.4"
 criterion = "0.8"
 serde_json = "1.0.140"
 
+# Linux-only: in-process user_events consumer/decoder used by the integration
+# tests to read EventHeader events directly from the perf ring buffer
+# (`one_collect`) and decode them (`tracepoint_decode`), instead of shelling out
+# to `perf record` + `perf-decode`.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+one_collect = "0.1.34532"
+tracepoint_decode = "0.5.0"
+
 [features]
 internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
 experimental_eventname_callback = []

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -138,12 +138,15 @@ pub use logs::ProcessorBuilder;
 #[cfg(feature = "experimental_eventname_callback")]
 pub use logs::EventNameCallback;
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
 
     #[cfg(feature = "experimental_eventname_callback")]
     use crate::EventNameCallback;
     use crate::Processor;
+    use one_collect::perf_event::{RingBufBuilder, RingBufSessionBuilder};
+    use one_collect::tracefs::TraceFS;
+    use one_collect::Writable;
     use opentelemetry::trace::Tracer;
     use opentelemetry::trace::{TraceContextExt, TracerProvider};
     use opentelemetry::{Key, KeyValue};
@@ -154,7 +157,8 @@ mod tests {
         trace::{Sampler, SdkTracerProvider},
     };
     use serde_json::{from_str, Value};
-    use std::process::Command;
+    use std::time::Duration;
+    use tracepoint_decode::{EventHeaderEnumeratorContext, PerfConvertOptions};
     use tracing::error;
     use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
@@ -895,89 +899,125 @@ mod tests {
     }
 
     fn check_user_events_available() -> Result<String, String> {
-        let output = Command::new("sudo")
-            .arg("cat")
-            .arg("/sys/kernel/tracing/user_events_status")
-            .output()
-            .map_err(|e| format!("Failed to execute command: {e}"))?;
-
-        if output.status.success() {
-            let status = String::from_utf8_lossy(&output.stdout);
-            Ok(status.to_string())
-        } else {
-            Err(format!(
-                "Command executed with failing error code: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ))
-        }
+        // Read the list of currently-registered user_events tracepoints directly
+        // from tracefs (`<tracefs>/user_events_status`) instead of shelling out
+        // to `sudo cat`. The test process already runs elevated, so it can read
+        // the status file directly.
+        let tracefs = TraceFS::open().map_err(|e| {
+            format!(
+                "Unable to open tracefs. user_events requires a Linux kernel with \
+                 tracefs mounted and sufficient permissions \
+                 (https://docs.kernel.org/trace/user_events.html): {e}"
+            )
+        })?;
+        let status_path = tracefs
+            .user_events_path()
+            .with_file_name("user_events_status");
+        std::fs::read_to_string(&status_path)
+            .map_err(|e| format!("Failed to read {}: {e}", status_path.display()))
     }
 
-    pub fn run_perf_and_decode(duration_secs: u64, event: &str) -> std::io::Result<String> {
-        // Run perf record for duration_secs seconds
-        let perf_status = Command::new("sudo")
-            .args([
-                "timeout",
-                "-s",
-                "SIGINT",
-                &duration_secs.to_string(),
-                "perf",
-                "record",
-                "-o",
-                "./perf.data",
-                "-e",
-                event,
-            ])
-            .status()?;
+    /// Captures EventHeader events from the given user_events tracepoint in-process
+    /// using `one_collect` for the perf ring buffer session and `tracepoint_decode`
+    /// for EventHeader decoding, then returns the decoded events as a JSON string
+    /// in the same `{ "./perf.data": [ {event}, ... ] }` shape the old
+    /// `perf-decode` pipeline produced, so the test assertions are unchanged.
+    ///
+    /// `event` is the full tracepoint spec, e.g. "user_events:myprovider_L2K1".
+    /// Capture runs for `duration_secs`; the caller emits events on another thread
+    /// during this window, mirroring the old `perf record` duration.
+    ///
+    /// This replaces the previous `perf record` + `perf-decode` external-tool
+    /// pipeline with a self-contained, in-process consumer (no external tools, no
+    /// temp files, no `sudo` shell-outs).
+    fn run_perf_and_decode(duration_secs: u64, event: &str) -> std::io::Result<String> {
+        let need_permission = "Need permission to access tracefs/perf_events (run via sudo?)";
 
-        if !perf_status.success() {
-            // Check if it's the expected signal termination (SIGINT from timeout)
-            // timeout sends SIGINT, which will cause a non-zero exit code (130 typically)
-            if !matches!(perf_status.code(), Some(124) | Some(130) | Some(143)) {
-                panic!(
-                    "perf record failed with exit code: {:?}",
-                    perf_status.code()
-                );
+        // Strip the "user_events:" system prefix to get the tracepoint name,
+        // e.g. "user_events:myprovider_L2K1" -> "myprovider_L2K1".
+        let tracepoint = event
+            .strip_prefix("user_events:")
+            .unwrap_or(event)
+            .to_string();
+
+        let tracefs = TraceFS::open()?;
+        let mut tp_event = tracefs.find_event("user_events", &tracepoint)?;
+
+        // The EventHeader payload begins at the `eventheader_flags` field, right
+        // after the tracepoint common fields. `tracepoint_decode` wants the event
+        // data starting at that offset.
+        let flags_offset = tp_event
+            .format()
+            .get_field("eventheader_flags")
+            .map(|f| f.offset)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "eventheader_flags field missing from tracepoint format",
+                )
+            })?;
+
+        let tp_name = tracepoint.clone();
+        let collected = Writable::<Vec<String>>::new(Vec::new());
+        let sink = collected.clone();
+        let mut ctx = EventHeaderEnumeratorContext::new();
+
+        tp_event.add_callback(move |data| {
+            let full = data.event_data();
+            if full.len() <= flags_offset {
+                return Ok(());
             }
-        }
+            let payload = &full[flags_offset..];
 
-        // Change permissions on perf.data (which is the default file perf records to) to allow reading
-        let chmod_status = Command::new("sudo")
-            .args(["chmod", "uog+r", "./perf.data"])
-            .status()?;
+            if let Ok(mut enumerator) = ctx.enumerate_with_name_and_data(
+                &tp_name,
+                payload,
+                EventHeaderEnumeratorContext::MOVE_NEXT_LIMIT_DEFAULT,
+            ) {
+                // Event identity, e.g. "myprovider:Log".
+                let identity = enumerator.event_info().identity_display().to_string();
 
-        if !chmod_status.success() {
-            panic!("chmod failed with exit code: {:?}", chmod_status.code());
-        }
+                // From the initial BeforeFirstItem state, this appends every
+                // top-level field as a comma-separated list of `"Name": value`
+                // pairs, with PartA/PartB/PartC rendered as nested JSON objects.
+                let mut body = String::new();
+                if enumerator
+                    .write_json_item_and_move_next_sibling(
+                        &mut body,
+                        false,
+                        PerfConvertOptions::Default,
+                    )
+                    .is_ok()
+                {
+                    sink.write(|out| out.push(format!("{{\"n\":\"{identity}\",{body}}}")));
+                }
+            }
+            Ok(())
+        });
 
-        // Decode the performance data and return it directly
-        // Note: This tool must be installed on the machine
-        // git clone https://github.com/microsoft/LinuxTracepoints &&
-        // cd LinuxTracepoints && mkdir build && cd build && cmake .. && make &&
-        // sudo cp bin/perf-decode /usr/local/bin &&
-        let decode_output = Command::new("perf-decode").args(["./perf.data"]).output()?;
+        let mut session = RingBufSessionBuilder::new()
+            .with_page_count(32)
+            .with_tracepoint_events(RingBufBuilder::for_tracepoint())
+            .with_target_pid(std::process::id() as i32)
+            .build()
+            .expect(need_permission);
 
-        if !decode_output.status.success() {
-            panic!(
-                "perf-decode failed with exit code: {:?}",
-                decode_output.status.code()
-            );
-        }
+        session
+            .add_event(tp_event)
+            .expect("Failed to add tracepoint event to session");
+        session.enable().expect(need_permission);
 
-        // Convert the output to a String
-        let raw_output = String::from_utf8_lossy(&decode_output.stdout).to_string();
+        // Capture for the requested window. The caller emits events on another
+        // thread during this time; `parse_for_duration` keeps draining the ring
+        // buffer until the duration elapses, so mid-window writes are captured.
+        session
+            .parse_for_duration(Duration::from_secs(duration_secs))
+            .expect("Failed to parse perf ring buffer");
+        session.disable().expect(need_permission);
 
-        // Remove any Byte Order Mark (BOM) characters
-        // UTF-8 BOM is EF BB BF (in hex)
-        let cleaned_output = if let Some(stripped) = raw_output.strip_prefix('\u{FEFF}') {
-            // Skip the BOM character
-            stripped.to_string()
-        } else {
-            raw_output
-        };
+        let mut events = Vec::new();
+        collected.read(|v| events = v.clone());
 
-        // Trim the output to remove any leading/trailing whitespace
-        let trimmed_output = cleaned_output.trim().to_string();
-
-        Ok(trimmed_output)
+        Ok(format!("{{\"./perf.data\":[{}]}}", events.join(",")))
     }
 }

--- a/opentelemetry-user-events-trace/Cargo.toml
+++ b/opentelemetry-user-events-trace/Cargo.toml
@@ -26,6 +26,14 @@ ctrlc = "3.4"
 criterion = "0.8"
 serde_json = "1.0.140"
 
+# Linux-only: in-process user_events consumer/decoder used by the integration
+# tests to read EventHeader events directly from the perf ring buffer
+# (`one_collect`) and decode them (`tracepoint_decode`), instead of shelling out
+# to `perf record` + `perf-decode`.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+one_collect = "0.1.34532"
+tracepoint_decode = "0.5.0"
+
 [features]
 internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs"]
 default = ["internal-logs"]

--- a/opentelemetry-user-events-trace/src/lib.rs
+++ b/opentelemetry-user-events-trace/src/lib.rs
@@ -57,17 +57,21 @@ mod trace;
 
 pub use trace::*;
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
 
     use crate::UserEventsTracerProviderBuilderExt;
+    use one_collect::perf_event::{RingBufBuilder, RingBufSessionBuilder};
+    use one_collect::tracefs::TraceFS;
+    use one_collect::Writable;
     use opentelemetry::{
         trace::{TraceContextExt, Tracer, TracerProvider},
         KeyValue,
     };
     use opentelemetry_sdk::trace::SdkTracerProvider;
     use serde_json::{from_str, Value};
-    use std::process::Command;
+    use std::time::Duration;
+    use tracepoint_decode::{EventHeaderEnumeratorContext, PerfConvertOptions};
 
     // This test requires a Linux kernel with user_events support, perf, and perf-decode.
     // It is run in CI via the user-events-integration-test job.
@@ -924,89 +928,125 @@ mod tests {
     }
 
     fn check_user_events_available() -> Result<String, String> {
-        let output = Command::new("sudo")
-            .arg("cat")
-            .arg("/sys/kernel/tracing/user_events_status")
-            .output()
-            .map_err(|e| format!("Failed to execute command: {e}"))?;
-
-        if output.status.success() {
-            let status = String::from_utf8_lossy(&output.stdout);
-            Ok(status.to_string())
-        } else {
-            Err(format!(
-                "Command executed with failing error code: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ))
-        }
+        // Read the list of currently-registered user_events tracepoints directly
+        // from tracefs (`<tracefs>/user_events_status`) instead of shelling out
+        // to `sudo cat`. The test process already runs elevated, so it can read
+        // the status file directly.
+        let tracefs = TraceFS::open().map_err(|e| {
+            format!(
+                "Unable to open tracefs. user_events requires a Linux kernel with \
+                 tracefs mounted and sufficient permissions \
+                 (https://docs.kernel.org/trace/user_events.html): {e}"
+            )
+        })?;
+        let status_path = tracefs
+            .user_events_path()
+            .with_file_name("user_events_status");
+        std::fs::read_to_string(&status_path)
+            .map_err(|e| format!("Failed to read {}: {e}", status_path.display()))
     }
 
-    pub fn run_perf_and_decode(duration_secs: u64, event: &str) -> std::io::Result<String> {
-        // Run perf record for duration_secs seconds
-        let perf_status = Command::new("sudo")
-            .args([
-                "timeout",
-                "-s",
-                "SIGINT",
-                &duration_secs.to_string(),
-                "perf",
-                "record",
-                "-o",
-                "./perf.data",
-                "-e",
-                event,
-            ])
-            .status()?;
+    /// Captures EventHeader events from the given user_events tracepoint in-process
+    /// using `one_collect` for the perf ring buffer session and `tracepoint_decode`
+    /// for EventHeader decoding, then returns the decoded events as a JSON string
+    /// in the same `{ "./perf.data": [ {event}, ... ] }` shape the old
+    /// `perf-decode` pipeline produced, so the test assertions are unchanged.
+    ///
+    /// `event` is the full tracepoint spec, e.g. "user_events:opentelemetry_traces_L4K1".
+    /// Capture runs for `duration_secs`; the caller emits events on another thread
+    /// during this window, mirroring the old `perf record` duration.
+    ///
+    /// This replaces the previous `perf record` + `perf-decode` external-tool
+    /// pipeline with a self-contained, in-process consumer (no external tools, no
+    /// temp files, no `sudo` shell-outs).
+    fn run_perf_and_decode(duration_secs: u64, event: &str) -> std::io::Result<String> {
+        let need_permission = "Need permission to access tracefs/perf_events (run via sudo?)";
 
-        if !perf_status.success() {
-            // Check if it's the expected signal termination (SIGINT from timeout)
-            // timeout sends SIGINT, which will cause a non-zero exit code (130 typically)
-            if !matches!(perf_status.code(), Some(124) | Some(130) | Some(143)) {
-                panic!(
-                    "perf record failed with exit code: {:?}",
-                    perf_status.code()
-                );
+        // Strip the "user_events:" system prefix to get the tracepoint name,
+        // e.g. "user_events:opentelemetry_traces_L4K1" -> "opentelemetry_traces_L4K1".
+        let tracepoint = event
+            .strip_prefix("user_events:")
+            .unwrap_or(event)
+            .to_string();
+
+        let tracefs = TraceFS::open()?;
+        let mut tp_event = tracefs.find_event("user_events", &tracepoint)?;
+
+        // The EventHeader payload begins at the `eventheader_flags` field, right
+        // after the tracepoint common fields. `tracepoint_decode` wants the event
+        // data starting at that offset.
+        let flags_offset = tp_event
+            .format()
+            .get_field("eventheader_flags")
+            .map(|f| f.offset)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "eventheader_flags field missing from tracepoint format",
+                )
+            })?;
+
+        let tp_name = tracepoint.clone();
+        let collected = Writable::<Vec<String>>::new(Vec::new());
+        let sink = collected.clone();
+        let mut ctx = EventHeaderEnumeratorContext::new();
+
+        tp_event.add_callback(move |data| {
+            let full = data.event_data();
+            if full.len() <= flags_offset {
+                return Ok(());
             }
-        }
+            let payload = &full[flags_offset..];
 
-        // Change permissions on perf.data (which is the default file perf records to) to allow reading
-        let chmod_status = Command::new("sudo")
-            .args(["chmod", "uog+r", "./perf.data"])
-            .status()?;
+            if let Ok(mut enumerator) = ctx.enumerate_with_name_and_data(
+                &tp_name,
+                payload,
+                EventHeaderEnumeratorContext::MOVE_NEXT_LIMIT_DEFAULT,
+            ) {
+                // Event identity, e.g. "opentelemetry_traces:Span".
+                let identity = enumerator.event_info().identity_display().to_string();
 
-        if !chmod_status.success() {
-            panic!("chmod failed with exit code: {:?}", chmod_status.code());
-        }
+                // From the initial BeforeFirstItem state, this appends every
+                // top-level field as a comma-separated list of `"Name": value`
+                // pairs, with PartA/PartB/PartC rendered as nested JSON objects.
+                let mut body = String::new();
+                if enumerator
+                    .write_json_item_and_move_next_sibling(
+                        &mut body,
+                        false,
+                        PerfConvertOptions::Default,
+                    )
+                    .is_ok()
+                {
+                    sink.write(|out| out.push(format!("{{\"n\":\"{identity}\",{body}}}")));
+                }
+            }
+            Ok(())
+        });
 
-        // Decode the performance data and return it directly
-        // Note: This tool must be installed on the machine
-        // git clone https://github.com/microsoft/LinuxTracepoints &&
-        // cd LinuxTracepoints && mkdir build && cd build && cmake .. && make &&
-        // sudo cp bin/perf-decode /usr/local/bin &&
-        let decode_output = Command::new("perf-decode").args(["./perf.data"]).output()?;
+        let mut session = RingBufSessionBuilder::new()
+            .with_page_count(32)
+            .with_tracepoint_events(RingBufBuilder::for_tracepoint())
+            .with_target_pid(std::process::id() as i32)
+            .build()
+            .expect(need_permission);
 
-        if !decode_output.status.success() {
-            panic!(
-                "perf-decode failed with exit code: {:?}",
-                decode_output.status.code()
-            );
-        }
+        session
+            .add_event(tp_event)
+            .expect("Failed to add tracepoint event to session");
+        session.enable().expect(need_permission);
 
-        // Convert the output to a String
-        let raw_output = String::from_utf8_lossy(&decode_output.stdout).to_string();
+        // Capture for the requested window. The caller emits events on another
+        // thread during this time; `parse_for_duration` keeps draining the ring
+        // buffer until the duration elapses, so mid-window writes are captured.
+        session
+            .parse_for_duration(Duration::from_secs(duration_secs))
+            .expect("Failed to parse perf ring buffer");
+        session.disable().expect(need_permission);
 
-        // Remove any Byte Order Mark (BOM) characters
-        // UTF-8 BOM is EF BB BF (in hex)
-        let cleaned_output = if let Some(stripped) = raw_output.strip_prefix('\u{FEFF}') {
-            // Skip the BOM character
-            stripped.to_string()
-        } else {
-            raw_output
-        };
+        let mut events = Vec::new();
+        collected.read(|v| events = v.clone());
 
-        // Trim the output to remove any leading/trailing whitespace
-        let trimmed_output = cleaned_output.trim().to_string();
-
-        Ok(trimmed_output)
+        Ok(format!("{{\"./perf.data\":[{}]}}", events.join(",")))
     }
 }


### PR DESCRIPTION
## Changes
- Simplify user_events integration tests setup by using `one_collect` and `tracepoint_decode` (No subprocesses / temp files / sudo shell-outs)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
