### PR TITLE
ci: add weaver live-check workflow for actix-web instrumentation (seed for #530)

### DIFF
--- a/.github/workflows/weaver-live-check-actix.yml
+++ b/.github/workflows/weaver-live-check-actix.yml
@@ -118,6 +118,11 @@ jobs:
           c "http://127.0.0.1:5000/error"
           echo "::endgroup::"
 
+          # Give the periodic metric reader one final export interval to flush
+          # before we tear down. (Spans use a simple processor and are already
+          # flushed synchronously per request.)
+          sleep 3
+
           kill "$APP_PID" && wait "$APP_PID" || true
 
       - name: Stop weaver live-check

--- a/.github/workflows/weaver-live-check-actix.yml
+++ b/.github/workflows/weaver-live-check-actix.yml
@@ -1,0 +1,135 @@
+name: Weaver Live Check (actix)
+
+# Validates that telemetry emitted by the actix-web instrumentation's
+# live-check-app example complies with the published OpenTelemetry
+# semantic conventions. Follows the same pattern as
+# weaver-live-check-tower.yml; both are part of issue #530.
+
+env:
+  CI: true
+  WEAVER_VERSION: v0.24.0
+  # Pinned semantic-conventions release for reproducible runs. Bump
+  # deliberately when conventions change.
+  SEMCONV_REGISTRY: 'https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.36.0.tar.gz[model]'
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'opentelemetry-instrumentation-actix-web/**'
+      - '.github/workflows/weaver-live-check-actix.yml'
+  merge_group:
+  push:
+    branches:
+      - main
+    paths:
+      - 'opentelemetry-instrumentation-actix-web/**'
+      - '.github/workflows/weaver-live-check-actix.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install stable Rust
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: weaver-live-check-actix-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build live-check-app example
+        working-directory: opentelemetry-instrumentation-actix-web/examples/live-check-app
+        run: cargo build --release
+
+      - name: Setup weaver
+        uses: open-telemetry/weaver/.github/actions/setup-weaver@v0.24.0
+        with:
+          version: ${{ env.WEAVER_VERSION }}
+
+      - name: Start weaver live-check
+        id: live-check
+        uses: open-telemetry/weaver/.github/actions/weaver-live-check-start@v0.24.0
+        with:
+          registry: ${{ env.SEMCONV_REGISTRY }}
+
+      # TODO: Consider defining a standard set of HTTP endpoints and their
+      # expected behaviour so that weaver (or a shared test harness) can drive
+      # traffic itself — each repo would just stand up a conformant app.
+      # Similar in spirit to how the W3C TraceContext test suite works.
+      - name: Run example + drive traffic
+        working-directory: opentelemetry-instrumentation-actix-web
+        env:
+          OTEL_METRIC_EXPORT_INTERVAL: '2000'
+          OTEL_BSP_SCHEDULE_DELAY: '1000'
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ steps.live-check.outputs.otlp-grpc-endpoint }}
+        run: |
+          set -euo pipefail
+
+          echo "::group::Start example service"
+          ../target/release/example-live-check-actix > "${{ steps.live-check.outputs.state-dir }}/example.log" 2>&1 &
+          APP_PID=$!
+          echo "app pid: $APP_PID"
+          echo "::endgroup::"
+
+          # Wait for the app to start serving on :5000
+          for _ in $(seq 1 30); do
+            if curl -fsS "http://127.0.0.1:5000/" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+
+          # Bounded curl helper so a stuck request never hangs the job.
+          c() { curl --max-time 5 -sS -o /dev/null "$@" || true; }
+
+          echo "::group::Drive traffic"
+          c "http://127.0.0.1:5000/"
+          c "http://127.0.0.1:5000/users/1"
+          c "http://127.0.0.1:5000/files/a/b/c/1.txt"
+          c -X POST   "http://127.0.0.1:5000/items"
+          c -X PUT    "http://127.0.0.1:5000/items/1"
+          c -X PATCH  "http://127.0.0.1:5000/items/1"
+          c -X DELETE "http://127.0.0.1:5000/items/1"
+          c -X HEAD    "http://127.0.0.1:5000/items/1/head"
+          c -X OPTIONS "http://127.0.0.1:5000/items"
+          c "http://127.0.0.1:5000/bad-request"
+          c "http://127.0.0.1:5000/unauthorized"
+          c "http://127.0.0.1:5000/no-such-route"
+          c "http://127.0.0.1:5000/error"
+          echo "::endgroup::"
+
+          kill "$APP_PID" && wait "$APP_PID" || true
+
+      - name: Stop weaver live-check
+        if: always()
+        uses: open-telemetry/weaver/.github/actions/weaver-live-check-stop@v0.24.0
+        with:
+          fail-on: violation
+
+      - name: Upload live-check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weaver-live-check-actix
+          path: ${{ steps.live-check.outputs.state-dir }}
+          if-no-files-found: warn

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "opentelemetry-etw-metrics",
     "opentelemetry-etw-traces",
     "opentelemetry-instrumentation-actix-web",
