### PR TITLE
fix(opentelemetry-aws): allow deprecated semconv constants from 0.32.1

### DIFF
--- a/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/cause_builder.rs
+++ b/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/cause_builder.rs
@@ -260,7 +260,11 @@ impl<'value> ValueBuilder<'value> for CauseBuilder<'value> {
 
 impl<'v> SpanAttributeProcessor<'v, 7> for CauseBuilder<'v> {
     const HANDLERS: [(&'static str, fn(&mut Self, &'v Value) -> bool); 7] = [
-        (semconv::RPC_SYSTEM, Self::rpc_system_is_aws_api),
+        (
+            #[allow(deprecated)]
+            semconv::RPC_SYSTEM,
+            Self::rpc_system_is_aws_api,
+        ),
         (semconv::TELEMETRY_SDK_LANGUAGE, Self::sdk_lang),
         (semconv::HTTP_STATUS_TEXT, Self::http_status_text),
         (

--- a/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/http_response_content_length_builder.rs
+++ b/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/http_response_content_length_builder.rs
@@ -57,7 +57,11 @@ impl<'value> ValueBuilder<'value> for HttpResponseContentLengthBuilder {
 
 impl<'v> SpanAttributeProcessor<'v, 2> for HttpResponseContentLengthBuilder {
     const HANDLERS: [(&'static str, fn(&mut Self, &'v Value) -> bool); 2] = [
-        (semconv::RPC_MESSAGE_TYPE, Self::message_type_is_received),
+        (
+            #[allow(deprecated)]
+            semconv::RPC_MESSAGE_TYPE,
+            Self::message_type_is_received,
+        ),
         (
             semconv::HTTP_RESPONSE_BODY_SIZE,
             Self::message_payload_size_bytes,

--- a/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/segment_name_builder.rs
+++ b/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/segment_name_builder.rs
@@ -119,10 +119,22 @@ impl<'value> ValueBuilder<'value> for SegmentNameBuilder<'value> {
 
 impl<'v> SpanAttributeProcessor<'v, 6> for SegmentNameBuilder<'v> {
     const HANDLERS: [(&'static str, fn(&mut Self, &'v Value) -> bool); 6] = [
-        (semconv::RPC_SYSTEM, Self::rpc_system_is_aws_api),
-        (semconv::PEER_SERVICE, Self::peer_service),
+        (
+            #[allow(deprecated)]
+            semconv::RPC_SYSTEM,
+            Self::rpc_system_is_aws_api,
+        ),
+        (
+            #[allow(deprecated)]
+            semconv::PEER_SERVICE,
+            Self::peer_service,
+        ),
         (semconv::AWS_SERVICE, Self::aws_service),
-        (semconv::RPC_SERVICE, Self::rpc_service),
+        (
+            #[allow(deprecated)]
+            semconv::RPC_SERVICE,
+            Self::rpc_service,
+        ),
         (semconv::DB_SERVICE, Self::db_service),
         (semconv::SERVICE_NAME, Self::service_name),
     ];

--- a/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/subsegment_namespace_builder.rs
+++ b/opentelemetry-aws/src/xray_exporter/translator/attribute_processing/value_builder/subsegment_namespace_builder.rs
@@ -64,7 +64,11 @@ impl<'value> ValueBuilder<'value> for SubsegmentNamespaceBuilder {
 }
 impl<'v> SpanAttributeProcessor<'v, 2> for SubsegmentNamespaceBuilder {
     const HANDLERS: [(&'static str, fn(&mut Self, &'v Value) -> bool); 2] = [
-        (semconv::RPC_SYSTEM, Self::rpc_system_is_aws_api),
+        (
+            #[allow(deprecated)]
+            semconv::RPC_SYSTEM,
+            Self::rpc_system_is_aws_api,
+        ),
         (semconv::AWS_SERVICE, Self::aws_service_is_some),
     ];
 }


### PR DESCRIPTION
`opentelemetry-semantic-conventions 0.32.1` deprecates `RPC_SYSTEM`, `RPC_MESSAGE_TYPE`, `PEER_SERVICE`, and `RPC_SERVICE`. The workspace pins `"0.32"`, so the patch is picked up automatically and breaks `clippy -D warnings` on `opentelemetry-aws` (currently failing CI on every PR).

Adds `#[allow(deprecated)]` per usage, matching the existing pattern for `HTTP_STATUS_CODE`. Not switching to renamed constants — that would change which attribute names the X-Ray exporter recognizes and is a separate behavior change.