### PR TITLE
chore: geneva-exporter - Bump OpenTelemetry dependencies to 0.32

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Forwarded `tls-native` (default) and `tls-rustls` feature flags from `geneva-uploader`. Build with `--no-default-features --features tls-rustls` to use the pure-Rust TLS backend (required for FIPS / OpenSSL-free deployments that install a custom `rustls::crypto::CryptoProvider`).
 
 ### Changed
+- Bump opentelemetry-proto version to 0.32.
 - Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
   to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`
   version and avoid duplicate `LogsDataView` trait errors. API-compatible;

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
 otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/otlp_builder/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/otlp_builder/Cargo.toml
@@ -17,5 +17,5 @@ workspace = true
 
 [dependencies]
 # Use the repo's opentelemetry-proto crate directly
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 prost = "0.14"

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/otlp_builder/src/builder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/otlp_builder/src/builder.rs
@@ -19,6 +19,7 @@ pub fn build_otlp_logs_minimal(
     if let Some((k, v)) = resource_kv {
         resource_attrs.push(KeyValue {
             key: k.to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(AnyValueValue::StringValue(v.to_string())),
             }),

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/otlp_builder/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/otlp_builder/src/lib.rs
@@ -57,6 +57,7 @@ unsafe extern "C" fn geneva_build_otlp_logs_minimal(
         };
         resource_attrs.push(KeyValue {
             key,
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(AnyValueValue::StringValue(val)),
             }),
@@ -154,6 +155,7 @@ unsafe extern "C" fn geneva_build_otlp_spans_minimal(
         };
         resource_attrs.push(KeyValue {
             key,
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(AnyValueValue::StringValue(val)),
             }),

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -2667,6 +2667,7 @@ mod tests {
                 resource: Some(Resource {
                     attributes: vec![KeyValue {
                         key: "service.name".to_string(),
+                        key_strindex: 0,
                         value: Some(AnyValue {
                             value: Some(any_value::Value::StringValue(
                                 "ffi-attr-types".to_string(),
@@ -2693,24 +2694,28 @@ mod tests {
                         attributes: vec![
                             KeyValue {
                                 key: "string.attr".to_string(),
+                                key_strindex: 0,
                                 value: Some(AnyValue {
                                     value: Some(any_value::Value::StringValue("value".to_string())),
                                 }),
                             },
                             KeyValue {
                                 key: "int.attr".to_string(),
+                                key_strindex: 0,
                                 value: Some(AnyValue {
                                     value: Some(any_value::Value::IntValue(42)),
                                 }),
                             },
                             KeyValue {
                                 key: "double.attr".to_string(),
+                                key_strindex: 0,
                                 value: Some(AnyValue {
                                     value: Some(any_value::Value::DoubleValue(3.5)),
                                 }),
                             },
                             KeyValue {
                                 key: "bool.attr".to_string(),
+                                key_strindex: 0,
                                 value: Some(AnyValue {
                                     value: Some(any_value::Value::BoolValue(true)),
                                 }),

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New `tls-rustls` feature flag enables a pure-Rust TLS backend (rustls + p12-keystore) as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. No built-in crypto provider (e.g. ring) is compiled in; consumers **must** install a `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start. The uploader returns a clear error if no provider is found.
 
 ### Changed
