### PR TITLE
perf(tower): use static-str KeyValue for common HTTP method/scheme

### DIFF
--- a/opentelemetry-instrumentation-tower/benches/middleware.rs
+++ b/opentelemetry-instrumentation-tower/benches/middleware.rs
@@ -27,8 +27,13 @@
 //!
 //! ### Middleware-internal (optimizable by this crate)
 //!
-//! - **Heap allocations per request**: `scheme`, `method`, `path`, `URI`,
-//!   `protocol`, `version` each `to_string()` / `to_owned()` into a new `String`.
+//! - **Heap allocations per request**: `path`, `URI` and (for non-common
+//!   methods or schemes) the `method`/`scheme` strings still `to_string()`
+//!   / `to_owned()` into a new `String`. The `method` and `scheme` labels
+//!   are promoted to `&'static str` for the common HTTP methods
+//!   (GET/POST/PUT/DELETE/HEAD/OPTIONS/PATCH/CONNECT/TRACE) and the `http`
+//!   and `https` schemes, so the corresponding `KeyValue::clone()` is
+//!   allocation-free in the hot path.
 //! - **`Vec<KeyValue>` allocations**: `span_attributes` and `label_superset`
 //!   are built and populated on every request.
 //! - **Unconditional attribute extraction**: all `KeyValue` attributes are built
@@ -60,12 +65,12 @@
 //!
 //! | Scenario             | Median   | vs baseline |
 //! | -------------------- | -------- | ----------- |
-//! | baseline             |   47 ns  | —           |
-//! | noop                 |  867 ns  | +820 ns     |
-//! | tracing              | 1048 ns  | +1000 ns    |
-//! | tracing-sampled-out  |  913 ns  | +866 ns     |
-//! | metrics              | 1202 ns  | +1155 ns    |
-//! | tracing + metrics    | 1353 ns  | +1306 ns    |
+//! | baseline             |   44 ns  | —           |
+//! | noop                 |  568 ns  | +524 ns     |
+//! | tracing              |  708 ns  | +664 ns     |
+//! | tracing-sampled-out  |  592 ns  | +548 ns     |
+//! | metrics              |  895 ns  | +851 ns     |
+//! | tracing + metrics    | 1054 ns  | +1010 ns    |
 //!
 //! Captured on: MacBook Pro, Apple M4 Pro (10P + 4E cores), 24 GB RAM,
 //! macOS 26.4.1, rustc 1.95.0, OpenTelemetry 0.32.

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -561,6 +561,26 @@ struct RequestData {
     custom_request_attributes: Vec<KeyValue>,
 }
 
+/// Maps common HTTP methods to a `&'static str` so the resulting `KeyValue`
+/// stores the method as a static string (no heap allocation, allocation-free
+/// `KeyValue::clone()`). Returns `None` for custom/extension methods, which
+/// fall back to an owned `String`.
+#[inline]
+fn method_as_static(m: &http::Method) -> Option<&'static str> {
+    match *m {
+        http::Method::GET => Some("GET"),
+        http::Method::POST => Some("POST"),
+        http::Method::PUT => Some("PUT"),
+        http::Method::DELETE => Some("DELETE"),
+        http::Method::HEAD => Some("HEAD"),
+        http::Method::OPTIONS => Some("OPTIONS"),
+        http::Method::PATCH => Some("PATCH"),
+        http::Method::CONNECT => Some("CONNECT"),
+        http::Method::TRACE => Some("TRACE"),
+        _ => None,
+    }
+}
+
 struct RequestFinalization<ResExt> {
     request_data: RequestData,
     layer_state: Arc<HTTPLayerState>,
@@ -636,11 +656,21 @@ where
         let protocol_name_kv = KeyValue::new(NETWORK_PROTOCOL_NAME_LABEL, protocol);
         let protocol_version_kv = KeyValue::new(NETWORK_PROTOCOL_VERSION_LABEL, version);
 
-        let scheme = req.uri().scheme_str().unwrap_or("").to_string();
-        let url_scheme_kv = KeyValue::new(URL_SCHEME_LABEL, scheme);
+        // Promote the common "http"/"https" schemes to `&'static str` so the
+        // `KeyValue` is allocation-free and clones across metric label sets are cheap.
+        let url_scheme_kv = match req.uri().scheme_str() {
+            Some("http") => KeyValue::new(URL_SCHEME_LABEL, "http"),
+            Some("https") => KeyValue::new(URL_SCHEME_LABEL, "https"),
+            Some(other) => KeyValue::new(URL_SCHEME_LABEL, other.to_owned()),
+            None => KeyValue::new(URL_SCHEME_LABEL, ""),
+        };
 
+        // Same trick for well-known HTTP methods.
         let method = req.method().as_str().to_owned();
-        let method_kv = KeyValue::new(HTTP_REQUEST_METHOD_LABEL, method.clone());
+        let method_kv = match method_as_static(req.method()) {
+            Some(s) => KeyValue::new(HTTP_REQUEST_METHOD_LABEL, s),
+            None => KeyValue::new(HTTP_REQUEST_METHOD_LABEL, method.clone()),
+        };
 
         // Extract route using the configured extractor
         let route = self.route_extractor.extract_route(&req);


### PR DESCRIPTION
Use `&'static str` for the `http.request.method` and `url.scheme` `KeyValue`s when the value is one of the 9 standard HTTP methods or `http`/`https`. Custom methods and other schemes fall back to allocating as before.

Each of these `KeyValue`s is cloned 2–3 times per request (span attributes, the unconditional `http.server.active_requests` `UpDownCounter::add()` call, and the metrics label set). With `OtelString::Static`, those clones are just pointer copies instead of allocating a new `Box<str>` each time.

Measured on Apple M4 Pro, OTel 0.32, criterion median of 30 samples:

| Scenario | Before | After | Delta |
|---|---|---|---|
| noop | 705 ns | 569 ns | −19% |
| tracing | 825 ns | 689 ns | −16% |
| tracing-sampled-out | 726 ns | 590 ns | −19% |
| metrics | 1024 ns | 890 ns | −13% |
| tracing + metrics | 1243 ns | 1013 ns | −18% |

First of a planned two-part split; a follow-up will reduce `Vec<KeyValue>` allocations and clones inside `finalize_request`.
