### PR TITLE
ci: assign reviewers when draft PR is marked ready for review

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -5,6 +5,7 @@ on:
   # made from forked repositories. If pull_request is used in these cases,
   # the github token will not have sufficient permission to update the PR.
   pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
The `assign-reviewers` workflow uses `pull_request_target` without explicit event types, which defaults to `opened`, `synchronize`, and `reopened`. When a PR is created as a draft and later marked ready, the `ready_for_review` event is never triggered, so component owners are never assigned as reviewers.

Adding `ready_for_review` to the event types fixes this.