### PR TITLE
feat(resource-detectors): add service instance detector

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `ContainerResourceDetector` to detect `container.id` from `/proc/self/cgroup`, with fallback to `/proc/self/mountinfo`.
 - Add host.name attribute to `HostResourceDetector`
+- Add `ServiceInstanceIdResourceDetector` to generate a random UUIDv4 `service.instance.id`.
 
 ## v0.11.0
 

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -25,10 +25,11 @@ Community supported Resource detectors implementations for applications instrume
 
 | Detector                | Implemented Resources             | OS Supported | Semantic Conventions                                                                      |
 |-------------------------|-----------------------------------|--------------|-------------------------------------------------------------------------------------------|
-| ProcessResourceDetector   | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
-| OsResourceDetector        | OS_TYPE                           | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
-| HostResourceDetector      | HOST_ID                           | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
-| HostResourceDetector      | HOST_ARCH, HOST_NAME              | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
-| K8sResourceDetector       | K8S_NAMESPACE_NAME                | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
-| K8sResourceDetector       | K8S_POD_NAME                      | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
-| ContainerResourceDetector | CONTAINER_ID                      | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/container.md |
+| ProcessResourceDetector           | PROCESS_COMMAND_ARGS, PROCESS_PID | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md |
+| OsResourceDetector                | OS_TYPE                           | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/os.md      |
+| HostResourceDetector              | HOST_ID                           | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
+| HostResourceDetector              | HOST_ARCH, HOST_NAME              | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md    |
+| K8sResourceDetector               | K8S_NAMESPACE_NAME                | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
+| K8sResourceDetector               | K8S_POD_NAME                      | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/k8s.md     |
+| ContainerResourceDetector         | CONTAINER_ID                      | linux        | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/container.md |
+| ServiceInstanceIdResourceDetector | SERVICE_INSTANCE_ID               | all          | https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/service.md |

--- a/opentelemetry-resource-detectors/src/lib.rs
+++ b/opentelemetry-resource-detectors/src/lib.rs
@@ -8,14 +8,18 @@
 //! - [`HostResourceDetector`] - detect unique host ID.
 //! - [`K8sResourceDetector`] - detect Kubernetes information.
 //! - [`ContainerResourceDetector`] - detect container ID.
+//! - [`ServiceInstanceIdResourceDetector`] - generate a unique service instance ID.
 mod container;
 mod host;
 mod k8s;
 mod os;
 mod process;
+mod service_instance;
+mod uuid;
 
 pub use container::ContainerResourceDetector;
 pub use host::HostResourceDetector;
 pub use k8s::K8sResourceDetector;
 pub use os::OsResourceDetector;
 pub use process::ProcessResourceDetector;
+pub use service_instance::ServiceInstanceIdResourceDetector;

--- a/opentelemetry-resource-detectors/src/service_instance.rs
+++ b/opentelemetry-resource-detectors/src/service_instance.rs
@@ -5,22 +5,31 @@ use crate::uuid;
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::ResourceDetector;
 use opentelemetry_sdk::Resource;
+use std::sync::OnceLock;
 
 /// Detect the `service.instance.id` resource attribute.
 ///
 /// The [OpenTelemetry specification] recommends `service.instance.id` be a
 /// random UUIDv4 when no inherently unique identifier is available.
 ///
+/// The id is generated once and reused for the lifetime of the process, so every
+/// resource built from this detector shares the same instance id.
+///
 /// [OpenTelemetry specification]: https://opentelemetry.io/docs/specs/semconv/resource/service/#service-instance
 #[derive(Debug, Default)]
 pub struct ServiceInstanceIdResourceDetector;
