### PR TITLE
feat(tower): add gRPC instrumentation layer

### DIFF
--- a/opentelemetry-instrumentation-tower/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/Cargo.toml
@@ -30,8 +30,11 @@ tower-layer = { version = "0.3", default-features = false }
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 http-body-util = { version = "0.1", default-features = false }
+opentelemetry-proto = { workspace = true, features = ["gen-tonic", "trace"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "trace", "testing"] }
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "net", "rt", "rt-multi-thread", "sync"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { version = "0.14.1", default-features = false, features = ["router", "transport"] }
 tower = { version = "0.5", features = ["util"] }
 tower-test = { version = "0.4" }
 

--- a/opentelemetry-instrumentation-tower/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/Cargo.toml
@@ -29,6 +29,7 @@ tower-layer = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+http-body-util = { version = "0.1", default-features = false }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "trace", "testing"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }

--- a/opentelemetry-instrumentation-tower/benches/middleware.rs
+++ b/opentelemetry-instrumentation-tower/benches/middleware.rs
@@ -77,8 +77,11 @@
 //!
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use http_body_util::{BodyExt, Empty};
 use opentelemetry::global;
+use opentelemetry::metrics::noop::NoopMeterProvider;
 use opentelemetry::trace::noop::NoopTracerProvider;
+use opentelemetry_instrumentation_tower::grpc::GRPCLayerBuilder;
 use opentelemetry_instrumentation_tower::HTTPLayerBuilder;
 use opentelemetry_sdk::{
     metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider},
@@ -94,6 +97,19 @@ async fn handler(_req: http::Request<String>) -> Result<http::Response<String>, 
     Ok(http::Response::new(String::new()))
 }
 
+/// Minimal gRPC handler — returns an empty HTTP/2 gRPC response.
+async fn grpc_handler(
+    _req: http::Request<Empty<&'static [u8]>>,
+) -> Result<http::Response<Empty<&'static [u8]>>, Infallible> {
+    Ok(http::Response::builder()
+        .status(http::StatusCode::OK)
+        .version(http::Version::HTTP_2)
+        .header("content-type", "application/grpc")
+        .header("grpc-status", "0")
+        .body(Empty::new())
+        .unwrap())
+}
+
 /// Build requests outside the timed loop so request construction cost does not
 /// inflate the middleware overhead measurement.
 fn build_requests(n: u64) -> Vec<http::Request<String>> {
@@ -103,6 +119,23 @@ fn build_requests(n: u64) -> Vec<http::Request<String>> {
                 .method("GET")
                 .uri("http://example.com/users/123")
                 .body(String::new())
+                .unwrap()
+        })
+        .collect()
+}
+
+/// Build gRPC-shaped HTTP/2 requests outside the timed loop so request construction
+/// cost does not inflate the middleware overhead measurement.
+fn build_grpc_requests(n: u64) -> Vec<http::Request<Empty<&'static [u8]>>> {
+    (0..n)
+        .map(|_| {
+            http::Request::builder()
+                .method("POST")
+                .uri("http://example.com/package.Service/GetThing")
+                .version(http::Version::HTTP_2)
+                .header("content-type", "application/grpc")
+                .header("te", "trailers")
+                .body(Empty::new())
                 .unwrap()
         })
         .collect()
@@ -130,6 +163,10 @@ fn setup_sampled_out_tracer() -> SdkTracerProvider {
 /// Call this in scenarios that should not generate traces.
 fn noop_tracer() {
     global::set_tracer_provider(NoopTracerProvider::new());
+}
+
+fn noop_meter() {
+    global::set_meter_provider(NoopMeterProvider::new());
 }
 
 /// Setup meter provider with in-memory exporter (minimal I/O overhead)
@@ -282,6 +319,150 @@ fn benchmark_middleware(c: &mut Criterion) {
     });
 
     group.finish();
+
+    let mut grpc_group = c.benchmark_group("tower-grpc-instrumentation");
+    grpc_group.throughput(Throughput::Elements(1));
+
+    grpc_group.bench_function(BenchmarkId::new("request", "baseline"), |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut service = tower::service_fn(grpc_handler);
+            let requests = build_grpc_requests(iters);
+
+            let start = std::time::Instant::now();
+            for req in requests {
+                let resp = service.ready().await.unwrap().call(req).await.unwrap();
+                let body = resp.into_body().collect().await.unwrap();
+                black_box(body);
+            }
+            start.elapsed()
+        });
+    });
+
+    grpc_group.bench_function(BenchmarkId::new("request", "noop"), |b| {
+        noop_tracer();
+        noop_meter();
+        let layer = GRPCLayerBuilder::builder().build();
+        b.to_async(&rt).iter_custom(|iters| {
+            let layer = layer.clone();
+            async move {
+                let mut service = ServiceBuilder::new()
+                    .layer(layer)
+                    .service(tower::service_fn(grpc_handler));
+                let requests = build_grpc_requests(iters);
+
+                let start = std::time::Instant::now();
+                for req in requests {
+                    let resp = service.ready().await.unwrap().call(req).await.unwrap();
+                    let body = resp.into_body().collect().await.unwrap();
+                    black_box(body);
+                }
+                start.elapsed()
+            }
+        });
+    });
+
+    grpc_group.bench_function(BenchmarkId::new("request", "tracing"), |b| {
+        let tracer_provider = setup_tracer();
+        noop_meter();
+        let layer = GRPCLayerBuilder::builder()
+            .with_tracer_provider(tracer_provider)
+            .build();
+        b.to_async(&rt).iter_custom(|iters| {
+            let layer = layer.clone();
+            async move {
+                let mut service = ServiceBuilder::new()
+                    .layer(layer)
+                    .service(tower::service_fn(grpc_handler));
+                let requests = build_grpc_requests(iters);
+
+                let start = std::time::Instant::now();
+                for req in requests {
+                    let resp = service.ready().await.unwrap().call(req).await.unwrap();
+                    let body = resp.into_body().collect().await.unwrap();
+                    black_box(body);
+                }
+                start.elapsed()
+            }
+        });
+    });
+
+    grpc_group.bench_function(BenchmarkId::new("request", "tracing-sampled-out"), |b| {
+        let tracer_provider = setup_sampled_out_tracer();
+        noop_meter();
+        let layer = GRPCLayerBuilder::builder()
+            .with_tracer_provider(tracer_provider)
+            .build();
+        b.to_async(&rt).iter_custom(|iters| {
+            let layer = layer.clone();
+            async move {
+                let mut service = ServiceBuilder::new()
+                    .layer(layer)
+                    .service(tower::service_fn(grpc_handler));
+                let requests = build_grpc_requests(iters);
+
+                let start = std::time::Instant::now();
+                for req in requests {
+                    let resp = service.ready().await.unwrap().call(req).await.unwrap();
+                    let body = resp.into_body().collect().await.unwrap();
+                    black_box(body);
+                }
+                start.elapsed()
+            }
+        });
+    });
+
+    grpc_group.bench_function(BenchmarkId::new("request", "metrics"), |b| {
+        noop_tracer();
+        let (meter_provider, _metric_exporter) = setup_meter();
+        let layer = GRPCLayerBuilder::builder()
+            .with_meter_provider(meter_provider)
+            .build();
+        b.to_async(&rt).iter_custom(|iters| {
+            let layer = layer.clone();
+            async move {
+                let mut service = ServiceBuilder::new()
+                    .layer(layer)
+                    .service(tower::service_fn(grpc_handler));
+                let requests = build_grpc_requests(iters);
+
+                let start = std::time::Instant::now();
+                for req in requests {
+                    let resp = service.ready().await.unwrap().call(req).await.unwrap();
+                    let body = resp.into_body().collect().await.unwrap();
+                    black_box(body);
+                }
+                start.elapsed()
+            }
+        });
+    });
+
+    grpc_group.bench_function(BenchmarkId::new("request", "tracing+metrics"), |b| {
+        let tracer_provider = setup_tracer();
+        let (meter_provider, _metric_exporter) = setup_meter();
+        let layer = GRPCLayerBuilder::builder()
+            .with_tracer_provider(tracer_provider)
+            .with_meter_provider(meter_provider)
+            .build();
+        b.to_async(&rt).iter_custom(|iters| {
+            let layer = layer.clone();
+            async move {
+                let mut service = ServiceBuilder::new()
+                    .layer(layer)
+                    .service(tower::service_fn(grpc_handler));
+                let requests = build_grpc_requests(iters);
+
+                let start = std::time::Instant::now();
+                for req in requests {
+                    let resp = service.ready().await.unwrap().call(req).await.unwrap();
+                    let body = resp.into_body().collect().await.unwrap();
+                    black_box(body);
+                }
+                start.elapsed()
+            }
+        });
+    });
+
+    grpc_group.finish();
 }
 
 criterion_group!(benches, benchmark_middleware);

--- a/opentelemetry-instrumentation-tower/examples/grpc.rs
+++ b/opentelemetry-instrumentation-tower/examples/grpc.rs
@@ -1,14 +1,17 @@
 use std::convert::Infallible;
 
 use http::{Request, Response, StatusCode};
+use http_body_util::Empty;
 use opentelemetry_instrumentation_tower::grpc::GRPCLayerBuilder;
 use tower::{Service, ServiceBuilder, ServiceExt};
 
-async fn grpc_handler(_req: Request<String>) -> Result<Response<String>, Infallible> {
+async fn grpc_handler(
+    _req: Request<Empty<&'static [u8]>>,
+) -> Result<Response<Empty<&'static [u8]>>, Infallible> {
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header("grpc-status", "0")
-        .body(String::new())
+        .body(Empty::new())
         .unwrap())
 }
 
