### PR TITLE
chore: Migrate geneva-uploader off unmaintained rustls-pemfile

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -23,7 +23,7 @@ uuid = { version = "1.0", features = ["v4"] }
 reqwest = { version = "0.12", features = ["http2"], default-features = false }
 native-tls = { version = "0.2", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
-rustls-pemfile = { version = "2", optional = true }
+rustls-pki-types = { version = "1.9", features = ["std"], optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 p12-keystore = { version = "0.2", optional = true }
 thiserror = "2.0"
@@ -61,7 +61,7 @@ tls-native = [
 ]
 tls-rustls = [
     "dep:rustls",
-    "dep:rustls-pemfile",
+    "dep:rustls-pki-types",
     "dep:rustls-native-certs",
     "dep:p12-keystore",
     "reqwest/rustls-tls-native-roots-no-provider",

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -1170,8 +1170,8 @@ fn build_rustls_client_config(
 
     #[cfg(test)]
     if let Some(root_ca_pem) = _test_root_ca_pem {
-        let mut reader = std::io::BufReader::new(root_ca_pem);
-        for cert in rustls_pemfile::certs(&mut reader) {
+        use rustls_pki_types::pem::PemObject;
+        for cert in rustls_pki_types::CertificateDer::pem_slice_iter(root_ca_pem) {
             let cert = cert.map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
             roots
                 .add(cert)


### PR DESCRIPTION
rustls-pemfile is unmaintained (RUSTSEC-2025-0134). Replace it with the PEM parsing now exposed directly by rustls-pki-types (>=1.9) via the PemObject trait, using CertificateDer::pem_slice_iter in the tls-rustls code path. This removes the direct rustls-pemfile dependency for downstream consumers such as otap-dataflow.
