### PR TITLE
chore: Standardize README badges across crates

### DIFF
--- a/opentelemetry-aws/README.md
+++ b/opentelemetry-aws/README.md
@@ -13,8 +13,6 @@ Additional types for exporting [`OpenTelemetry`] data to AWS.
 
 [![Crates.io: opentelemetry-aws](https://img.shields.io/crates/v/opentelemetry-aws.svg)](https://crates.io/crates/opentelemetry-aws)
 [![Documentation](https://docs.rs/opentelemetry-aws/badge.svg)](https://docs.rs/opentelemetry-aws)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-aws)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview

--- a/opentelemetry-contrib/README.md
+++ b/opentelemetry-contrib/README.md
@@ -13,8 +13,6 @@ Community supported vendor integrations for applications instrumented with [`Ope
 
 [![Crates.io: opentelemetry-contrib](https://img.shields.io/crates/v/opentelemetry-contrib.svg)](https://crates.io/crates/opentelemetry-contrib)
 [![Documentation](https://docs.rs/opentelemetry-contrib/badge.svg)](https://docs.rs/opentelemetry-contrib)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-contrib)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview

--- a/opentelemetry-datadog/README.md
+++ b/opentelemetry-datadog/README.md
@@ -24,8 +24,6 @@ Community supported vendor integrations for applications instrumented with [`Ope
 
 [![Crates.io: opentelemetry-datadog](https://img.shields.io/crates/v/opentelemetry-datadog.svg)](https://crates.io/crates/opentelemetry-datadog)
 [![Documentation](https://docs.rs/opentelemetry-datadog/badge.svg)](https://docs.rs/opentelemetry-datadog)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-datadog)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview

--- a/opentelemetry-etw-logs/README.md
+++ b/opentelemetry-etw-logs/README.md
@@ -21,8 +21,6 @@ captured by agents running locally and listening for specific ETW events.
 
 [![Crates.io: opentelemetry-etw-logs](https://img.shields.io/crates/v/opentelemetry-etw-logs.svg)](https://crates.io/crates/opentelemetry-etw-logs)
 [![Documentation](https://docs.rs/opentelemetry-etw-logs/badge.svg)](https://docs.rs/opentelemetry-etw-logs)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-etw-logs)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Viewing ETW Logs

--- a/opentelemetry-etw-metrics/README.md
+++ b/opentelemetry-etw-metrics/README.md
@@ -21,8 +21,6 @@ captured by agents running locally and listening for specific ETW events.
 
 [![Crates.io: opentelemetry-etw-metrics](https://img.shields.io/crates/v/opentelemetry-etw-metrics.svg)](https://crates.io/crates/opentelemetry-etw-metrics)
 [![Documentation](https://docs.rs/opentelemetry-etw-metrics/badge.svg)](https://docs.rs/opentelemetry-etw-metrics)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-etw-metrics)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Viewing ETW Metrics

--- a/opentelemetry-etw-traces/README.md
+++ b/opentelemetry-etw-traces/README.md
@@ -22,6 +22,10 @@ captured by agents running locally and listening for specific ETW events.
 Spans are encoded following the [Microsoft Common Schema v4.0](https://learn.microsoft.com/en-us/opentelemetry/common-schema) format using
 [TraceLogging Dynamic](https://crates.io/crates/tracelogging_dynamic).
 
+[![Crates.io: opentelemetry-etw-traces](https://img.shields.io/crates/v/opentelemetry-etw-traces.svg)](https://crates.io/crates/opentelemetry-etw-traces)
+[![Documentation](https://docs.rs/opentelemetry-etw-traces/badge.svg)](https://docs.rs/opentelemetry-etw-traces)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
+
 ## Viewing ETW Traces
 
 Traces exported to ETW can be viewed using tools like `logman`, `perfview` etc.

--- a/opentelemetry-instrumentation-actix-web/README.md
+++ b/opentelemetry-instrumentation-actix-web/README.md
@@ -13,8 +13,6 @@
 
 [![Crates.io: opentelemetry-instrumentation-actix-web](https://img.shields.io/crates/v/opentelemetry-instrumentation-actix-web.svg)](https://crates.io/crates/opentelemetry-instrumentation-actix-web)
 [![Documentation](https://docs.rs/opentelemetry-instrumentation-actix-web/badge.svg)](https://docs.rs/opentelemetry-instrumentation-actix-web)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-instrumentation-actix-web)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ### Exporter configuration

--- a/opentelemetry-instrumentation-tower/README.md
+++ b/opentelemetry-instrumentation-tower/README.md
@@ -13,6 +13,10 @@ OpenTelemetry HTTP Metrics and Tracing Middleware for Tower-compatible Rust HTTP
 
 This middleware provides both metrics and distributed tracing for HTTP requests, following OpenTelemetry semantic conventions.
 
+[![Crates.io: opentelemetry-instrumentation-tower](https://img.shields.io/crates/v/opentelemetry-instrumentation-tower.svg)](https://crates.io/crates/opentelemetry-instrumentation-tower)
+[![Documentation](https://docs.rs/opentelemetry-instrumentation-tower/badge.svg)](https://docs.rs/opentelemetry-instrumentation-tower)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
+
 ## Features
 
 - **HTTP Metrics**: Request duration, active requests, request/response body sizes

--- a/opentelemetry-resource-detectors/README.md
+++ b/opentelemetry-resource-detectors/README.md
@@ -13,8 +13,6 @@ Community supported Resource detectors implementations for applications instrume
 
 [![Crates.io: opentelemetry-resource-detectors](https://img.shields.io/crates/v/opentelemetry-resource-detectors.svg)](https://crates.io/crates/opentelemetry-resource-detectors)
 [![Documentation](https://docs.rs/opentelemetry-resource-detectors/badge.svg)](https://docs.rs/opentelemetry-resource-detectors)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-resource-detectors)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview

--- a/opentelemetry-stackdriver/README.md
+++ b/opentelemetry-stackdriver/README.md
@@ -24,8 +24,6 @@ Contributions are welcome.
 
 [![Crates.io: opentelemetry-stackdriver](https://img.shields.io/crates/v/opentelemetry-stackdriver.svg)](https://crates.io/crates/opentelemetry-stackdriver)
 [![Documentation](https://docs.rs/opentelemetry-stackdriver/badge.svg)](https://docs.rs/opentelemetry-stackdriver)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-stackdriver)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Propagator

--- a/opentelemetry-user-events-logs/README.md
+++ b/opentelemetry-user-events-logs/README.md
@@ -28,8 +28,6 @@ This user_events exporter enables applications to use OpenTelemetry API to captu
 
 [![Crates.io: opentelemetry-user-events-logs](https://img.shields.io/crates/v/opentelemetry-user-events-logs.svg)](https://crates.io/crates/opentelemetry-user-events-logs)
 [![Documentation](https://docs.rs/opentelemetry-user-events-logs/badge.svg)](https://docs.rs/opentelemetry-user-events-logs)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-user-events-logs)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## OpenTelemetry Overview

--- a/opentelemetry-user-events-metrics/README.md
+++ b/opentelemetry-user-events-metrics/README.md
@@ -28,8 +28,6 @@ This kernel feature is supported started in Linux kernel 5.18 onwards. The featu
 
 [![Crates.io: opentelemetry-user-events-metrics](https://img.shields.io/crates/v/opentelemetry-user-events-metrics.svg)](https://crates.io/crates/opentelemetry-user-events-metrics)
 [![Documentation](https://docs.rs/opentelemetry-user-events-metrics/badge.svg)](https://docs.rs/opentelemetry-user-events-metrics)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-user-events-metrics)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## OpenTelemetry Overview

--- a/opentelemetry-user-events-trace/README.md
+++ b/opentelemetry-user-events-trace/README.md
@@ -28,8 +28,6 @@ This user_events exporter enables applications to use OpenTelemetry API to captu
 
 [![Crates.io: opentelemetry-user-events-trace](https://img.shields.io/crates/v/opentelemetry-user-events-trace.svg)](https://crates.io/crates/opentelemetry-user-events-trace)
 [![Documentation](https://docs.rs/opentelemetry-user-events-trace/badge.svg)](https://docs.rs/opentelemetry-user-events-trace)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-user-events-trace)](./LICENSE)
-[![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust-contrib/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust-contrib/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## OpenTelemetry Overview


### PR DESCRIPTION
Unifies the badge block in every crate README to: `crates.io` version, `docs.rs`, Slack.

- Removes the `LICENSE` badge — its `./LICENSE` target 404'd (no per-crate license file). License info is also surfaced on crates.io via the `license` field in `Cargo.toml`.
- Removes the per-crate `GitHub Actions CI` badge — CI is repo-wide, so the same badge was duplicated across 11 READMEs.
- Adds the standard 3-badge block to `opentelemetry-etw-traces` and `opentelemetry-instrumentation-tower`, which had none.