+    "opentelemetry-instrumentation-actix-web/examples/*",
     "opentelemetry-instrumentation-tower",
     "opentelemetry-instrumentation-tower/examples/*",
     "opentelemetry-resource-detectors",

--- a/opentelemetry-instrumentation-actix-web/examples/live-check-app/Cargo.toml
+++ b/opentelemetry-instrumentation-actix-web/examples/live-check-app/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "example-live-check-actix"
+version = "0.1.0-alpha.0"
+edition = "2021"
+rust-version = "1.88.0"
+publish = false
+
+# Purpose-built example used by the `weaver-live-check-actix` CI workflow
+# to exercise the actix-web instrumentation across a comprehensive HTTP
+# method x status-code x route-shape matrix. Not intended as illustrative
+# user-facing documentation - use `examples/server.rs` for that.
+
+[dependencies]
+opentelemetry-instrumentation-actix-web = { path = "../../", default-features = false, features = ["metrics"] }
+actix-web = { version = "4.12", default-features = false, features = ["macros", "compress-zstd"] }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, default-features = false, features = ["rt-tokio"] }
+opentelemetry-otlp = { workspace = true, features = ["grpc-tonic", "metrics", "trace"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"], default-features = false }
+
+[lints]
+workspace = true

--- a/opentelemetry-instrumentation-actix-web/examples/live-check-app/src/main.rs
+++ b/opentelemetry-instrumentation-actix-web/examples/live-check-app/src/main.rs
@@ -1,0 +1,166 @@
+// Purpose-built example for the weaver-live-check-actix CI workflow.
+// Exercises the actix-web HTTP instrumentation across the full
+// HTTP-method x status-code x route-shape matrix so that weaver can
+// validate as many attribute combinations as possible against the
+// pinned semantic-conventions registry.
+
+use actix_web::{http::Method, web, App, HttpResponse, HttpServer, Responder};
+use opentelemetry::global;
+use opentelemetry_instrumentation_actix_web::{RequestMetrics, RequestTracing};
+use opentelemetry_otlp::{MetricExporter, SpanExporter};
+use opentelemetry_sdk::{
+    metrics::{PeriodicReader, SdkMeterProvider},
+    trace::SdkTracerProvider,
+    Resource,
+};
+use std::sync::OnceLock;
+
+const SERVICE_NAME: &str = "example-live-check-actix";
+
+fn get_resource() -> Resource {
+    static RESOURCE: OnceLock<Resource> = OnceLock::new();
+    RESOURCE
+        .get_or_init(|| Resource::builder().with_service_name(SERVICE_NAME).build())
+        .clone()
+}
+
+// 200 OK handlers ---------------------------------------------------------
+
+async fn root() -> &'static str {
+    "ok"
+}
+
+async fn get_user(path: web::Path<u32>) -> String {
+    format!("user-{}", path.into_inner())
+}
+
+async fn get_file(path: web::Path<String>) -> String {
+    format!("file:{}", path.into_inner())
+}
+
+// 201 / 200 / 204 status code handlers ------------------------------------
+
+async fn create_item() -> impl Responder {
+    HttpResponse::Created().body("created")
+}
+
+async fn update_item(path: web::Path<u32>) -> String {
+    format!("updated {}", path.into_inner())
+}
+
+async fn patch_item(path: web::Path<u32>) -> String {
+    format!("patched {}", path.into_inner())
+}
+
+async fn delete_item(_path: web::Path<u32>) -> HttpResponse {
+    HttpResponse::NoContent().finish()
+}
+
+async fn options_items() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+// 4xx / 5xx handlers (handled errors) -------------------------------------
+
+async fn bad_request() -> impl Responder {
+    HttpResponse::BadRequest().body("bad input")
+}
+
+async fn unauthorized() -> impl Responder {
+    HttpResponse::Unauthorized().finish()
+}
+
+async fn server_error() -> impl Responder {
+    HttpResponse::InternalServerError().body("intentional")
+}
+
+// HEAD on a templated route to exercise an additional method.
+async fn item_head(_path: web::Path<u32>) -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+// NOTE: tower's live-check-app also exercises a panicking handler (converted to
+// a 500 response via `tower-http`'s `CatchPanicLayer`, then recorded by the
+// OTel layer). The actix-web instrumentation does not currently emit a span or
+// record metrics when a handler panics — the future panics before the
+// middleware response wrapper runs. The /error path already exercises 5xx
+// attribute coverage, so a panicking handler is intentionally omitted here.
+
+async fn shutdown_signal() {
+    use tokio::signal;
+    let ctrl_c = async {
+        signal::ctrl_c().await.expect("ctrl-c handler");
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(unix)]
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+    #[cfg(not(unix))]
+    ctrl_c.await;
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let metric_exporter = MetricExporter::builder().with_tonic().build().unwrap();
+    let reader = PeriodicReader::builder(metric_exporter).build();
+    let meter_provider = SdkMeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(get_resource())
+        .build();
+    global::set_meter_provider(meter_provider.clone());
+
+    let span_exporter = SpanExporter::builder().with_tonic().build().unwrap();
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(span_exporter)
+        .with_resource(get_resource())
+        .build();
+    global::set_tracer_provider(tracer_provider.clone());
+
+    // The matrix exercised below:
+    //   methods:      GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+    //   status codes: 200, 201, 204, 400, 401, 404, 500
+    //   route shapes: literal, templated param, wildcard catch-all
+    //   error shape:  handled 4xx/5xx + unhandled panic
+    let server = HttpServer::new(|| {
+        App::new()
+            .wrap(RequestTracing::new())
+            .wrap(RequestMetrics::default())
+            .route("/", web::get().to(root))
+            .route("/users/{id}", web::get().to(get_user))
+            .route("/items", web::post().to(create_item))
+            .route("/items", web::method(Method::OPTIONS).to(options_items))
+            .route("/items/{id}", web::put().to(update_item))
+            .route("/items/{id}", web::patch().to(patch_item))
+            .route("/items/{id}", web::delete().to(delete_item))
+            .route("/items/{id}/head", web::head().to(item_head))
+            .route("/files/{path:.*}", web::get().to(get_file))
+            .route("/bad-request", web::get().to(bad_request))
+            .route("/unauthorized", web::get().to(unauthorized))
+            .route("/error", web::get().to(server_error))
+    })
+    // Single worker keeps a panic from racing against shutdown signal delivery.
+    .workers(1)
+    .bind(("0.0.0.0", 5000))?
+    .shutdown_timeout(2)
+    .run();
+
+    let server_handle = server.handle();
+    let server_task = tokio::spawn(server);
+
+    shutdown_signal().await;
+    server_handle.stop(true).await;
+    let _ = server_task.await;
+
+    let _ = meter_provider.shutdown();
+    let _ = tracer_provider.shutdown();
+
+    Ok(())
+}

--- a/opentelemetry-instrumentation-actix-web/examples/live-check-app/src/main.rs
+++ b/opentelemetry-instrumentation-actix-web/examples/live-check-app/src/main.rs
@@ -118,17 +118,23 @@ async fn main() -> std::io::Result<()> {
     global::set_meter_provider(meter_provider.clone());
 
     let span_exporter = SpanExporter::builder().with_tonic().build().unwrap();
+    // Simple processor (synchronous per-span export) instead of batch: keeps
+    // the example resilient to runtime model differences between actix-rt and
+    // plain tokio - every span hits weaver before the next request returns,
+    // no flush-on-shutdown race.
     let tracer_provider = SdkTracerProvider::builder()
-        .with_batch_exporter(span_exporter)
+        .with_simple_exporter(span_exporter)
         .with_resource(get_resource())
         .build();
     global::set_tracer_provider(tracer_provider.clone());
+
+    eprintln!("live-check-app: starting on 0.0.0.0:5000");
 
     // The matrix exercised below:
     //   methods:      GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
     //   status codes: 200, 201, 204, 400, 401, 404, 500
     //   route shapes: literal, templated param, wildcard catch-all
-    //   error shape:  handled 4xx/5xx + unhandled panic
+    //   error shape:  handled 4xx/5xx (no panic - see note above)
     let server = HttpServer::new(|| {
         App::new()
             .wrap(RequestTracing::new())
@@ -146,8 +152,10 @@ async fn main() -> std::io::Result<()> {
             .route("/unauthorized", web::get().to(unauthorized))
             .route("/error", web::get().to(server_error))
     })
-    // Single worker keeps a panic from racing against shutdown signal delivery.
     .workers(1)
+    // We drive shutdown explicitly; actix's built-in signal handler would race
+    // with our flush-on-shutdown sequence below.
+    .disable_signals()
     .bind(("0.0.0.0", 5000))?
     .shutdown_timeout(2)
     .run();
@@ -156,11 +164,19 @@ async fn main() -> std::io::Result<()> {
     let server_task = tokio::spawn(server);
 
     shutdown_signal().await;
+    eprintln!("live-check-app: shutdown signal received, stopping server");
     server_handle.stop(true).await;
     let _ = server_task.await;
 
-    let _ = meter_provider.shutdown();
-    let _ = tracer_provider.shutdown();
+    eprintln!("live-check-app: flushing tracer/meter providers");
+    if let Err(e) = tracer_provider.shutdown() {
+        eprintln!("live-check-app: tracer shutdown error: {e:?}");
+    }
+    if let Err(e) = meter_provider.shutdown() {
+        eprintln!("live-check-app: meter shutdown error: {e:?}");
+    }
+    eprintln!("live-check-app: done");
 
     Ok(())
 }
+

--- a/opentelemetry-instrumentation-actix-web/examples/live-check-app/src/main.rs
+++ b/opentelemetry-instrumentation-actix-web/examples/live-check-app/src/main.rs
@@ -179,4 +179,3 @@ async fn main() -> std::io::Result<()> {
 
     Ok(())
 }
-


### PR DESCRIPTION
Follow-up to #613. Extends the weaver live-check CI pattern from tower to the actix-web instrumentation, per #530.

Runs a purpose-built `live-check-app` example (under `opentelemetry-instrumentation-actix-web/examples/live-check-app/`) against an OTLP-mode weaver listener and fails the job on any semantic-convention `violation`. The example exercises the same HTTP method × status-code × route-shape matrix the tower example does so weaver validates as many attribute combinations as possible. JSON report uploaded as a workflow artifact.

Uses the reusable `weaver-live-check-start` / `weaver-live-check-stop` composite actions from open-telemetry/weaver, pinned to the `v0.24.0` release. Semconv registry pinned to `v1.36.0` (the version the `opentelemetry-semantic-conventions 0.32` crate is based on). Same workflow shape and pins as `weaver-live-check-tower.yml`.

Differences from the tower example, all of them properties of the instrumentation we're testing rather than the workflow:

- Spans are exported via a simple processor (synchronous per-span) instead of a batch processor. With batching under actix-rt, the exporter background task did not flush by the time the job tore the process down, so weaver saw zero entities. Simple-exporter is fine for an example whose purpose is "every request must produce a span weaver sees".
- `actix` middleware does not currently record a span or metric when a handler panics (the future panics before the response wrapper runs), so the panicking `/throw` route from the tower example is intentionally omitted. The `/error` route already exercises 5xx attribute coverage. Adding panic-recording to the actix middleware is a worthwhile follow-up, out of scope here.
- Server uses `.disable_signals()` and we own SIGTERM/SIGINT so the shutdown sequence flushes telemetry deterministically.

CI result on this branch: **0 violations**, 134 information advisories + 3 improvement advisories. The workflow passes with `fail-on: violation`, same policy as tower.

Findings worth tracking as follow-ups (not blocking this PR):

- `error.type` is set to raw status-code strings (`"400"`, `"401"`, `"404"`, `"500"`) on 4xx/5xx spans. The semconv `error.type` attribute is an enum and weaver flags these as `undefined_enum_variant`. Should be set to a canonical enum value or `_OTHER`.
- `error.type` is missing entirely on a number of error spans/data-points where semconv calls for it (31 occurrences).
- `network.protocol.name` is missing on spans/metric data-points (39 occurrences).
- `http.response.status_code` is missing on some metric data-points (13 occurrences).
- `user_agent.synthetic.type` opt-in attribute not present (39 occurrences) — informational, opt-in is fine to skip.
- Same three "not stable; stability = development" notes the tower run produces (`http.server.active_requests`, `http.server.request.body.size`, `http.server.response.body.size`) — informational only, also present on tower.
- `meter_provider.shutdown()` from inside an `actix_web::main` runtime times out (`InternalFailure("[Timeout(5s)]")`). Data still lands because the PeriodicReader exports during the workflow's pre-kill grace period. Worth a separate investigation into the actix-rt × OTel SDK interaction.

Now that two instrumentation libraries use the same workflow shape, the next natural step is to factor out the shared scaffolding (action invocations, traffic-driver helper, artifact upload) so adding the third instrumentation library doesn't mean copy-pasting another ~140-line YAML file. Tracking separately.
