### PR TITLE
chore: geneva-exporter upgrade open-telemetry dependencies to v0.32.0

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
 otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -22,10 +22,7 @@ uuid = { version = "1.0", features = ["v4"] }
 # http2 feature is required by hyper-util even when using http1_only().
 reqwest = { version = "0.12", features = ["http2"], default-features = false }
 native-tls = { version = "0.2", optional = true }
-rustls = { version = "0.23", default-features = false, features = [
-    "std",
-    "tls12",
-], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
 rustls-pemfile = { version = "2", optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 p12-keystore = { version = "0.2", optional = true }
@@ -34,20 +31,14 @@ chrono = "0.4"
 url = "2.2"
 md-5 = "0.11.0"
 hex = "0.4"
-lz4_flex = { version = "0.11", features = [
-    "safe-encode",
-], default-features = false }
+lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
 # Azure Identity dependencies - using public crates.io versions.
 # Default features are disabled so the consumer-selected TLS backend (see
 # `tls-native` / `tls-rustls` below) chooses whether to pull in `native-tls`
 # through azure_core. Otherwise azure_core 0.29's defaults include
 # `reqwest_native_tls`, which links native-tls unconditionally.
 azure_identity = { version = "0.29", default-features = false }
-azure_core = { version = "0.29", default-features = false, features = [
-    "reqwest",
-    "reqwest_gzip",
-    "reqwest_deflate",
-] }
+azure_core = { version = "0.29", default-features = false, features = ["reqwest", "reqwest_gzip", "reqwest_deflate"] }
 tracing = "0.1"
 # Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; upper bound excludes
 # 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
@@ -90,14 +81,11 @@ wiremock = "0.6"
 futures = "0.3"
 num_cpus = "1.16"
 lz4_flex = { version = "0.11" }
-criterion = { version = "0.8" }
-rand = { version = "0.9" }
+criterion = {version = "0.8"}
+rand = {version = "0.9"}
 
 [lints]
 workspace = true
 
 [package.metadata.cargo-machete]
-ignored = [
-    "md-5",
-    "time",
-] # md-5 is incorrectly detected as unused; time is pinned to pull in the RUSTSEC-2026-0009 fix transitively.
+ignored = ["md-5", "time"] # md-5 is incorrectly detected as unused; time is pinned to pull in the RUSTSEC-2026-0009 fix transitively.

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
@@ -22,7 +22,10 @@ uuid = { version = "1.0", features = ["v4"] }
 # http2 feature is required by hyper-util even when using http1_only().
 reqwest = { version = "0.12", features = ["http2"], default-features = false }
 native-tls = { version = "0.2", optional = true }
-rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "tls12",
+], optional = true }
 rustls-pemfile = { version = "2", optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 p12-keystore = { version = "0.2", optional = true }
@@ -31,14 +34,20 @@ chrono = "0.4"
 url = "2.2"
 md-5 = "0.11.0"
 hex = "0.4"
-lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = false }
+lz4_flex = { version = "0.11", features = [
+    "safe-encode",
+], default-features = false }
 # Azure Identity dependencies - using public crates.io versions.
 # Default features are disabled so the consumer-selected TLS backend (see
 # `tls-native` / `tls-rustls` below) chooses whether to pull in `native-tls`
 # through azure_core. Otherwise azure_core 0.29's defaults include
 # `reqwest_native_tls`, which links native-tls unconditionally.
 azure_identity = { version = "0.29", default-features = false }
-azure_core = { version = "0.29", default-features = false, features = ["reqwest", "reqwest_gzip", "reqwest_deflate"] }
+azure_core = { version = "0.29", default-features = false, features = [
+    "reqwest",
+    "reqwest_gzip",
+    "reqwest_deflate",
+] }
 tracing = "0.1"
 # Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; upper bound excludes
 # 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
@@ -81,11 +90,14 @@ wiremock = "0.6"
 futures = "0.3"
 num_cpus = "1.16"
 lz4_flex = { version = "0.11" }
-criterion = {version = "0.8"}
-rand = {version = "0.9"}
+criterion = { version = "0.8" }
+rand = { version = "0.9" }
 
 [lints]
 workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["md-5", "time"] # md-5 is incorrectly detected as unused; time is pinned to pull in the RUSTSEC-2026-0009 fix transitively.
+ignored = [
+    "md-5",
+    "time",
+] # md-5 is incorrectly detected as unused; time is pinned to pull in the RUSTSEC-2026-0009 fix transitively.

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["opentelemetry", "geneva", "logs", "traces", "exporter"]
 license = "Apache-2.0"
 
 [dependencies]
-opentelemetry_sdk = { version = "0.31", default-features = false, features = ["logs", "trace"] }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["logs", "trace"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 futures = "0.3"
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
