### PR TITLE
ci: split ETW and user_events integration tests into separate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,43 +65,6 @@ jobs:
     - name: Test (Unix)
       if: ${{ matrix.os != 'windows-latest'}}
       run: bash ./scripts/test.sh
-  user-events-integration-test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-      with:
-        egress-policy: audit
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        submodules: true
-    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-      with:
-        toolchain: stable
-        components: llvm-tools-preview
-    - name: cargo install cargo-llvm-cov
-      uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
-      with:
-        tool: cargo-llvm-cov
-    - name: Check user_events kernel support
-      run: |
-        sudo cat /sys/kernel/tracing/user_events_status || { echo "user_events not supported on this runner"; exit 1; }
-    - name: Run user_events integration tests (trace)
-      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov --no-report --manifest-path opentelemetry-user-events-trace/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
-    - name: Run user_events integration tests (logs)
-      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov --no-report --manifest-path opentelemetry-user-events-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
-    - name: Run user_events integration tests (metrics)
-      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov --no-report --manifest-path opentelemetry-user-events-metrics/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
-    - name: Generate lcov report
-      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov report --lcov --output-path lcov.info
-    - name: Make lcov.info readable for codecov upload
-      run: sudo chmod a+r lcov.info
-    - name: Upload to codecov.io
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
-      with:
-        files: lcov.info
-        flags: user-events-integration
-        fail_ci_if_error: false
   geneva-uploader-test-server-integration-test:
     runs-on: ubuntu-latest
     steps:
@@ -120,38 +83,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test geneva-uploader with geneva-test-server
       run: cargo test -p geneva-uploader --features mock_auth --test geneva_test_server_integration -- --ignored
-  etw-integration-test:
-    runs-on: windows-latest
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-      with:
-        egress-policy: audit
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        submodules: true
-    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-      with:
-        toolchain: stable
-        components: llvm-tools-preview
-    - name: cargo install cargo-llvm-cov
-      uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
-      with:
-        tool: cargo-llvm-cov
-    - name: Run ETW integration tests (logs)
-      run: cargo llvm-cov --no-report --manifest-path opentelemetry-etw-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
-    - name: Run ETW integration tests (metrics)
-      run: cargo llvm-cov --no-report --manifest-path opentelemetry-etw-metrics/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
-    - name: Run ETW integration tests (traces)
-      run: cargo llvm-cov --no-report --manifest-path opentelemetry-etw-traces/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
-    - name: Generate lcov report
-      run: cargo llvm-cov report --lcov --output-path lcov.info
-    - name: Upload to codecov.io
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
-      with:
-        files: lcov.info
-        flags: etw-integration
-        fail_ci_if_error: false
   lint:
     strategy:
       matrix:

--- a/.github/workflows/etw.yml
+++ b/.github/workflows/etw.yml
@@ -1,0 +1,64 @@
+name: ETW Integration
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'opentelemetry-etw-logs/**'
+      - 'opentelemetry-etw-metrics/**'
+      - 'opentelemetry-etw-traces/**'
+      - 'Cargo.toml'
+      - '.github/workflows/etw.yml'
+  merge_group:
+  push:
+    branches:
+      - main
+    paths:
+      - 'opentelemetry-etw-logs/**'
+      - 'opentelemetry-etw-metrics/**'
+      - 'opentelemetry-etw-traces/**'
+      - 'Cargo.toml'
+      - '.github/workflows/etw.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  etw-integration-test:
+    runs-on: windows-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: stable
+        components: llvm-tools-preview
+    - name: cargo install cargo-llvm-cov
+      uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+      with:
+        tool: cargo-llvm-cov
+    - name: Run ETW integration tests (logs)
+      run: cargo llvm-cov --no-report --manifest-path opentelemetry-etw-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Run ETW integration tests (metrics)
+      run: cargo llvm-cov --no-report --manifest-path opentelemetry-etw-metrics/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Run ETW integration tests (traces)
+      run: cargo llvm-cov --no-report --manifest-path opentelemetry-etw-traces/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Generate lcov report
+      run: cargo llvm-cov report --lcov --output-path lcov.info
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+      with:
+        files: lcov.info
+        flags: etw-integration
+        fail_ci_if_error: false

--- a/.github/workflows/user-events.yml
+++ b/.github/workflows/user-events.yml
@@ -1,0 +1,69 @@
+name: user_events Integration
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'opentelemetry-user-events-logs/**'
+      - 'opentelemetry-user-events-metrics/**'
+      - 'opentelemetry-user-events-trace/**'
+      - 'Cargo.toml'
+      - '.github/workflows/user-events.yml'
+  merge_group:
+  push:
+    branches:
+      - main
+    paths:
+      - 'opentelemetry-user-events-logs/**'
+      - 'opentelemetry-user-events-metrics/**'
+      - 'opentelemetry-user-events-trace/**'
+      - 'Cargo.toml'
+      - '.github/workflows/user-events.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  user-events-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: stable
+        components: llvm-tools-preview
+    - name: cargo install cargo-llvm-cov
+      uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+      with:
+        tool: cargo-llvm-cov
+    - name: Check user_events kernel support
+      run: |
+        sudo cat /sys/kernel/tracing/user_events_status || { echo "user_events not supported on this runner"; exit 1; }
+    - name: Run user_events integration tests (trace)
+      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov --no-report --manifest-path opentelemetry-user-events-trace/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Run user_events integration tests (logs)
+      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov --no-report --manifest-path opentelemetry-user-events-logs/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Run user_events integration tests (metrics)
+      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov --no-report --manifest-path opentelemetry-user-events-metrics/Cargo.toml --all-features -- --ignored --nocapture --test-threads=1
+    - name: Generate lcov report
+      run: sudo -E $HOME/.cargo/bin/cargo llvm-cov report --lcov --output-path lcov.info
+    - name: Make lcov.info readable for codecov upload
+      run: sudo chmod a+r lcov.info
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+      with:
+        files: lcov.info
+        flags: user-events-integration
+        fail_ci_if_error: false


### PR DESCRIPTION
Moves the ETW and user_events integration test jobs out of the main `ci.yml` and into dedicated `etw.yml` and `user-events.yml` workflows, each gated on native `paths:` filters so they only run when the corresponding crates (or the workflow file itself or root `Cargo.toml`) change.

Motivation: these jobs are crate-specific (ETW is Windows-only, user_events is Linux-only with kernel requirements) and don't belong in the main CI pipeline. Splitting them into their own workflows keeps `ci.yml` focused on workspace-wide checks and lets each crate's integration tests run only when relevant changes land.