@@ -22,7 +25,7 @@ async fn main() {
     let request = Request::builder()
         .method("POST")
         .uri("http://example.com/example.Greeter/SayHello")
-        .body(String::new())
+        .body(Empty::new())
         .unwrap();
 
     let _response = service.ready().await.unwrap().call(request).await.unwrap();

--- a/opentelemetry-instrumentation-tower/examples/grpc.rs
+++ b/opentelemetry-instrumentation-tower/examples/grpc.rs
@@ -1,0 +1,29 @@
+use std::convert::Infallible;
+
+use http::{Request, Response, StatusCode};
+use opentelemetry_instrumentation_tower::grpc::GRPCLayerBuilder;
+use tower::{Service, ServiceBuilder, ServiceExt};
+
+async fn grpc_handler(_req: Request<String>) -> Result<Response<String>, Infallible> {
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("grpc-status", "0")
+        .body(String::new())
+        .unwrap())
+}
+
+#[tokio::main]
+async fn main() {
+    let layer = GRPCLayerBuilder::builder().build();
+    let mut service = ServiceBuilder::new()
+        .layer(layer)
+        .service(tower::service_fn(grpc_handler));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("http://example.com/example.Greeter/SayHello")
+        .body(String::new())
+        .unwrap();
+
+    let _response = service.ready().await.unwrap().call(request).await.unwrap();
+}

--- a/opentelemetry-instrumentation-tower/examples/grpc.rs
+++ b/opentelemetry-instrumentation-tower/examples/grpc.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use http::{Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, Version};
 use http_body_util::Empty;
 use opentelemetry_instrumentation_tower::grpc::GRPCLayerBuilder;
 use tower::{Service, ServiceBuilder, ServiceExt};
@@ -10,6 +10,8 @@ async fn grpc_handler(
 ) -> Result<Response<Empty<&'static [u8]>>, Infallible> {
     Ok(Response::builder()
         .status(StatusCode::OK)
+        .version(Version::HTTP_2)
+        .header("content-type", "application/grpc")
         .header("grpc-status", "0")
         .body(Empty::new())
         .unwrap())
@@ -25,6 +27,9 @@ async fn main() {
     let request = Request::builder()
         .method("POST")
         .uri("http://example.com/example.Greeter/SayHello")
+        .version(Version::HTTP_2)
+        .header("content-type", "application/grpc")
+        .header("te", "trailers")
         .body(Empty::new())
         .unwrap();
 

--- a/opentelemetry-instrumentation-tower/src/grpc.rs
+++ b/opentelemetry-instrumentation-tower/src/grpc.rs
@@ -24,43 +24,6 @@ const OTEL_DEFAULT_RPC_SERVER_DURATION_BOUNDS: [f64; 14] = [
     0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
 ];
 
-/// Extracts a fully-qualified gRPC method from an HTTP request.
-pub trait GRPCMethodExtractor<B>: Clone + Send + Sync + 'static {
-    /// Returns the `rpc.method` value when available.
-    fn extract_method(&self, req: &http::Request<B>) -> Option<String>;
-}
-
-/// Extracts the gRPC method from paths shaped like `/package.Service/Method`.
-#[derive(Clone, Default)]
-pub struct DefaultGRPCMethodExtractor;
-
-impl<B> GRPCMethodExtractor<B> for DefaultGRPCMethodExtractor {
-    fn extract_method(&self, req: &http::Request<B>) -> Option<String> {
-        parse_grpc_path(req.uri().path()).map(str::to_owned)
-    }
-}
-
-/// A function-based gRPC method extractor.
-#[derive(Clone)]
-pub struct FnGRPCMethodExtractor<F> {
-    extractor: F,
-}
-
-impl<F> FnGRPCMethodExtractor<F> {
-    pub fn new(extractor: F) -> Self {
-        Self { extractor }
-    }
-}
-
-impl<F, B> GRPCMethodExtractor<B> for FnGRPCMethodExtractor<F>
-where
-    F: Fn(&http::Request<B>) -> Option<String> + Clone + Send + Sync + 'static,
-{
-    fn extract_method(&self, req: &http::Request<B>) -> Option<String> {
-        (self.extractor)(req)
-    }
-}
-
 /// Trait for extracting custom attributes from gRPC requests.
 pub trait GRPCRequestAttributeExtractor<B>: Clone + Send + Sync + 'static {
     fn extract_attributes(&self, req: &http::Request<B>) -> Vec<KeyValue>;
