### PR TITLE
perf(tower): consume RequestData in finalize_request, pre-size label vec

### DIFF
--- a/opentelemetry-instrumentation-tower/benches/middleware.rs
+++ b/opentelemetry-instrumentation-tower/benches/middleware.rs
@@ -34,8 +34,11 @@
 //!   (GET/POST/PUT/DELETE/HEAD/OPTIONS/PATCH/CONNECT/TRACE) and the `http`
 //!   and `https` schemes, so the corresponding `KeyValue::clone()` is
 //!   allocation-free in the hot path.
-//! - **`Vec<KeyValue>` allocations**: `span_attributes` and `label_superset`
-//!   are built and populated on every request.
+//! - **`Vec<KeyValue>` allocations**: `span_attributes` is still built per
+//!   request. `label_superset` (the metric label set) is pre-sized to its
+//!   final capacity and ownership of the per-request `KeyValue`s is moved
+//!   into it instead of being cloned, so it only allocates its backing
+//!   buffer.
 //! - **Unconditional attribute extraction**: all `KeyValue` attributes are built
 //!   on every request without first checking whether the tracer or meter are
 //!   no-ops.
@@ -65,12 +68,12 @@
 //!
 //! | Scenario             | Median   | vs baseline |
 //! | -------------------- | -------- | ----------- |