+- Bump opentelemetry-proto version to 0.32.
 - Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
   to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`
   version and avoid duplicate `LogsDataView` trait errors. API-compatible;

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
@@ -83,6 +83,11 @@ num_cpus = "1.16"
 lz4_flex = { version = "0.11" }
 criterion = {version = "0.8"}
 rand = {version = "0.9"}
+
+[[test]]
+name = "geneva_test_server_integration"
+path = "tests/geneva_test_server_integration.rs"
+required-features = ["mock_auth"]
 
 [lints]
 workspace = true

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
@@ -52,6 +52,7 @@ fn build_export_logs_request() -> ExportLogsServiceRequest {
             resource: Some(Resource {
                 attributes: vec![KeyValue {
                     key: "service.name".to_string(),
+                    key_strindex: 0,
                     value: Some(AnyValue {
                         value: Some(any_value::Value::StringValue(
                             "geneva-view-basic-example".to_string(),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -82,6 +82,7 @@ mod benchmarks {
 
             log.attributes.push(KeyValue {
                 key,
+                key_strindex: 0,
                 value: Some(value),
             });
         }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -1268,6 +1268,7 @@ mod tests {
         // Add some attributes
         log.attributes.push(KeyValue {
             key: "user_id".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::StringValue("user123".to_string())),
             }),
@@ -1275,6 +1276,7 @@ mod tests {
 
         log.attributes.push(KeyValue {
             key: "request_count".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::IntValue(42)),
             }),
@@ -1320,6 +1322,7 @@ mod tests {
         };
         log3.attributes.push(KeyValue {
             key: "user_id".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::StringValue("user123".to_string())),
             }),
@@ -1423,12 +1426,14 @@ mod tests {
         };
         log.attributes.push(KeyValue {
             key: "user".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::StringValue("alice".to_string())),
             }),
         });
         log.attributes.push(KeyValue {
             key: "attempt".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::IntValue(2)),
             }),
@@ -1585,12 +1590,14 @@ mod tests {
         let mut dup_log = base_log.clone();
         dup_log.attributes.push(KeyValue {
             key: "dup".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::IntValue(1)),
             }),
         });
         dup_log.attributes.push(KeyValue {
             key: "dup".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::IntValue(2)),
             }),
@@ -1652,6 +1659,7 @@ mod tests {
         };
         log3.attributes.push(KeyValue {
             key: "user_id".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::StringValue("user123".to_string())),
             }),
@@ -1752,6 +1760,7 @@ mod tests {
         };
         log4.attributes.push(KeyValue {
             key: "error_code".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::IntValue(404)),
             }),
@@ -1805,6 +1814,7 @@ mod tests {
 
         span.attributes.push(KeyValue {
             key: "http.method".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::StringValue("GET".to_string())),
             }),
@@ -1812,6 +1822,7 @@ mod tests {
 
         span.attributes.push(KeyValue {
             key: "http.status_code".to_string(),
+            key_strindex: 0,
             value: Some(AnyValue {
                 value: Some(Value::IntValue(200)),
             }),

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -78,6 +78,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
 fn string_attr(key: &str, value: &str) -> KeyValue {
     KeyValue {
         key: key.to_string(),
+        key_strindex: 0,
         value: Some(AnyValue {
             value: Some(Value::StringValue(value.to_string())),
         }),
@@ -87,6 +88,7 @@ fn string_attr(key: &str, value: &str) -> KeyValue {
 fn int_attr(key: &str, value: i64) -> KeyValue {
     KeyValue {
         key: key.to_string(),
+        key_strindex: 0,
         value: Some(AnyValue {
             value: Some(Value::IntValue(value)),
         }),

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Forwarded `tls-native` (default) and `tls-rustls` feature flags from `geneva-uploader`. Build with `--no-default-features --features tls-rustls` to use the pure-Rust TLS backend (required for FIPS / OpenSSL-free deployments that install a custom `rustls::crypto::CryptoProvider`).
 
 ### Changed
+- Bump opentelemetry, opentelemetry_sdk, and opentelemetry-proto versions to 0.32.
 - Bump pinned `otel-arrow` rev for `otap-df-pdata-views` to `4f522d2e` so
   consumers can unify on a single `otap-df-pdata-views` version and avoid
   duplicate `LogsDataView` trait errors. API-compatible; the view trait

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["opentelemetry", "geneva", "logs", "traces", "exporter"]
 license = "Apache-2.0"
 
 [dependencies]
-opentelemetry_sdk = { version = "0.31", default-features = false, features = ["logs", "trace"] }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["logs", "trace"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["logs", "trace"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 futures = "0.3"
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
@@ -27,9 +27,9 @@ tls-native = ["geneva-uploader/tls-native"]
 tls-rustls = ["geneva-uploader/tls-rustls"]
 
 [dev-dependencies]
-opentelemetry-appender-tracing = { version = "0.31" }
-opentelemetry = { version = "0.31" }
-opentelemetry_sdk = { version = "0.31", features = ["logs", "trace", "experimental_logs_batch_log_processor_with_async_runtime", "experimental_async_runtime", "rt-tokio"] }
+opentelemetry-appender-tracing = { version = "0.32" }
+opentelemetry = { version = "0.32" }
+opentelemetry_sdk = { version = "0.32", features = ["logs", "trace", "experimental_logs_batch_log_processor_with_async_runtime", "experimental_async_runtime", "rt-tokio"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter", "fmt", "registry", "std"] }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/logs/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/logs/exporter.rs
@@ -51,7 +51,7 @@ impl fmt::Debug for GenevaExporter {
 
 impl opentelemetry_sdk::logs::LogExporter for GenevaExporter {
     async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
-        let otlp = group_logs_by_resource_and_scope(batch, &self.resource);
+        let otlp = group_logs_by_resource_and_scope(&batch, &self.resource);
 
         // Encode and compress logs into batches
         let view = ProtoLogsView(&otlp);
@@ -297,6 +297,7 @@ impl<'a> AnyValueView<'a> for ProtoAVView<'a> {
             Some(ProtoVal::ArrayValue(_)) => ValueType::Empty, // not iterable through this view
             Some(ProtoVal::KvlistValue(_)) => ValueType::Empty, // not iterable through this view
             Some(ProtoVal::BytesValue(_)) => ValueType::Bytes,
+            Some(ProtoVal::StringValueStrindex(_)) => ValueType::Empty,
             None => ValueType::Empty,
         }
     }

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/src/trace/exporter.rs
@@ -82,7 +82,7 @@ impl SpanExporter for GenevaTraceExporter {
         self.resource = resource.into();
     }
 
-    fn shutdown(&mut self) -> OTelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         // Set shutdown flag to true
         self._is_shutdown.store(true, atomic::Ordering::Relaxed);
         // TODO: Use the is_shutdown value in export() method to prevent exports after shutdown


### PR DESCRIPTION
**_Acknowledgement_**: initial upgrade work was started in #664 by @albertlockett; this PR carries it forward with the remaining compatibility fixes and changelog updates.

Fixes #
Design discussion issue (if applicable) #

  ## Changes

  Bumps Geneva exporter crates to OpenTelemetry 0.32 dependencies:
  - `opentelemetry-proto` to 0.32
  - `opentelemetry_sdk` to 0.32
  - related dev OpenTelemetry dependencies to 0.32

  Also updates small API compatibility changes needed for the 0.32 bump.

  ## Merge requirement checklist

  * [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
  * [ ] Unit tests added/updated (not applicable; dependency bump only)
  * [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
  * [x] Changes in public API reviewed (not applicable; no public API changes intended)