@@ -136,14 +99,8 @@ struct GRPCLayerState {
 
 #[derive(Clone)]
 /// [`Service`] used by [`GRPCLayer`].
-pub struct GRPCService<
-    S,
-    MethodExt = DefaultGRPCMethodExtractor,
-    ReqExt = NoOpGRPCExtractor,
-    ResExt = NoOpGRPCExtractor,
-> {
+pub struct GRPCService<S, ReqExt = NoOpGRPCExtractor, ResExt = NoOpGRPCExtractor> {
     state: Arc<GRPCLayerState>,
-    method_extractor: MethodExt,
     request_extractor: ReqExt,
     response_extractor: ResExt,
     inner_service: S,
@@ -152,13 +109,8 @@ pub struct GRPCService<
 
 #[derive(Clone)]
 /// [`Layer`] which applies OpenTelemetry gRPC server metrics and tracing middleware.
-pub struct GRPCLayer<
-    MethodExt = DefaultGRPCMethodExtractor,
-    ReqExt = NoOpGRPCExtractor,
-    ResExt = NoOpGRPCExtractor,
-> {
+pub struct GRPCLayer<ReqExt = NoOpGRPCExtractor, ResExt = NoOpGRPCExtractor> {
     state: Arc<GRPCLayerState>,
-    method_extractor: MethodExt,
     request_extractor: ReqExt,
     response_extractor: ResExt,
     tracer: Arc<BoxedTracer>,
@@ -178,15 +130,10 @@ impl Default for GRPCLayer {
 }
 
 /// Builder for [`GRPCLayer`].
-pub struct GRPCLayerBuilder<
-    MethodExt = DefaultGRPCMethodExtractor,
-    ReqExt = NoOpGRPCExtractor,
-    ResExt = NoOpGRPCExtractor,
-> {
+pub struct GRPCLayerBuilder<ReqExt = NoOpGRPCExtractor, ResExt = NoOpGRPCExtractor> {
     tracer: Option<Arc<BoxedTracer>>,
     meter: Option<Meter>,
     duration_bounds: Option<Vec<f64>>,
-    method_extractor: MethodExt,
     request_extractor: ReqExt,
     response_extractor: ResExt,
 }
@@ -197,45 +144,18 @@ impl GRPCLayerBuilder {
             tracer: None,
             meter: None,
             duration_bounds: Some(Vec::from(OTEL_DEFAULT_RPC_SERVER_DURATION_BOUNDS)),
-            method_extractor: DefaultGRPCMethodExtractor,
             request_extractor: NoOpGRPCExtractor,
             response_extractor: NoOpGRPCExtractor,
         }
     }
 }
 
-impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
-    /// Set a custom gRPC method extractor.
-    pub fn with_method_extractor<NewMethodExt>(
-        self,
-        extractor: NewMethodExt,
-    ) -> GRPCLayerBuilder<NewMethodExt, ReqExt, ResExt> {
-        GRPCLayerBuilder {
-            tracer: self.tracer,
-            meter: self.meter,
-            duration_bounds: self.duration_bounds,
-            method_extractor: extractor,
-            request_extractor: self.request_extractor,
-            response_extractor: self.response_extractor,
-        }
-    }
-
-    /// Convenience method to set a function-based gRPC method extractor.
-    pub fn with_method_extractor_fn<F, B>(
-        self,
-        f: F,
-    ) -> GRPCLayerBuilder<FnGRPCMethodExtractor<F>, ReqExt, ResExt>
-    where
-        F: Fn(&http::Request<B>) -> Option<String> + Clone + Send + Sync + 'static,
-    {
-        self.with_method_extractor(FnGRPCMethodExtractor::new(f))
-    }
-
+impl<ReqExt, ResExt> GRPCLayerBuilder<ReqExt, ResExt> {
     /// Set a request attribute extractor.
     pub fn with_request_extractor<NewReqExt, B>(
         self,
         extractor: NewReqExt,
-    ) -> GRPCLayerBuilder<MethodExt, NewReqExt, ResExt>
+    ) -> GRPCLayerBuilder<NewReqExt, ResExt>
     where
         NewReqExt: GRPCRequestAttributeExtractor<B>,
     {
@@ -243,7 +163,6 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
             tracer: self.tracer,
             meter: self.meter,
             duration_bounds: self.duration_bounds,
-            method_extractor: self.method_extractor,
             request_extractor: extractor,
             response_extractor: self.response_extractor,
         }
@@ -253,7 +172,7 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
     pub fn with_request_extractor_fn<F, B>(
         self,
         f: F,
-    ) -> GRPCLayerBuilder<MethodExt, FnGRPCRequestExtractor<F>, ResExt>
+    ) -> GRPCLayerBuilder<FnGRPCRequestExtractor<F>, ResExt>
     where
         F: Fn(&http::Request<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
     {
@@ -264,7 +183,7 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
     pub fn with_response_extractor<NewResExt, B>(
         self,
         extractor: NewResExt,
-    ) -> GRPCLayerBuilder<MethodExt, ReqExt, NewResExt>
+    ) -> GRPCLayerBuilder<ReqExt, NewResExt>
     where
         NewResExt: GRPCResponseAttributeExtractor<B>,
     {
@@ -272,7 +191,6 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
             tracer: self.tracer,
             meter: self.meter,
             duration_bounds: self.duration_bounds,
-            method_extractor: self.method_extractor,
             request_extractor: self.request_extractor,
             response_extractor: extractor,
         }
@@ -282,7 +200,7 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
     pub fn with_response_extractor_fn<F, B>(
         self,
         f: F,
-    ) -> GRPCLayerBuilder<MethodExt, ReqExt, FnGRPCResponseExtractor<F>>
+    ) -> GRPCLayerBuilder<ReqExt, FnGRPCResponseExtractor<F>>
     where
         F: Fn(&http::Response<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
     {
@@ -307,7 +225,7 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
         self
     }
 
-    pub fn build(self) -> GRPCLayer<MethodExt, ReqExt, ResExt> {
+    pub fn build(self) -> GRPCLayer<ReqExt, ResExt> {
         let tracer = self
             .tracer
             .unwrap_or_else(|| Arc::new(global::tracer_with_scope(instrumentation_scope())));
@@ -320,7 +238,6 @@ impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
 
         GRPCLayer {
             state: Arc::new(GRPCLayerState::new(meter, duration_bounds)),
-            method_extractor: self.method_extractor,
             request_extractor: self.request_extractor,
             response_extractor: self.response_extractor,
             tracer,
@@ -341,18 +258,16 @@ impl GRPCLayerState {
     }
 }
 
-impl<S, MethodExt, ReqExt, ResExt> Layer<S> for GRPCLayer<MethodExt, ReqExt, ResExt>
+impl<S, ReqExt, ResExt> Layer<S> for GRPCLayer<ReqExt, ResExt>
 where
-    MethodExt: Clone,
     ReqExt: Clone,
     ResExt: Clone,
 {
-    type Service = GRPCService<S, MethodExt, ReqExt, ResExt>;
+    type Service = GRPCService<S, ReqExt, ResExt>;
 
     fn layer(&self, service: S) -> Self::Service {
         GRPCService {
             state: self.state.clone(),
-            method_extractor: self.method_extractor.clone(),
             request_extractor: self.request_extractor.clone(),
             response_extractor: self.response_extractor.clone(),
             inner_service: service,
@@ -374,6 +289,13 @@ struct RequestFinalization<ResExt> {
     response_extractor: ResExt,
 }
 
+struct BodyFinalization {
+    request_data: RequestData,
+    layer_state: Arc<GRPCLayerState>,
+    custom_response_attributes: Vec<KeyValue>,
+    http_status: http::StatusCode,
+}
+
 pin_project! {
     /// Future type returned by [`GRPCService`].
     pub struct GRPCResponseFuture<F, ResExt> {
@@ -388,37 +310,135 @@ impl<F, ResBody, E, ResExt> Future for GRPCResponseFuture<F, ResExt>
 where
     F: Future<Output = result::Result<http::Response<ResBody>, E>>,
     E: fmt::Debug,
+    ResBody: http_body::Body,
+    ResBody::Error: fmt::Debug,
     ResExt: GRPCResponseAttributeExtractor<ResBody>,
 {
-    type Output = F::Output;
+    type Output = result::Result<http::Response<GRPCResponseBody<ResBody>>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let _guard = this.otel_cx.clone().attach();
         let result = std::task::ready!(this.inner.poll(cx));
-        if let Some(fin) = this.finalization.take() {
-            finalize_request(
-                &result,
-                fin.request_data,
-                &fin.layer_state,
-                &fin.response_extractor,
-            );
+        match result {
+            Ok(response) => {
+                let fin = this
+                    .finalization
+                    .take()
+                    .expect("gRPC response future polled after completion");
+                let custom_response_attributes =
+                    fin.response_extractor.extract_attributes(&response);
+                let http_status = response.status();
+                let rpc_status_code = rpc_status_code(response.headers(), http_status);
+                let (parts, body) = response.into_parts();
+                let body = GRPCResponseBody {
+                    inner: body,
+                    otel_cx: this.otel_cx.clone(),
+                    finalization: Some(BodyFinalization {
+                        request_data: fin.request_data,
+                        layer_state: fin.layer_state,
+                        custom_response_attributes,
+                        http_status,
+                    }),
+                    rpc_status_code,
+                };
+                Poll::Ready(Ok(http::Response::from_parts(parts, body)))
+            }
+            Err(error) => {
+                if let Some(fin) = this.finalization.take() {
+                    finalize_error(&error, fin.request_data, &fin.layer_state);
+                }
+                Poll::Ready(Err(error))
+            }
         }
-        Poll::Ready(result)
     }
 }
 
-impl<S, ReqBody, ResBody, MethodExt, ReqExt, ResExt> Service<http::Request<ReqBody>>
-    for GRPCService<S, MethodExt, ReqExt, ResExt>
+pin_project! {
+    /// Response body wrapper that observes gRPC status from trailers.
+    pub struct GRPCResponseBody<B> {
+        #[pin]
+        inner: B,
+        otel_cx: OtelContext,
+        finalization: Option<BodyFinalization>,
+        rpc_status_code: &'static str,
+    }
+
+    impl<B> PinnedDrop for GRPCResponseBody<B> {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+            if let Some(fin) = this.finalization.take() {
+                let _guard = this.otel_cx.clone().attach();
+                finalize_response(*this.rpc_status_code, fin);
+            }
+        }
+    }
+}
+
+impl<B> http_body::Body for GRPCResponseBody<B>
+where
+    B: http_body::Body,
+    B::Error: fmt::Debug,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<result::Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let mut this = self.project();
+
+        match std::task::ready!(this.inner.as_mut().poll_frame(cx)) {
+            Some(Ok(frame)) => {
+                if let Some(trailers) = frame.trailers_ref() {
+                    if let Some(fin) = this.finalization.take() {
+                        let rpc_status_code = rpc_status_code(trailers, fin.http_status);
+                        *this.rpc_status_code = rpc_status_code;
+                        let _guard = this.otel_cx.clone().attach();
+                        finalize_response(rpc_status_code, fin);
+                    }
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Some(Err(error)) => {
+                if let Some(fin) = this.finalization.take() {
+                    let _guard = this.otel_cx.clone().attach();
+                    finalize_body_error(&error, fin);
+                }
+                Poll::Ready(Some(Err(error)))
+            }
+            None => {
+                if let Some(fin) = this.finalization.take() {
+                    let _guard = this.otel_cx.clone().attach();
+                    finalize_response(*this.rpc_status_code, fin);
+                }
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl<S, ReqBody, ResBody, ReqExt, ResExt> Service<http::Request<ReqBody>>
+    for GRPCService<S, ReqExt, ResExt>
 where
     S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
     S::Future: Send,
     S::Error: fmt::Debug,
-    MethodExt: GRPCMethodExtractor<ReqBody>,
     ReqExt: GRPCRequestAttributeExtractor<ReqBody>,
     ResExt: GRPCResponseAttributeExtractor<ResBody>,
+    ResBody: http_body::Body,
+    ResBody::Error: fmt::Debug,
 {
-    type Response = S::Response;
+    type Response = http::Response<GRPCResponseBody<ResBody>>;
     type Error = S::Error;
     type Future = GRPCResponseFuture<S::Future, ResExt>;
 
@@ -432,10 +452,9 @@ where
             propagator.extract(&HeaderExtractor(req.headers()))
         });
 
-        let rpc_method = self
-            .method_extractor
-            .extract_method(&req)
-            .unwrap_or_else(|| req.uri().path().trim_start_matches('/').to_owned());
+        let rpc_method = parse_grpc_path(req.uri().path())
+            .unwrap_or_else(|| req.uri().path().trim_start_matches('/'))
+            .to_owned();
 
         let system_kv = KeyValue::new(semconv::attribute::RPC_SYSTEM_NAME, "grpc");
         let method_kv = KeyValue::new(semconv::attribute::RPC_METHOD, rpc_method.clone());
@@ -484,92 +503,87 @@ where
     }
 }
 
-fn finalize_request<ResBody, E, ResExt>(
-    result: &result::Result<http::Response<ResBody>, E>,
-    request_data: RequestData,
-    layer_state: &Arc<GRPCLayerState>,
-    response_extractor: &ResExt,
-) where
-    E: fmt::Debug,
-    ResExt: GRPCResponseAttributeExtractor<ResBody>,
-{
+fn finalize_response(rpc_status_code: &'static str, fin: BodyFinalization) {
     let cx = OtelContext::current();
     let span = cx.span();
+    let failed = is_error_status(rpc_status_code);
 
-    match result {
-        Ok(response) => {
-            let rpc_status_code = rpc_status_code(response);
-            let custom_response_attributes = response_extractor.extract_attributes(response);
-            let failed = is_error_status(rpc_status_code);
-
-            let mut label_superset = Vec::with_capacity(
-                3 + usize::from(failed)
-                    + request_data.custom_request_attributes.len()
-                    + custom_response_attributes.len(),
-            );
-            label_superset.push(request_data.system_kv.clone());
-            label_superset.push(request_data.method_kv.clone());
-            label_superset.push(KeyValue::new(
-                semconv::attribute::RPC_RESPONSE_STATUS_CODE,
-                rpc_status_code,
-            ));
-            if failed {
-                label_superset.push(KeyValue::new(
-                    semconv::attribute::ERROR_TYPE,
-                    rpc_status_code,
-                ));
-            }
-            label_superset.extend(request_data.custom_request_attributes);
-            label_superset.extend(custom_response_attributes.iter().cloned());
-
-            span.set_attribute(KeyValue::new(
-                semconv::attribute::RPC_RESPONSE_STATUS_CODE,
-                rpc_status_code,
-            ));
-            for attr in custom_response_attributes {
-                span.set_attribute(attr);
-            }
-            if failed {
-                span.set_attribute(KeyValue::new(
-                    semconv::attribute::ERROR_TYPE,
-                    rpc_status_code,
-                ));
-                span.set_status(Status::Error {
-                    description: format!("gRPC status {rpc_status_code}").into(),
-                });
-            }
-
-            layer_state.server_duration.record(
-                request_data.duration_start.elapsed().as_secs_f64(),
-                &label_superset,
-            );
-        }
-        Err(error) => {
-            span.set_status(Status::Error {
-                description: format!("{error:?}").into(),
-            });
-
-            let label_superset = [
-                request_data.system_kv.clone(),
-                request_data.method_kv.clone(),
-                KeyValue::new(semconv::attribute::ERROR_TYPE, "_OTHER"),
-            ];
-            layer_state.server_duration.record(
-                request_data.duration_start.elapsed().as_secs_f64(),
-                &label_superset,
-            );
-        }
+    let mut label_superset = Vec::with_capacity(
+        3 + usize::from(failed)
+            + fin.request_data.custom_request_attributes.len()
+            + fin.custom_response_attributes.len(),
+    );
+    label_superset.push(fin.request_data.system_kv.clone());
+    label_superset.push(fin.request_data.method_kv.clone());
+    label_superset.push(KeyValue::new(
+        semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+        rpc_status_code,
+    ));
+    if failed {
+        label_superset.push(KeyValue::new(
+            semconv::attribute::ERROR_TYPE,
+            rpc_status_code,
+        ));
     }
+    label_superset.extend(fin.request_data.custom_request_attributes);
+    label_superset.extend(fin.custom_response_attributes.iter().cloned());
+
+    span.set_attribute(KeyValue::new(
+        semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+        rpc_status_code,
+    ));
+    for attr in fin.custom_response_attributes {
+        span.set_attribute(attr);
+    }
+    if failed {
+        span.set_attribute(KeyValue::new(
+            semconv::attribute::ERROR_TYPE,
+            rpc_status_code,
+        ));
+        span.set_status(Status::Error {
+            description: format!("gRPC status {rpc_status_code}").into(),
+        });
+    }
+
+    fin.layer_state.server_duration.record(
+        fin.request_data.duration_start.elapsed().as_secs_f64(),
+        &label_superset,
+    );
 }
 
-fn rpc_status_code<B>(response: &http::Response<B>) -> &'static str {
-    response
-        .headers()
+fn finalize_error(
+    error: &impl fmt::Debug,
+    request_data: RequestData,
+    layer_state: &Arc<GRPCLayerState>,
+) {
+    let cx = OtelContext::current();
+    let span = cx.span();
+    span.set_status(Status::Error {
+        description: format!("{error:?}").into(),
+    });
+
+    let label_superset = [
+        request_data.system_kv.clone(),
+        request_data.method_kv.clone(),
+        KeyValue::new(semconv::attribute::ERROR_TYPE, "_OTHER"),
+    ];
+    layer_state.server_duration.record(
+        request_data.duration_start.elapsed().as_secs_f64(),
+        &label_superset,
+    );
+}
+
+fn finalize_body_error(error: &impl fmt::Debug, fin: BodyFinalization) {
+    finalize_error(&error, fin.request_data, &fin.layer_state);
+}
+
+fn rpc_status_code(headers: &http::HeaderMap, http_status: http::StatusCode) -> &'static str {
+    headers
         .get("grpc-status")
         .and_then(|value| value.to_str().ok())
         .map(grpc_status_name)
         .unwrap_or_else(|| {
-            if response.status().is_success() {
+            if http_status.is_success() {
                 "OK"
             } else {
                 "UNKNOWN"
@@ -632,7 +646,10 @@ fn instrumentation_scope() -> InstrumentationScope {
 mod tests {
     use super::*;
 
+    use std::convert::Infallible;
+
     use http::{Request, Response, StatusCode};
+    use http_body_util::{BodyExt, Empty};
     use opentelemetry_sdk::metrics::{
         data::{AggregatedMetrics, MetricData},
         InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
@@ -640,6 +657,34 @@ mod tests {
     use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider};
     use std::time::Duration;
     use tower::Service;
+
+    struct TrailerBody {
+        trailers: Option<http::HeaderMap>,
+    }
+
+    impl TrailerBody {
+        fn new(trailers: http::HeaderMap) -> Self {
+            Self {
+                trailers: Some(trailers),
+            }
+        }
+    }
+
+    impl http_body::Body for TrailerBody {
+        type Data = &'static [u8];
+        type Error = Infallible;
+
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<result::Result<http_body::Frame<Self::Data>, Self::Error>>> {
+            Poll::Ready(
+                self.trailers
+                    .take()
+                    .map(|trailers| Ok(http_body::Frame::trailers(trailers))),
+            )
+        }
+    }
 
     #[test]
     fn parses_grpc_path() {
@@ -663,12 +708,12 @@ mod tests {
         let layer = GRPCLayerBuilder::builder()
             .with_tracer_provider(tracer_provider.clone())
             .build();
-        let service = tower::service_fn(|_req: Request<String>| async {
+        let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
             Ok::<_, std::convert::Infallible>(
                 Response::builder()
                     .status(StatusCode::OK)
                     .header("grpc-status", "0")
-                    .body(String::new())
+                    .body(Empty::<&'static [u8]>::new())
                     .unwrap(),
             )
         });
@@ -677,10 +722,11 @@ mod tests {
         let request = Request::builder()
             .method("POST")
             .uri("http://example.com/package.Service/GetThing")
-            .body(String::new())
+            .body(Empty::new())
             .unwrap();
 
-        let _response = service.call(request).await.unwrap();
+        let response = service.call(request).await.unwrap();
+        response.into_body().collect().await.unwrap();
         tracer_provider.force_flush().unwrap();
 
         let spans = trace_exporter.get_finished_spans().unwrap();
@@ -706,12 +752,12 @@ mod tests {
         let layer = GRPCLayerBuilder::builder()
             .with_tracer_provider(tracer_provider.clone())
             .build();
-        let service = tower::service_fn(|_req: Request<String>| async {
+        let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
             Ok::<_, std::convert::Infallible>(
                 Response::builder()
                     .status(StatusCode::OK)
                     .header("grpc-status", "13")
-                    .body(String::new())
+                    .body(Empty::<&'static [u8]>::new())
                     .unwrap(),
             )
         });
@@ -720,10 +766,11 @@ mod tests {
         let request = Request::builder()
             .method("POST")
             .uri("http://example.com/package.Service/GetThing")
-            .body(String::new())
+            .body(Empty::new())
             .unwrap();
 
-        let _response = service.call(request).await.unwrap();
+        let response = service.call(request).await.unwrap();
+        response.into_body().collect().await.unwrap();
         tracer_provider.force_flush().unwrap();
 
         let spans = trace_exporter.get_finished_spans().unwrap();
@@ -739,6 +786,49 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_grpc_trailer_status_overrides_header_status() {
+        let trace_exporter = InMemorySpanExporterBuilder::new().build();
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(trace_exporter.clone())
+            .build();
+
+        let layer = GRPCLayerBuilder::builder()
+            .with_tracer_provider(tracer_provider.clone())
+            .build();
+        let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
+            let mut trailers = http::HeaderMap::new();
+            trailers.insert("grpc-status", http::HeaderValue::from_static("13"));
+
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("grpc-status", "0")
+                    .body(TrailerBody::new(trailers))
+                    .unwrap(),
+            )
+        });
+        let mut service = layer.layer(service);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("http://example.com/package.Service/GetThing")
+            .body(Empty::new())
+            .unwrap();
+
+        let response = service.call(request).await.unwrap();
+        response.into_body().collect().await.unwrap();
+        tracer_provider.force_flush().unwrap();
+
+        let spans = trace_exporter.get_finished_spans().unwrap();
+        assert_eq!(spans.len(), 1);
+        assert!(matches!(spans[0].status, Status::Error { .. }));
+        assert!(spans[0].attributes.contains(&KeyValue::new(
+            semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+            "INTERNAL"
+        )));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_grpc_metrics_labels() {
         let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone())
@@ -749,12 +839,12 @@ mod tests {
             .with_meter_provider(meter_provider.clone())
             .build();
 
-        let service = tower::service_fn(|_req: Request<String>| async {
+        let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
             Ok::<_, std::convert::Infallible>(
                 Response::builder()
                     .status(StatusCode::OK)
                     .header("grpc-status", "0")
-                    .body(String::new())
+                    .body(Empty::<&'static [u8]>::new())
                     .unwrap(),
             )
         });
@@ -763,10 +853,11 @@ mod tests {
         let request = Request::builder()
             .method("POST")
             .uri("http://example.com/package.Service/GetThing")
-            .body(String::new())
+            .body(Empty::new())
             .unwrap();
 
-        let _response = service.call(request).await.unwrap();
+        let response = service.call(request).await.unwrap();
+        response.into_body().collect().await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         let metrics = exporter.get_finished_metrics().unwrap();

--- a/opentelemetry-instrumentation-tower/src/grpc.rs
+++ b/opentelemetry-instrumentation-tower/src/grpc.rs
@@ -369,7 +369,7 @@ pin_project! {
             let this = this.project();
             if let Some(fin) = this.finalization.take() {
                 let _guard = this.otel_cx.clone().attach();
-                finalize_response(*this.rpc_status_code, fin);
+                finalize_response(this.rpc_status_code, fin);
             }
         }
     }
@@ -411,7 +411,7 @@ where
             None => {
                 if let Some(fin) = this.finalization.take() {
                     let _guard = this.otel_cx.clone().attach();
-                    finalize_response(*this.rpc_status_code, fin);
+                    finalize_response(this.rpc_status_code, fin);
                 }
                 Poll::Ready(None)
             }

--- a/opentelemetry-instrumentation-tower/src/grpc.rs
+++ b/opentelemetry-instrumentation-tower/src/grpc.rs
@@ -1,0 +1,806 @@
+use std::borrow::Cow;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+use std::{fmt, result};
+
+use opentelemetry::global::{self, BoxedTracer, ObjectSafeTracer};
+use opentelemetry::metrics::{Histogram, Meter, MeterProvider};
+use opentelemetry::trace::{SpanKind, Status, TraceContextExt, Tracer, TracerProvider};
+use opentelemetry::{Context as OtelContext, InstrumentationScope, KeyValue};
+use opentelemetry_http::HeaderExtractor;
+use opentelemetry_semantic_conventions as semconv;
+use pin_project_lite::pin_project;
+use tower_layer::Layer;
+use tower_service::Service;
+
+const INSTRUMENTATION_NAME: &str = "opentelemetry-instrumentation-tower";
+
+const RPC_SERVER_DURATION_UNIT: &str = "s";
+
+const OTEL_DEFAULT_RPC_SERVER_DURATION_BOUNDS: [f64; 14] = [
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+
+/// Extracts a fully-qualified gRPC method from an HTTP request.
+pub trait GRPCMethodExtractor<B>: Clone + Send + Sync + 'static {
+    /// Returns the `rpc.method` value when available.
+    fn extract_method(&self, req: &http::Request<B>) -> Option<String>;
+}
+
+/// Extracts the gRPC method from paths shaped like `/package.Service/Method`.
+#[derive(Clone, Default)]
+pub struct DefaultGRPCMethodExtractor;
+
+impl<B> GRPCMethodExtractor<B> for DefaultGRPCMethodExtractor {
+    fn extract_method(&self, req: &http::Request<B>) -> Option<String> {
+        parse_grpc_path(req.uri().path()).map(str::to_owned)
+    }
+}
+
+/// A function-based gRPC method extractor.
+#[derive(Clone)]
+pub struct FnGRPCMethodExtractor<F> {
+    extractor: F,
+}
+
+impl<F> FnGRPCMethodExtractor<F> {
+    pub fn new(extractor: F) -> Self {
+        Self { extractor }
+    }
+}
+
+impl<F, B> GRPCMethodExtractor<B> for FnGRPCMethodExtractor<F>
+where
+    F: Fn(&http::Request<B>) -> Option<String> + Clone + Send + Sync + 'static,
+{
+    fn extract_method(&self, req: &http::Request<B>) -> Option<String> {
+        (self.extractor)(req)
+    }
+}
+
+/// Trait for extracting custom attributes from gRPC requests.
+pub trait GRPCRequestAttributeExtractor<B>: Clone + Send + Sync + 'static {
+    fn extract_attributes(&self, req: &http::Request<B>) -> Vec<KeyValue>;
+}
+
+/// Trait for extracting custom attributes from gRPC responses.
+pub trait GRPCResponseAttributeExtractor<B>: Clone + Send + Sync + 'static {
+    fn extract_attributes(&self, res: &http::Response<B>) -> Vec<KeyValue>;
+}
+
+/// Default implementation that extracts no attributes.
+#[derive(Clone)]
+pub struct NoOpGRPCExtractor;
+
+impl<B> GRPCRequestAttributeExtractor<B> for NoOpGRPCExtractor {
+    fn extract_attributes(&self, _req: &http::Request<B>) -> Vec<KeyValue> {
+        vec![]
+    }
+}
+
+impl<B> GRPCResponseAttributeExtractor<B> for NoOpGRPCExtractor {
+    fn extract_attributes(&self, _res: &http::Response<B>) -> Vec<KeyValue> {
+        vec![]
+    }
+}
+
+/// A function-based gRPC request attribute extractor.
+#[derive(Clone)]
+pub struct FnGRPCRequestExtractor<F> {
+    extractor: F,
+}
+
+impl<F> FnGRPCRequestExtractor<F> {
+    pub fn new(extractor: F) -> Self {
+        Self { extractor }
+    }
+}
+
+impl<F, B> GRPCRequestAttributeExtractor<B> for FnGRPCRequestExtractor<F>
+where
+    F: Fn(&http::Request<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+{
+    fn extract_attributes(&self, req: &http::Request<B>) -> Vec<KeyValue> {
+        (self.extractor)(req)
+    }
+}
+
+/// A function-based gRPC response attribute extractor.
+#[derive(Clone)]
+pub struct FnGRPCResponseExtractor<F> {
+    extractor: F,
+}
+
+impl<F> FnGRPCResponseExtractor<F> {
+    pub fn new(extractor: F) -> Self {
+        Self { extractor }
+    }
+}
+
+impl<F, B> GRPCResponseAttributeExtractor<B> for FnGRPCResponseExtractor<F>
+where
+    F: Fn(&http::Response<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+{
+    fn extract_attributes(&self, res: &http::Response<B>) -> Vec<KeyValue> {
+        (self.extractor)(res)
+    }
+}
+
+#[derive(Clone)]
+struct GRPCLayerState {
+    server_duration: Histogram<f64>,
+}
+
+#[derive(Clone)]
+/// [`Service`] used by [`GRPCLayer`].
+pub struct GRPCService<
+    S,
+    MethodExt = DefaultGRPCMethodExtractor,
+    ReqExt = NoOpGRPCExtractor,
+    ResExt = NoOpGRPCExtractor,
+> {
+    state: Arc<GRPCLayerState>,
+    method_extractor: MethodExt,
+    request_extractor: ReqExt,
+    response_extractor: ResExt,
+    inner_service: S,
+    tracer: Arc<BoxedTracer>,
+}
+
+#[derive(Clone)]
+/// [`Layer`] which applies OpenTelemetry gRPC server metrics and tracing middleware.
+pub struct GRPCLayer<
+    MethodExt = DefaultGRPCMethodExtractor,
+    ReqExt = NoOpGRPCExtractor,
+    ResExt = NoOpGRPCExtractor,
+> {
+    state: Arc<GRPCLayerState>,
+    method_extractor: MethodExt,
+    request_extractor: ReqExt,
+    response_extractor: ResExt,
+    tracer: Arc<BoxedTracer>,
+}
+
+impl GRPCLayer {
+    /// Create a new gRPC layer with default configuration using global providers.
+    pub fn new() -> Self {
+        GRPCLayerBuilder::builder().build()
+    }
+}
+
+impl Default for GRPCLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for [`GRPCLayer`].
+pub struct GRPCLayerBuilder<
+    MethodExt = DefaultGRPCMethodExtractor,
+    ReqExt = NoOpGRPCExtractor,
+    ResExt = NoOpGRPCExtractor,
+> {
+    tracer: Option<Arc<BoxedTracer>>,
+    meter: Option<Meter>,
+    duration_bounds: Option<Vec<f64>>,
+    method_extractor: MethodExt,
+    request_extractor: ReqExt,
+    response_extractor: ResExt,
+}
+
+impl GRPCLayerBuilder {
+    pub fn builder() -> Self {
+        Self {
+            tracer: None,
+            meter: None,
+            duration_bounds: Some(Vec::from(OTEL_DEFAULT_RPC_SERVER_DURATION_BOUNDS)),
+            method_extractor: DefaultGRPCMethodExtractor,
+            request_extractor: NoOpGRPCExtractor,
+            response_extractor: NoOpGRPCExtractor,
+        }
+    }
+}
+
+impl<MethodExt, ReqExt, ResExt> GRPCLayerBuilder<MethodExt, ReqExt, ResExt> {
+    /// Set a custom gRPC method extractor.
+    pub fn with_method_extractor<NewMethodExt>(
+        self,
+        extractor: NewMethodExt,
+    ) -> GRPCLayerBuilder<NewMethodExt, ReqExt, ResExt> {
+        GRPCLayerBuilder {
+            tracer: self.tracer,
+            meter: self.meter,
+            duration_bounds: self.duration_bounds,
+            method_extractor: extractor,
+            request_extractor: self.request_extractor,
+            response_extractor: self.response_extractor,
+        }
+    }
+
+    /// Convenience method to set a function-based gRPC method extractor.
+    pub fn with_method_extractor_fn<F, B>(
+        self,
+        f: F,
+    ) -> GRPCLayerBuilder<FnGRPCMethodExtractor<F>, ReqExt, ResExt>
+    where
+        F: Fn(&http::Request<B>) -> Option<String> + Clone + Send + Sync + 'static,
+    {
+        self.with_method_extractor(FnGRPCMethodExtractor::new(f))
+    }
+
+    /// Set a request attribute extractor.
+    pub fn with_request_extractor<NewReqExt, B>(
+        self,
+        extractor: NewReqExt,
+    ) -> GRPCLayerBuilder<MethodExt, NewReqExt, ResExt>
+    where
+        NewReqExt: GRPCRequestAttributeExtractor<B>,
+    {
+        GRPCLayerBuilder {
+            tracer: self.tracer,
+            meter: self.meter,
+            duration_bounds: self.duration_bounds,
+            method_extractor: self.method_extractor,
+            request_extractor: extractor,
+            response_extractor: self.response_extractor,
+        }
+    }
+
+    /// Convenience method to set a function-based request attribute extractor.
+    pub fn with_request_extractor_fn<F, B>(
+        self,
+        f: F,
+    ) -> GRPCLayerBuilder<MethodExt, FnGRPCRequestExtractor<F>, ResExt>
+    where
+        F: Fn(&http::Request<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+    {
+        self.with_request_extractor(FnGRPCRequestExtractor::new(f))
+    }
+
+    /// Set a response attribute extractor.
+    pub fn with_response_extractor<NewResExt, B>(
+        self,
+        extractor: NewResExt,
+    ) -> GRPCLayerBuilder<MethodExt, ReqExt, NewResExt>
+    where
+        NewResExt: GRPCResponseAttributeExtractor<B>,
+    {
+        GRPCLayerBuilder {
+            tracer: self.tracer,
+            meter: self.meter,
+            duration_bounds: self.duration_bounds,
+            method_extractor: self.method_extractor,
+            request_extractor: self.request_extractor,
+            response_extractor: extractor,
+        }
+    }
+
+    /// Convenience method to set a function-based response attribute extractor.
+    pub fn with_response_extractor_fn<F, B>(
+        self,
+        f: F,
+    ) -> GRPCLayerBuilder<MethodExt, ReqExt, FnGRPCResponseExtractor<F>>
+    where
+        F: Fn(&http::Response<B>) -> Vec<KeyValue> + Clone + Send + Sync + 'static,
+    {
+        self.with_response_extractor(FnGRPCResponseExtractor::new(f))
+    }
+
+    /// Override the tracer provider used for trace collection.
+    pub fn with_tracer_provider<P>(mut self, tracer_provider: P) -> Self
+    where
+        P: TracerProvider,
+        P::Tracer: ObjectSafeTracer + Send + Sync + 'static,
+    {
+        self.tracer = Some(Arc::new(BoxedTracer::new(Box::new(
+            tracer_provider.tracer_with_scope(instrumentation_scope()),
+        ))));
+        self
+    }
+
+    /// Override the meter provider used for metrics collection.
+    pub fn with_meter_provider(mut self, meter_provider: impl MeterProvider) -> Self {
+        self.meter = Some(meter_provider.meter_with_scope(instrumentation_scope()));
+        self
+    }
+
+    pub fn build(self) -> GRPCLayer<MethodExt, ReqExt, ResExt> {
+        let tracer = self
+            .tracer
+            .unwrap_or_else(|| Arc::new(global::tracer_with_scope(instrumentation_scope())));
+        let meter = self
+            .meter
+            .unwrap_or_else(|| global::meter_with_scope(instrumentation_scope()));
+        let duration_bounds = self
+            .duration_bounds
+            .unwrap_or_else(|| Vec::from(OTEL_DEFAULT_RPC_SERVER_DURATION_BOUNDS));
+
+        GRPCLayer {
+            state: Arc::new(GRPCLayerState::new(meter, duration_bounds)),
+            method_extractor: self.method_extractor,
+            request_extractor: self.request_extractor,
+            response_extractor: self.response_extractor,
+            tracer,
+        }
+    }
+}
+
+impl GRPCLayerState {
+    fn new(meter: Meter, duration_bounds: Vec<f64>) -> Self {
+        Self {
+            server_duration: meter
+                .f64_histogram(Cow::from(semconv::metric::RPC_SERVER_CALL_DURATION))
+                .with_description("Duration of inbound gRPC requests.")
+                .with_unit(Cow::from(RPC_SERVER_DURATION_UNIT))
+                .with_boundaries(duration_bounds)
+                .build(),
+        }
+    }
+}
+
+impl<S, MethodExt, ReqExt, ResExt> Layer<S> for GRPCLayer<MethodExt, ReqExt, ResExt>
+where
+    MethodExt: Clone,
+    ReqExt: Clone,
+    ResExt: Clone,
+{
+    type Service = GRPCService<S, MethodExt, ReqExt, ResExt>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        GRPCService {
+            state: self.state.clone(),
+            method_extractor: self.method_extractor.clone(),
+            request_extractor: self.request_extractor.clone(),
+            response_extractor: self.response_extractor.clone(),
+            inner_service: service,
+            tracer: self.tracer.clone(),
+        }
+    }
+}
+
+struct RequestData {
+    duration_start: Instant,
+    system_kv: KeyValue,
+    method_kv: KeyValue,
+    custom_request_attributes: Vec<KeyValue>,
+}
+
+struct RequestFinalization<ResExt> {
+    request_data: RequestData,
+    layer_state: Arc<GRPCLayerState>,
+    response_extractor: ResExt,
+}
+
+pin_project! {
+    /// Future type returned by [`GRPCService`].
+    pub struct GRPCResponseFuture<F, ResExt> {
+        #[pin]
+        inner: F,
+        otel_cx: OtelContext,
+        finalization: Option<RequestFinalization<ResExt>>,
+    }
+}
+
+impl<F, ResBody, E, ResExt> Future for GRPCResponseFuture<F, ResExt>
+where
+    F: Future<Output = result::Result<http::Response<ResBody>, E>>,
+    E: fmt::Debug,
+    ResExt: GRPCResponseAttributeExtractor<ResBody>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _guard = this.otel_cx.clone().attach();
+        let result = std::task::ready!(this.inner.poll(cx));
+        if let Some(fin) = this.finalization.take() {
+            finalize_request(
+                &result,
+                fin.request_data,
+                &fin.layer_state,
+                &fin.response_extractor,
+            );
+        }
+        Poll::Ready(result)
+    }
+}
+
+impl<S, ReqBody, ResBody, MethodExt, ReqExt, ResExt> Service<http::Request<ReqBody>>
+    for GRPCService<S, MethodExt, ReqExt, ResExt>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>>,
+    S::Future: Send,
+    S::Error: fmt::Debug,
+    MethodExt: GRPCMethodExtractor<ReqBody>,
+    ReqExt: GRPCRequestAttributeExtractor<ReqBody>,
+    ResExt: GRPCResponseAttributeExtractor<ResBody>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = GRPCResponseFuture<S::Future, ResExt>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<result::Result<(), Self::Error>> {
+        self.inner_service.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let duration_start = Instant::now();
+        let parent_cx = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(req.headers()))
+        });
+
+        let rpc_method = self
+            .method_extractor
+            .extract_method(&req)
+            .unwrap_or_else(|| req.uri().path().trim_start_matches('/').to_owned());
+
+        let system_kv = KeyValue::new(semconv::attribute::RPC_SYSTEM_NAME, "grpc");
+        let method_kv = KeyValue::new(semconv::attribute::RPC_METHOD, rpc_method.clone());
+        let custom_request_attributes = self.request_extractor.extract_attributes(&req);
+
+        let mut span_attributes = Vec::with_capacity(2 + custom_request_attributes.len());
+        span_attributes.push(system_kv.clone());
+        if !rpc_method.is_empty() {
+            span_attributes.push(method_kv.clone());
+        }
+        span_attributes.extend(custom_request_attributes.iter().cloned());
+
+        let span_name = if rpc_method.is_empty() {
+            req.uri().path().to_owned()
+        } else {
+            rpc_method.clone()
+        };
+
+        let span = self
+            .tracer
+            .span_builder(span_name)
+            .with_kind(SpanKind::Server)
+            .with_attributes(span_attributes)
+            .start_with_context(self.tracer.as_ref(), &parent_cx);
+        let otel_cx = parent_cx.with_span(span);
+
+        let request_data = RequestData {
+            duration_start,
+            system_kv,
+            method_kv,
+            custom_request_attributes,
+        };
+        let layer_state = self.state.clone();
+        let response_extractor = self.response_extractor.clone();
+        let inner = self.inner_service.call(req);
+
+        GRPCResponseFuture {
+            inner,
+            otel_cx,
+            finalization: Some(RequestFinalization {
+                request_data,
+                layer_state,
+                response_extractor,
+            }),
+        }
+    }
+}
+
+fn finalize_request<ResBody, E, ResExt>(
+    result: &result::Result<http::Response<ResBody>, E>,
+    request_data: RequestData,
+    layer_state: &Arc<GRPCLayerState>,
+    response_extractor: &ResExt,
+) where
+    E: fmt::Debug,
+    ResExt: GRPCResponseAttributeExtractor<ResBody>,
+{
+    let cx = OtelContext::current();
+    let span = cx.span();
+
+    match result {
+        Ok(response) => {
+            let rpc_status_code = rpc_status_code(response);
+            let custom_response_attributes = response_extractor.extract_attributes(response);
+            let failed = is_error_status(rpc_status_code);
+
+            let mut label_superset = Vec::with_capacity(
+                3 + usize::from(failed)
+                    + request_data.custom_request_attributes.len()
+                    + custom_response_attributes.len(),
+            );
+            label_superset.push(request_data.system_kv.clone());
+            label_superset.push(request_data.method_kv.clone());
+            label_superset.push(KeyValue::new(
+                semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+                rpc_status_code,
+            ));
+            if failed {
+                label_superset.push(KeyValue::new(
+                    semconv::attribute::ERROR_TYPE,
+                    rpc_status_code,
+                ));
+            }
+            label_superset.extend(request_data.custom_request_attributes);
+            label_superset.extend(custom_response_attributes.iter().cloned());
+
+            span.set_attribute(KeyValue::new(
+                semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+                rpc_status_code,
+            ));
+            for attr in custom_response_attributes {
+                span.set_attribute(attr);
+            }
+            if failed {
+                span.set_attribute(KeyValue::new(
+                    semconv::attribute::ERROR_TYPE,
+                    rpc_status_code,
+                ));
+                span.set_status(Status::Error {
+                    description: format!("gRPC status {rpc_status_code}").into(),
+                });
+            }
+
+            layer_state.server_duration.record(
+                request_data.duration_start.elapsed().as_secs_f64(),
+                &label_superset,
+            );
+        }
+        Err(error) => {
+            span.set_status(Status::Error {
+                description: format!("{error:?}").into(),
+            });
+
+            let label_superset = [
+                request_data.system_kv.clone(),
+                request_data.method_kv.clone(),
+                KeyValue::new(semconv::attribute::ERROR_TYPE, "_OTHER"),
+            ];
+            layer_state.server_duration.record(
+                request_data.duration_start.elapsed().as_secs_f64(),
+                &label_superset,
+            );
+        }
+    }
+}
+
+fn rpc_status_code<B>(response: &http::Response<B>) -> &'static str {
+    response
+        .headers()
+        .get("grpc-status")
+        .and_then(|value| value.to_str().ok())
+        .map(grpc_status_name)
+        .unwrap_or_else(|| {
+            if response.status().is_success() {
+                "OK"
+            } else {
+                "UNKNOWN"
+            }
+        })
+}
+
+fn grpc_status_name(code: &str) -> &'static str {
+    match code {
+        "0" => "OK",
+        "1" => "CANCELLED",
+        "2" => "UNKNOWN",
+        "3" => "INVALID_ARGUMENT",
+        "4" => "DEADLINE_EXCEEDED",
+        "5" => "NOT_FOUND",
+        "6" => "ALREADY_EXISTS",
+        "7" => "PERMISSION_DENIED",
+        "8" => "RESOURCE_EXHAUSTED",
+        "9" => "FAILED_PRECONDITION",
+        "10" => "ABORTED",
+        "11" => "OUT_OF_RANGE",
+        "12" => "UNIMPLEMENTED",
+        "13" => "INTERNAL",
+        "14" => "UNAVAILABLE",
+        "15" => "DATA_LOSS",
+        "16" => "UNAUTHENTICATED",
+        _ => "UNKNOWN",
+    }
+}
+
+fn is_error_status(status: &str) -> bool {
+    matches!(
+        status,
+        "UNKNOWN"
+            | "DEADLINE_EXCEEDED"
+            | "UNIMPLEMENTED"
+            | "INTERNAL"
+            | "UNAVAILABLE"
+            | "DATA_LOSS"
+    )
+}
+
+fn parse_grpc_path(path: &str) -> Option<&str> {
+    let path = path.strip_prefix('/')?;
+    let (service, method) = path.rsplit_once('/')?;
+    if service.is_empty() || method.is_empty() {
+        return None;
+    }
+    Some(path)
+}
+
+fn instrumentation_scope() -> InstrumentationScope {
+    InstrumentationScope::builder(INSTRUMENTATION_NAME)
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_schema_url(semconv::SCHEMA_URL)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use http::{Request, Response, StatusCode};
+    use opentelemetry_sdk::metrics::{
+        data::{AggregatedMetrics, MetricData},
+        InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+    };
+    use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider};
+    use std::time::Duration;
+    use tower::Service;
+
+    #[test]
+    fn parses_grpc_path() {
+        assert_eq!(
+            parse_grpc_path("/opentelemetry.proto.collector.trace.v1.TraceService/Export"),
+            Some("opentelemetry.proto.collector.trace.v1.TraceService/Export")
+        );
+        assert_eq!(parse_grpc_path("/Service/Method"), Some("Service/Method"));
+        assert_eq!(parse_grpc_path("Service/Method"), None);
+        assert_eq!(parse_grpc_path("/Service"), None);
+        assert_eq!(parse_grpc_path("/Service/"), None);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_grpc_tracing_with_in_memory_tracer() {
+        let trace_exporter = InMemorySpanExporterBuilder::new().build();
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(trace_exporter.clone())
+            .build();
+
+        let layer = GRPCLayerBuilder::builder()
+            .with_tracer_provider(tracer_provider.clone())
+            .build();
+        let service = tower::service_fn(|_req: Request<String>| async {
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("grpc-status", "0")
+                    .body(String::new())
+                    .unwrap(),
+            )
+        });
+        let mut service = layer.layer(service);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("http://example.com/package.Service/GetThing")
+            .body(String::new())
+            .unwrap();
+
+        let _response = service.call(request).await.unwrap();
+        tracer_provider.force_flush().unwrap();
+
+        let spans = trace_exporter.get_finished_spans().unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].name, "package.Service/GetThing");
+        assert_eq!(
+            spans[0].attributes,
+            vec![
+                KeyValue::new(semconv::attribute::RPC_SYSTEM_NAME, "grpc"),
+                KeyValue::new(semconv::attribute::RPC_METHOD, "package.Service/GetThing"),
+                KeyValue::new(semconv::attribute::RPC_RESPONSE_STATUS_CODE, "OK"),
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_grpc_error_status_marks_span_error() {
+        let trace_exporter = InMemorySpanExporterBuilder::new().build();
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(trace_exporter.clone())
+            .build();
+
+        let layer = GRPCLayerBuilder::builder()
+            .with_tracer_provider(tracer_provider.clone())
+            .build();
+        let service = tower::service_fn(|_req: Request<String>| async {
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("grpc-status", "13")
+                    .body(String::new())
+                    .unwrap(),
+            )
+        });
+        let mut service = layer.layer(service);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("http://example.com/package.Service/GetThing")
+            .body(String::new())
+            .unwrap();
+
+        let _response = service.call(request).await.unwrap();
+        tracer_provider.force_flush().unwrap();
+
+        let spans = trace_exporter.get_finished_spans().unwrap();
+        assert_eq!(spans.len(), 1);
+        assert!(matches!(spans[0].status, Status::Error { .. }));
+        assert!(spans[0].attributes.contains(&KeyValue::new(
+            semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+            "INTERNAL"
+        )));
+        assert!(spans[0]
+            .attributes
+            .contains(&KeyValue::new(semconv::attribute::ERROR_TYPE, "INTERNAL")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_grpc_metrics_labels() {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(Duration::from_millis(100))
+            .build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let layer = GRPCLayerBuilder::builder()
+            .with_meter_provider(meter_provider.clone())
+            .build();
+
+        let service = tower::service_fn(|_req: Request<String>| async {
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("grpc-status", "0")
+                    .body(String::new())
+                    .unwrap(),
+            )
+        });
+        let mut service = layer.layer(service);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("http://example.com/package.Service/GetThing")
+            .body(String::new())
+            .unwrap();
+
+        let _response = service.call(request).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let metrics = exporter.get_finished_metrics().unwrap();
+        assert!(!metrics.is_empty());
+
+        let scope_metrics = metrics[0]
+            .scope_metrics()
+            .next()
+            .expect("Should have scope metrics");
+        let duration_metric = scope_metrics
+            .metrics()
+            .find(|m| m.name() == semconv::metric::RPC_SERVER_CALL_DURATION)
+            .expect("Duration metric should exist");
+
+        if let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = duration_metric.data() {
+            let data_point = histogram
+                .data_points()
+                .next()
+                .expect("Should have data point");
+            let attributes: Vec<_> = data_point.attributes().collect();
+            assert_eq!(attributes.len(), 3);
+            assert!(attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == semconv::attribute::RPC_SYSTEM_NAME
+                    && kv.value.as_str() == "grpc"));
+            assert!(attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == semconv::attribute::RPC_METHOD
+                    && kv.value.as_str() == "package.Service/GetThing"));
+            assert!(attributes.iter().any(|kv| kv.key.as_str()
+                == semconv::attribute::RPC_RESPONSE_STATUS_CODE
+                && kv.value.as_str() == "OK"));
+        } else {
+            panic!("Expected histogram data for duration metric");
+        }
+    }
+}

--- a/opentelemetry-instrumentation-tower/src/grpc.rs
+++ b/opentelemetry-instrumentation-tower/src/grpc.rs
@@ -648,7 +648,7 @@ mod tests {
 
     use std::convert::Infallible;
 
-    use http::{Request, Response, StatusCode};
+    use http::{Request, Response, StatusCode, Version};
     use http_body_util::{BodyExt, Empty};
     use opentelemetry_sdk::metrics::{
         data::{AggregatedMetrics, MetricData},
@@ -686,6 +686,27 @@ mod tests {
         }
     }
 
+    fn grpc_request() -> Request<Empty<&'static [u8]>> {
+        Request::builder()
+            .method("POST")
+            .uri("http://example.com/package.Service/GetThing")
+            .version(Version::HTTP_2)
+            .header("content-type", "application/grpc")
+            .header("te", "trailers")
+            .body(Empty::new())
+            .unwrap()
+    }
+
+    fn grpc_response<B>(grpc_status: &'static str, body: B) -> Response<B> {
+        Response::builder()
+            .status(StatusCode::OK)
+            .version(Version::HTTP_2)
+            .header("content-type", "application/grpc")
+            .header("grpc-status", grpc_status)
+            .body(body)
+            .unwrap()
+    }
+
     #[test]
     fn parses_grpc_path() {
         assert_eq!(
@@ -709,23 +730,11 @@ mod tests {
             .with_tracer_provider(tracer_provider.clone())
             .build();
         let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
-            Ok::<_, std::convert::Infallible>(
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header("grpc-status", "0")
-                    .body(Empty::<&'static [u8]>::new())
-                    .unwrap(),
-            )
+            Ok::<_, std::convert::Infallible>(grpc_response("0", Empty::<&'static [u8]>::new()))
         });
         let mut service = layer.layer(service);
 
-        let request = Request::builder()
-            .method("POST")
-            .uri("http://example.com/package.Service/GetThing")
-            .body(Empty::new())
-            .unwrap();
-
-        let response = service.call(request).await.unwrap();
+        let response = service.call(grpc_request()).await.unwrap();
         response.into_body().collect().await.unwrap();
         tracer_provider.force_flush().unwrap();
 
@@ -753,23 +762,11 @@ mod tests {
             .with_tracer_provider(tracer_provider.clone())
             .build();
         let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
-            Ok::<_, std::convert::Infallible>(
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header("grpc-status", "13")
-                    .body(Empty::<&'static [u8]>::new())
-                    .unwrap(),
-            )
+            Ok::<_, std::convert::Infallible>(grpc_response("13", Empty::<&'static [u8]>::new()))
         });
         let mut service = layer.layer(service);
 
-        let request = Request::builder()
-            .method("POST")
-            .uri("http://example.com/package.Service/GetThing")
-            .body(Empty::new())
-            .unwrap();
-
-        let response = service.call(request).await.unwrap();
+        let response = service.call(grpc_request()).await.unwrap();
         response.into_body().collect().await.unwrap();
         tracer_provider.force_flush().unwrap();
 
@@ -799,23 +796,11 @@ mod tests {
             let mut trailers = http::HeaderMap::new();
             trailers.insert("grpc-status", http::HeaderValue::from_static("13"));
 
-            Ok::<_, std::convert::Infallible>(
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header("grpc-status", "0")
-                    .body(TrailerBody::new(trailers))
-                    .unwrap(),
-            )
+            Ok::<_, std::convert::Infallible>(grpc_response("0", TrailerBody::new(trailers)))
         });
         let mut service = layer.layer(service);
 
-        let request = Request::builder()
-            .method("POST")
-            .uri("http://example.com/package.Service/GetThing")
-            .body(Empty::new())
-            .unwrap();
-
-        let response = service.call(request).await.unwrap();
+        let response = service.call(grpc_request()).await.unwrap();
         response.into_body().collect().await.unwrap();
         tracer_provider.force_flush().unwrap();
 
@@ -840,23 +825,11 @@ mod tests {
             .build();
 
         let service = tower::service_fn(|_req: Request<Empty<&'static [u8]>>| async {
-            Ok::<_, std::convert::Infallible>(
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header("grpc-status", "0")
-                    .body(Empty::<&'static [u8]>::new())
-                    .unwrap(),
-            )
+            Ok::<_, std::convert::Infallible>(grpc_response("0", Empty::<&'static [u8]>::new()))
         });
         let mut service = layer.layer(service);
 
-        let request = Request::builder()
-            .method("POST")
-            .uri("http://example.com/package.Service/GetThing")
-            .body(Empty::new())
-            .unwrap();
-
-        let response = service.call(request).await.unwrap();
+        let response = service.call(grpc_request()).await.unwrap();
         response.into_body().collect().await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -21,6 +21,8 @@ use pin_project_lite::pin_project;
 use tower_layer::Layer;
 use tower_service::Service;
 
+pub mod grpc;
+
 const HTTP_SERVER_DURATION_METRIC: &str = semconv::metric::HTTP_SERVER_REQUEST_DURATION;
 const HTTP_SERVER_DURATION_UNIT: &str = "s";
 

--- a/opentelemetry-instrumentation-tower/tests/grpc_tonic.rs
+++ b/opentelemetry-instrumentation-tower/tests/grpc_tonic.rs
@@ -1,0 +1,211 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use opentelemetry::trace::Status as SpanStatus;
+use opentelemetry::KeyValue;
+use opentelemetry_instrumentation_tower::grpc::GRPCLayerBuilder;
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    trace_service_client::TraceServiceClient,
+    trace_service_server::{TraceService, TraceServiceServer},
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+};
+use opentelemetry_sdk::metrics::{
+    data::{AggregatedMetrics, MetricData},
+    InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+};
+use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SdkTracerProvider};
+use opentelemetry_semantic_conventions as semconv;
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+const OTLP_TRACE_METHOD: &str = "opentelemetry.proto.collector.trace.v1.TraceService/Export";
+
+#[derive(Clone, Copy)]
+enum ServerBehavior {
+    Ok,
+    InternalError,
+}
+
+#[derive(Clone, Copy)]
+struct MockTraceService {
+    behavior: ServerBehavior,
+}
+
+#[tonic::async_trait]
+impl TraceService for MockTraceService {
+    async fn export(
+        &self,
+        _request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        match self.behavior {
+            ServerBehavior::Ok => Ok(Response::new(ExportTraceServiceResponse {
+                partial_success: None,
+            })),
+            ServerBehavior::InternalError => Err(Status::internal("boom")),
+        }
+    }
+}
+
+async fn spawn_trace_server(
+    behavior: ServerBehavior,
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+) -> (SocketAddr, oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpListenerStream::new(listener);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let layer = GRPCLayerBuilder::builder()
+        .with_tracer_provider(tracer_provider)
+        .with_meter_provider(meter_provider)
+        .build();
+    let service = TraceServiceServer::new(MockTraceService { behavior });
+
+    let handle = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .layer(layer)
+            .add_service(service)
+            .serve_with_incoming_shutdown(incoming, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    (addr, shutdown_tx, handle)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn records_real_tonic_unary_success() {
+    let trace_exporter = InMemorySpanExporterBuilder::new().build();
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(trace_exporter.clone())
+        .build();
+    let metric_exporter = InMemoryMetricExporter::default();
+    let reader = PeriodicReader::builder(metric_exporter.clone())
+        .with_interval(Duration::from_millis(100))
+        .build();
+    let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+    let (addr, shutdown_tx, server_handle) = spawn_trace_server(
+        ServerBehavior::Ok,
+        tracer_provider.clone(),
+        meter_provider.clone(),
+    )
+    .await;
+
+    let mut client = TraceServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+    client
+        .export(ExportTraceServiceRequest {
+            resource_spans: vec![],
+        })
+        .await
+        .unwrap();
+
+    tracer_provider.force_flush().unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let spans = trace_exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].name, OTLP_TRACE_METHOD);
+    assert_eq!(spans[0].status, SpanStatus::Unset);
+    assert_eq!(
+        spans[0].attributes,
+        vec![
+            KeyValue::new(semconv::attribute::RPC_SYSTEM_NAME, "grpc"),
+            KeyValue::new(semconv::attribute::RPC_METHOD, OTLP_TRACE_METHOD),
+            KeyValue::new(semconv::attribute::RPC_RESPONSE_STATUS_CODE, "OK"),
+        ]
+    );
+
+    let metrics = metric_exporter.get_finished_metrics().unwrap();
+    let duration_metric = metrics
+        .iter()
+        .flat_map(|resource_metrics| resource_metrics.scope_metrics())
+        .flat_map(|scope_metrics| scope_metrics.metrics())
+        .find(|metric| metric.name() == semconv::metric::RPC_SERVER_CALL_DURATION)
+        .expect("duration metric should exist");
+
+    if let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = duration_metric.data() {
+        let data_point = histogram
+            .data_points()
+            .next()
+            .expect("duration metric should have a data point");
+        let attributes: Vec<_> = data_point.attributes().collect();
+        assert!(attributes
+            .iter()
+            .any(|kv| kv.key.as_str() == semconv::attribute::RPC_SYSTEM_NAME
+                && kv.value.as_str() == "grpc"));
+        assert!(attributes
+            .iter()
+            .any(|kv| kv.key.as_str() == semconv::attribute::RPC_METHOD
+                && kv.value.as_str() == OTLP_TRACE_METHOD));
+        assert!(attributes.iter().any(|kv| kv.key.as_str()
+            == semconv::attribute::RPC_RESPONSE_STATUS_CODE
+            && kv.value.as_str() == "OK"));
+    } else {
+        panic!("expected histogram data for duration metric");
+    }
+
+    shutdown_tx.send(()).unwrap();
+    server_handle.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn records_real_tonic_unary_error_status() {
+    let trace_exporter = InMemorySpanExporterBuilder::new().build();
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(trace_exporter.clone())
+        .build();
+    let metric_exporter = InMemoryMetricExporter::default();
+    let reader = PeriodicReader::builder(metric_exporter)
+        .with_interval(Duration::from_millis(100))
+        .build();
+    let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+    let (addr, shutdown_tx, server_handle) = spawn_trace_server(
+        ServerBehavior::InternalError,
+        tracer_provider.clone(),
+        meter_provider,
+    )
+    .await;
+
+    let mut client = TraceServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+    let error = client
+        .export(ExportTraceServiceRequest {
+            resource_spans: vec![],
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), tonic::Code::Internal);
+
+    tracer_provider.force_flush().unwrap();
+
+    let spans = trace_exporter.get_finished_spans().unwrap();
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].name, OTLP_TRACE_METHOD);
+    assert!(spans[0]
+        .attributes
+        .contains(&KeyValue::new(semconv::attribute::RPC_SYSTEM_NAME, "grpc")));
+    assert!(spans[0].attributes.contains(&KeyValue::new(
+        semconv::attribute::RPC_METHOD,
+        OTLP_TRACE_METHOD
+    )));
+    assert!(spans[0].attributes.contains(&KeyValue::new(
+        semconv::attribute::RPC_RESPONSE_STATUS_CODE,
+        "INTERNAL"
+    )));
+    assert!(matches!(spans[0].status, SpanStatus::Error { .. }));
+    assert!(spans[0]
+        .attributes
+        .contains(&KeyValue::new(semconv::attribute::ERROR_TYPE, "INTERNAL")));
+
+    shutdown_tx.send(()).unwrap();
+    server_handle.await.unwrap();
+}


### PR DESCRIPTION
## Summary

Add a Tower gRPC server instrumentation layer with tracing and metrics.

This follows the existing Tower HTTP layer shape where it makes sense:

- `GRPCLayer` / `GRPCService` / `GRPCLayerBuilder` mirror the HTTP layer structure.
- Request and response custom attribute extractors are supported, like the HTTP layer.
- Provider-based configuration is supported through `with_tracer_provider` and `with_meter_provider`.
- The implementation avoids boxed response futures and uses concrete `pin-project-lite` futures, matching the current HTTP-layer performance direction.
- Request data is consumed by value during finalization, vectors are pre-sized, and small error label sets use stack arrays.

The layer records the current RPC semantic convention attributes/metric:

- `rpc.system.name = "grpc"`
- `rpc.method`
- `rpc.response.status_code`
- `error.type` for failed RPCs
- `rpc.server.call.duration`

## Design notes / caveats

- This is server-side instrumentation only.
- The layer derives `rpc.method` from gRPC request paths shaped like `/{service}/{method}` and uses that same value as the span name.
- There is intentionally no custom method extractor. Unlike HTTP paths, gRPC method cardinality is normally bounded by the proto service definition, so the route-extractor/cardinality problem from the HTTP layer does not apply in the same way.
- gRPC status is observed from `grpc-status` response headers and, for streaming responses, from trailers.
- Streaming/trailer support is implemented by wrapping the response body. This means the service response type changes to `Response<GRPCResponseBody<B>>`, but tonic accepts this because the wrapper preserves the inner body `Data` and `Error` types.
- Finalization happens when trailers are observed, when the body ends, on body error, or as a drop fallback.
- Duration therefore measures the response stream lifecycle, not just time-to-response-headers.
- The implementation currently records `rpc.server.call.duration` only. It does not attempt to mirror HTTP-only metrics like active requests or request/response body sizes.
- Error span status follows the RPC semantic-convention guidance for library-generated gRPC errors. Application-level gRPC status codes such as `NOT_FOUND` are not automatically treated as span errors.

## Tests / examples

- Unit tests cover path parsing, tracing attributes, error status, metrics labels, and trailers overriding header status.
- Unit fixtures are HTTP/2-shaped gRPC requests/responses (`POST`, `HTTP_2`, `content-type: application/grpc`, `te: trailers`) while still avoiding a full network stack.
- A real tonic integration test uses `opentelemetry-proto`'s generated OTLP `TraceService` client/server and applies `GRPCLayer` through `tonic::transport::Server::builder().layer(...)`.
- The tonic integration test verifies that the layer composes with tonic and records the expected span name and RPC semantic attributes from a real generated gRPC request.
- There is a small `examples/grpc.rs` showing layer usage with a Tower service.

Open question: I added the tonic integration test to validate compatibility with a real tonic server/client. Now that the lower-level unit tests are finalized, we may decide the integration test is not worth the additional dev dependency on `opentelemetry-proto`, `tonic`, and `tokio-stream`. I am happy to remove it if maintainers prefer to keep this crate's dev dependency surface smaller.

## Benchmarks

The existing `middleware` Criterion benchmark now includes a gRPC group parallel to the HTTP group.

Quick local run:

```sh
cargo bench -p opentelemetry-instrumentation-tower --bench middleware -- --quick
```

Approximate medians from that run:

| Scenario | HTTP total | gRPC total | HTTP overhead vs baseline | gRPC overhead vs baseline |
|---|---:|---:|---:|---:|
| baseline | 69 ns | 344 ns | - | - |
| no-op | 744 ns | 869 ns | +675 ns | +525 ns |
| tracing | 932 ns | 1.10 us | +863 ns | +752 ns |
| tracing sampled-out | 798 ns | 922 ns | +729 ns | +577 ns |
| metrics | 1.26 us | 982 ns | +1.19 us | +638 ns |
| tracing + metrics | 1.46 us | 1.25 us | +1.39 us | +907 ns |

Notes:

- Raw HTTP and gRPC totals are not apples-to-apples. The gRPC benchmark consumes the response body to trigger trailer/body finalization, so its baseline is higher.
- Overhead-over-baseline is a better comparison for the middleware cost.
- The gRPC metrics path currently does less work than the HTTP layer because it records only `rpc.server.call.duration`; the HTTP layer records additional HTTP metrics and labels.
- These are quick local numbers, intended as a regression sanity check rather than stable reference numbers.

## Testing

- `cargo fmt --package opentelemetry-instrumentation-tower`
- `cargo test -p opentelemetry-instrumentation-tower`
- `cargo check -p opentelemetry-instrumentation-tower --examples`
- `cargo check -p opentelemetry-instrumentation-tower --benches`
- `cargo bench -p opentelemetry-instrumentation-tower --bench middleware -- --quick`
