### PR TITLE
chore: fix cargo-deny advisory failures

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,4 +31,7 @@ ignore = [
     # exporter is planned for removal (see #609), at which point this entry
     # can be dropped.
     "RUSTSEC-2026-0174",
+    # quick-xml 0.26.0; dev-only via pprof -> inferno. No upstream fix yet.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
Ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 (quick-xml 0.26.0) in `deny.toml`

Refs: https://rustsec.org/advisories/RUSTSEC-2026-0194, https://rustsec.org/advisories/RUSTSEC-2026-0195