+
+fn instance_id() -> &'static str {
+    static INSTANCE_ID: OnceLock<String> = OnceLock::new();
+    INSTANCE_ID.get_or_init(uuid::v4)
+}
 
 impl ResourceDetector for ServiceInstanceIdResourceDetector {
     fn detect(&self) -> Resource {
         Resource::builder_empty()
             .with_attributes(vec![KeyValue::new(
                 opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID,
-                uuid::v4(),
+                instance_id(),
             )])
             .build()
     }
@@ -47,11 +56,13 @@ mod tests {
     }
 
     #[test]
-    fn generates_a_new_id_per_detect() {
-        let detector = ServiceInstanceIdResourceDetector;
+    fn returns_the_same_id_across_detectors() {
         let key = Key::from_static_str(
             opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID,
         );
-        assert_ne!(detector.detect().get(&key), detector.detect().get(&key));
+        let first = ServiceInstanceIdResourceDetector.detect().get(&key);
+        let second = ServiceInstanceIdResourceDetector.detect().get(&key);
+        assert!(first.is_some());
+        assert_eq!(first, second);
     }
 }

--- a/opentelemetry-resource-detectors/src/service_instance.rs
+++ b/opentelemetry-resource-detectors/src/service_instance.rs
@@ -1,0 +1,57 @@
+//! Service instance ID resource detector
+//!
+//! Generate a unique `service.instance.id`.
+use crate::uuid;
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::resource::ResourceDetector;
+use opentelemetry_sdk::Resource;
+
+/// Detect the `service.instance.id` resource attribute.
+///
+/// The [OpenTelemetry specification] recommends `service.instance.id` be a
+/// random UUIDv4 when no inherently unique identifier is available.
+///
+/// [OpenTelemetry specification]: https://opentelemetry.io/docs/specs/semconv/resource/service/#service-instance
+#[derive(Debug, Default)]
+pub struct ServiceInstanceIdResourceDetector;
+
+impl ResourceDetector for ServiceInstanceIdResourceDetector {
+    fn detect(&self) -> Resource {
+        Resource::builder_empty()
+            .with_attributes(vec![KeyValue::new(
+                opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID,
+                uuid::v4(),
+            )])
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServiceInstanceIdResourceDetector;
+    use opentelemetry::{Key, Value};
+    use opentelemetry_sdk::resource::ResourceDetector;
+
+    #[test]
+    fn detects_service_instance_id() {
+        let resource = ServiceInstanceIdResourceDetector.detect();
+        assert_eq!(resource.len(), 1);
+
+        let value = resource.get(&Key::from_static_str(
+            opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID,
+        ));
+        match value {
+            Some(Value::String(id)) => assert_eq!(id.as_str().len(), 36),
+            other => panic!("expected a string service.instance.id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generates_a_new_id_per_detect() {
+        let detector = ServiceInstanceIdResourceDetector;
+        let key = Key::from_static_str(
+            opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID,
+        );
+        assert_ne!(detector.detect().get(&key), detector.detect().get(&key));
+    }
+}

--- a/opentelemetry-resource-detectors/src/uuid.rs
+++ b/opentelemetry-resource-detectors/src/uuid.rs
@@ -1,9 +1,9 @@
 //! Minimal UUIDv4 generation.
 //!
-//! In order to avoid third-party dependencies, we generate UUIDv4s using only 
-//! the standard library. The result will be unique, but not cryptographically 
-//! secure, which is sufficient for service instance IDs. Randomness comes 
-//! from an OS-seeded [`RandomState`], with time, process id, and a counter 
+//! In order to avoid third-party dependencies, we generate UUIDv4s using only
+//! the standard library. The result will be unique, but not cryptographically
+//! secure, which is sufficient for service instance IDs. Randomness comes
+//! from an OS-seeded [`RandomState`], with time, process id, and a counter
 //! mixed in so repeated calls are extremely unlikely to collide.
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hasher};
@@ -16,15 +16,15 @@ static COUNTER: AtomicU64 = AtomicU64::new(0);
 ///  e.g. `"f47ac10b-58cc-4372-a567-0e02b2c3d479"`.
 pub(crate) fn v4() -> String {
     let mut bytes = random_bytes();
-    
+
     // https://www.rfc-editor.org/rfc/rfc9562.html#name-version-field
     // Set the high nibble of bytes[6] to 0100. This is the version.
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
-   
+
     // https://www.rfc-editor.org/rfc/rfc9562.html#name-variant-field
     // Set the two most significant bits of bytes[8] to 10. This is the variant.
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    
+
     format(&bytes)
 }
 
@@ -37,7 +37,7 @@ fn random_bytes() -> [u8; 16] {
 }
 
 /// Produce 64 random bits. Each call uses an independently seeded RandomState.
-/// Time, process ID, and a counter are mixed in to ensure successive calls 
+/// Time, process ID, and a counter are mixed in to ensure successive calls
 /// produce different output.
 fn seed_word() -> u64 {
     let mut hasher = RandomState::new().build_hasher();

--- a/opentelemetry-resource-detectors/src/uuid.rs
+++ b/opentelemetry-resource-detectors/src/uuid.rs
@@ -1,0 +1,101 @@
+//! Minimal UUIDv4 generation.
+//!
+//! In order to avoid third-party dependencies, we generate UUIDv4s using only 
+//! the standard library. The result will be unique, but not cryptographically 
+//! secure, which is sufficient for service instance IDs. Randomness comes 
+//! from an OS-seeded [`RandomState`], with time, process id, and a counter 
+//! mixed in so repeated calls are extremely unlikely to collide.
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a random UUIDv4 as a canonical hyphenated string,
+///  e.g. `"f47ac10b-58cc-4372-a567-0e02b2c3d479"`.
+pub(crate) fn v4() -> String {
+    let mut bytes = random_bytes();
+    
+    // https://www.rfc-editor.org/rfc/rfc9562.html#name-version-field
+    // Set the high nibble of bytes[6] to 0100. This is the version.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+   
+    // https://www.rfc-editor.org/rfc/rfc9562.html#name-variant-field
+    // Set the two most significant bits of bytes[8] to 10. This is the variant.
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    
+    format(&bytes)
+}
+
+/// Produce 128 random bits from two calls to `seed_word()`.
+fn random_bytes() -> [u8; 16] {
+    let mut out = [0u8; 16];
+    out[..8].copy_from_slice(&seed_word().to_ne_bytes());
+    out[8..].copy_from_slice(&seed_word().to_ne_bytes());
+    out
+}
+
+/// Produce 64 random bits. Each call uses an independently seeded RandomState.
+/// Time, process ID, and a counter are mixed in to ensure successive calls 
+/// produce different output.
+fn seed_word() -> u64 {
+    let mut hasher = RandomState::new().build_hasher();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    hasher.write_u64(nanos);
+    hasher.write_u32(std::process::id());
+    hasher.write_u64(COUNTER.fetch_add(1, Ordering::Relaxed));
+    hasher.finish()
+}
+
+/// Format the bytes as a canonical hyphenated UUIDv4 string.
+fn format(bytes: &[u8; 16]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(36);
+    for (i, byte) in bytes.iter().enumerate() {
+        if matches!(i, 4 | 6 | 8 | 10) {
+            s.push('-');
+        }
+        // Push the high nibble then the low nibble as hex chars.
+        s.push(HEX[(byte >> 4) as usize] as char);
+        s.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::v4;
+
+    #[test]
+    fn formats_canonical_v4() {
+        let uuid = v4();
+
+        // 32 hex digits + 4 hyphens.
+        assert_eq!(uuid.len(), 36);
+
+        let bytes = uuid.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if matches!(i, 8 | 13 | 18 | 23) {
+                assert_eq!(b, b'-', "expected hyphen at index {i}");
+            } else {
+                assert!(b.is_ascii_hexdigit() && !b.is_ascii_uppercase());
+            }
+        }
+
+        // Version nibble is 4.
+        assert_eq!(bytes[14], b'4');
+        // Variant nibble is one of 8, 9, a, b.
+        assert!(matches!(bytes[19], b'8' | b'9' | b'a' | b'b'));
+    }
+
+    #[test]
+    fn generates_distinct_values() {
+        let count = 1000;
+        let unique: std::collections::HashSet<_> = (0..count).map(|_| v4()).collect();
+        assert_eq!(unique.len(), count);
+    }
+}


### PR DESCRIPTION
Fixes #658

## Changes
- Adds `ServiceInstanceIdResourceDetector` to set service.instance.id to a random UUIDv4 per the [service semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/service/#service-instance).
- To avoid third-party dependencies, a minimal stdlib-only internal UUID module was added

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