-//! | baseline             |   44 ns  | —           |
-//! | noop                 |  568 ns  | +524 ns     |
-//! | tracing              |  708 ns  | +664 ns     |
-//! | tracing-sampled-out  |  592 ns  | +548 ns     |
-//! | metrics              |  895 ns  | +851 ns     |
-//! | tracing + metrics    | 1054 ns  | +1010 ns    |
+//! | baseline             |   53 ns  | —           |
+//! | noop                 |  559 ns  | +506 ns     |
+//! | tracing              |  680 ns  | +627 ns     |
+//! | tracing-sampled-out  |  581 ns  | +528 ns     |
+//! | metrics              |  855 ns  | +802 ns     |
+//! | tracing + metrics    |  970 ns  | +917 ns     |
 //!
 //! Captured on: MacBook Pro, Apple M4 Pro (10P + 4E cores), 24 GB RAM,
 //! macOS 26.4.1, rustc 1.95.0, OpenTelemetry 0.32.

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -616,7 +616,7 @@ where
         if let Some(fin) = this.finalization.take() {
             finalize_request(
                 &result,
-                &fin.request_data,
+                fin.request_data,
                 &fin.layer_state,
                 &fin.response_extractor,
             );
@@ -760,7 +760,7 @@ where
 /// Finalizes the request by updating the span and recording metrics after the response is received.
 fn finalize_request<ResBody, E, ResExt>(
     result: &result::Result<http::Response<ResBody>, E>,
-    request_data: &RequestData,
+    request_data: RequestData,
     layer_state: &Arc<HTTPLayerState>,
     response_extractor: &ResExt,
 ) where
@@ -768,40 +768,31 @@ fn finalize_request<ResBody, E, ResExt>(
     ResExt: ResponseAttributeExtractor<ResBody>,
     E: std::fmt::Debug,
 {
+    let RequestData {
+        duration_start,
+        req_body_size,
+        protocol_name_kv,
+        protocol_version_kv,
+        url_scheme_kv,
+        method_kv,
+        route_kv_opt,
+        custom_request_attributes,
+    } = request_data;
+
     let cx = OtelContext::current();
     let span = cx.span();
 
     match result {
         Ok(response) => {
             let status = response.status();
+            let status_code_kv =
+                KeyValue::new(HTTP_RESPONSE_STATUS_CODE_LABEL, i64::from(status.as_u16()));
 
-            // Build base label set
-            let mut label_superset = vec![
-                request_data.protocol_name_kv.clone(),
-                request_data.protocol_version_kv.clone(),
-                request_data.url_scheme_kv.clone(),
-                request_data.method_kv.clone(),
-                KeyValue::new(HTTP_RESPONSE_STATUS_CODE_LABEL, i64::from(status.as_u16())),
-            ];
-
-            if let Some(route_kv) = &request_data.route_kv_opt {
-                label_superset.push(route_kv.clone());
-            }
-
-            // Add custom request attributes
-            label_superset.extend(request_data.custom_request_attributes.clone());
-
-            // Extract and add custom response attributes
+            // Extract custom response attributes (empty/non-allocating for NoOp).
             let custom_response_attributes = response_extractor.extract_attributes(response);
-            label_superset.extend(custom_response_attributes.clone());
 
             // Update span
-            span.set_attribute(KeyValue::new(
-                semconv::trace::HTTP_RESPONSE_STATUS_CODE,
-                status.as_u16() as i64,
-            ));
-
-            // Add custom response attributes to span
+            span.set_attribute(status_code_kv.clone());
             for attr in &custom_response_attributes {
                 span.set_attribute(attr.clone());
             }
@@ -813,13 +804,32 @@ fn finalize_request<ResBody, E, ResExt>(
                 });
             }
 
-            // Record metrics
-            layer_state.server_request_duration.record(
-                request_data.duration_start.elapsed().as_secs_f64(),
-                &label_superset,
-            );
+            // Build label superset by moving owned values where possible.
+            // `url_scheme_kv` and `method_kv` are cloned for the active-requests
+            // decrement; their underlying strings are typically `&'static str`
+            // so the clones are allocation-free.
+            let cap = 5
+                + route_kv_opt.is_some() as usize
+                + custom_request_attributes.len()
+                + custom_response_attributes.len();
+            let mut label_superset = Vec::with_capacity(cap);
+            label_superset.push(protocol_name_kv);
+            label_superset.push(protocol_version_kv);
+            label_superset.push(url_scheme_kv.clone());
+            label_superset.push(method_kv.clone());
+            label_superset.push(status_code_kv);
+            if let Some(route_kv) = route_kv_opt {
+                label_superset.push(route_kv);
+            }
+            // Move (not clone) the custom attribute Vecs into the label set.
+            label_superset.extend(custom_request_attributes);
+            label_superset.extend(custom_response_attributes);
 
-            if let Some(req_content_length) = request_data.req_body_size {
+            layer_state
+                .server_request_duration
+                .record(duration_start.elapsed().as_secs_f64(), &label_superset);
+
+            if let Some(req_content_length) = req_body_size {
                 layer_state
                     .server_request_body_size
                     .record(req_content_length, &label_superset);
@@ -830,6 +840,10 @@ fn finalize_request<ResBody, E, ResExt>(
                     .server_response_body_size
                     .record(resp_content_length, &label_superset);
             }
+
+            layer_state
+                .server_active_requests
+                .add(-1, &[url_scheme_kv, method_kv]);
         }
         Err(error) => {
             // Mark span as error
@@ -837,29 +851,23 @@ fn finalize_request<ResBody, E, ResExt>(
                 description: format!("{:?}", error).into(),
             });
 
-            // Still record duration metric with error label
-            let label_superset = vec![
-                request_data.protocol_name_kv.clone(),
-                request_data.protocol_version_kv.clone(),
-                request_data.url_scheme_kv.clone(),
-                request_data.method_kv.clone(),
+            // Still record duration metric (without status code).
+            let label_superset = [
+                protocol_name_kv,
+                protocol_version_kv,
+                url_scheme_kv.clone(),
+                method_kv.clone(),
             ];
 
-            layer_state.server_request_duration.record(
-                request_data.duration_start.elapsed().as_secs_f64(),
-                &label_superset,
-            );
+            layer_state
+                .server_request_duration
+                .record(duration_start.elapsed().as_secs_f64(), &label_superset);
+
+            layer_state
+                .server_active_requests
+                .add(-1, &[url_scheme_kv, method_kv]);
         }
     }
-
-    // Always decrement active requests counter
-    layer_state.server_active_requests.add(
-        -1,
-        &[
-            request_data.url_scheme_kv.clone(),
-            request_data.method_kv.clone(),
-        ],
-    );
 }
 
 fn split_and_format_protocol_version(http_version: http::Version) -> (&'static str, &'static str) {

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -687,13 +687,13 @@ where
         let this = self.project();
         let _guard = this.otel_cx.clone().attach();
         let result = std::task::ready!(this.inner.poll(cx));
-        if let Some(fin) = this.finalization.take() {
-            finalize_request(
-                &result,
-                fin.request_data,
-                &fin.layer_state,
-                &fin.response_extractor,
-            );
+        if let Some(RequestFinalization {
+            request_data,
+            layer_state,
+            response_extractor,
+        }) = this.finalization.take()
+        {
+            finalize_request(&result, request_data, &layer_state, &response_extractor);
         }
         Poll::Ready(result)
     }


### PR DESCRIPTION
Consumes `RequestData` by value in `finalize_request` so per-request `KeyValue`s and the two custom-attr `Vec`s can be moved into the metric label set instead of cloned. `label_superset` is pre-sized with `Vec::with_capacity(...)`, and the error-path label set uses a stack array.

No behavior change — same metric labels, same span attributes, same span status. `test_metrics_labels` covers the exact attribute sets and still passes.

Measured on Apple M4 Pro, OTel 0.32, criterion median of 30 samples, two runs averaged, against current `main` (already includes #671):

| Scenario             | Before  | After  | Delta             |
|----------------------|---------|--------|-------------------|
| noop                 | 586 ns  | 559 ns | −5%               |
| tracing              | 683 ns  | 680 ns | not significant   |
| tracing-sampled-out  | 590 ns  | 581 ns | −2% to −4%        |
| metrics              | 931 ns  | 855 ns | **−7% to −9%**    |
| tracing + metrics    | 1023 ns | 970 ns | **−5% to −8%**    |

Tracing-only is unchanged because the no-op meter never builds the label `Vec` to begin with.
