### PR TITLE
feat(geneva-uploader): route logs and spans by table name

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 use geneva_uploader::client::{EncodedBatch, GenevaClient, GenevaClientConfig, UploadError};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
 use std::path::PathBuf;
@@ -596,10 +596,10 @@ pub unsafe extern "C" fn geneva_client_new(
         role_name,
         role_instance,
         msi_resource,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map,
@@ -1645,10 +1645,10 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -2177,10 +2177,10 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -2306,10 +2306,10 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -2473,10 +2473,10 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -2600,10 +2600,10 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -2773,10 +2773,10 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 use geneva_uploader::client::{EncodedBatch, GenevaClient, GenevaClientConfig, UploadError};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
 use std::path::PathBuf;
@@ -596,6 +596,12 @@ pub unsafe extern "C" fn geneva_client_new(
         role_name,
         role_instance,
         msi_resource,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map,
     };
 
@@ -1639,6 +1645,12 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
@@ -2165,6 +2177,12 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
@@ -2288,6 +2306,12 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
@@ -2456,6 +2480,12 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
         let client = GenevaClient::new(cfg).expect("failed to create GenevaClient with MockAuth");
@@ -2577,6 +2607,12 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 
@@ -2744,6 +2780,12 @@ mod tests {
             role_name: "testrole".to_string(),
             role_instance: "testinstance".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -2248,9 +2248,9 @@ mod tests {
         drop(mock_server);
     }
 
-    // Verifies batching groups by LogRecord.event_name:
-    // multiple different event_names in one request produce multiple batches,
-    // and each batch upload hits ingestion with the corresponding event query param.
+    // Verifies fixed-table routing for OTLP logs:
+    // multiple different record event names coalesce into one batch, and the
+    // upload uses the log table name as the event query param.
     #[test]
     #[cfg(all(feature = "mock_auth", feature = "otlp_bytes"))]
     fn test_encode_batching_by_event_name_and_upload() {
@@ -2364,9 +2364,9 @@ mod tests {
         assert_eq!(rc as u32, GenevaError::Success as u32, "encode failed");
         assert!(!batches_ptr.is_null());
 
-        // Expect 2 batches (EventA, EventB)
+        // Fixed-table routing coalesces different record event names into one batch.
         let len = unsafe { geneva_batches_len(batches_ptr) };
-        assert_eq!(len, 2, "expected 2 batches grouped by event_name");
+        assert_eq!(len, 1, "expected one batch for the log table");
 
         // Upload all batches
         for i in 0..len {
@@ -2383,9 +2383,8 @@ mod tests {
             };
         }
 
-        // Verify requests contain event=EventA and event=EventB in their URLs
-        // Poll until both POSTs appear or timeout to avoid flakiness
-        let (urls, has_a, has_b) = runtime().block_on(async {
+        // Verify requests use the fixed Log table name in their URLs.
+        let (urls, has_log_event) = runtime().block_on(async {
             use tokio::time::{sleep, Duration};
             let mut last_urls: Vec<String> = Vec::new();
             for _ in 0..200 {
@@ -2396,10 +2395,9 @@ mod tests {
                     .map(|r| r.url.to_string())
                     .collect();
 
-                let has_a = posts.iter().any(|u| u.contains("event=EventA"));
-                let has_b = posts.iter().any(|u| u.contains("event=EventB"));
-                if has_a && has_b {
-                    return (posts, true, true);
+                let has_log_event = posts.iter().any(|u| u.contains("event=Log"));
+                if has_log_event {
+                    return (posts, true);
                 }
 
                 if !posts.is_empty() {
@@ -2413,17 +2411,12 @@ mod tests {
                 let reqs = mock_server.received_requests().await.unwrap();
                 last_urls = reqs.into_iter().map(|r| r.url.to_string()).collect();
             }
-            let has_a = last_urls.iter().any(|u| u.contains("event=EventA"));
-            let has_b = last_urls.iter().any(|u| u.contains("event=EventB"));
-            (last_urls, has_a, has_b)
+            let has_log_event = last_urls.iter().any(|u| u.contains("event=Log"));
+            (last_urls, has_log_event)
         });
         assert!(
-            has_a,
-            "Expected request containing event=EventA; got: {urls:?}"
-        );
-        assert!(
-            has_b,
-            "Expected request containing event=EventB; got: {urls:?}"
+            has_log_event,
+            "Expected request containing event=Log; got: {urls:?}"
         );
 
         // Cleanup
@@ -2578,8 +2571,8 @@ mod tests {
         );
 
         let len = unsafe { geneva_batches_len(batches_ptr) };
-        // Two different event names → two batches
-        assert_eq!(len, 2, "expected one batch per event name");
+        // Fixed-table routing coalesces different record event names into one batch.
+        assert_eq!(len, 1, "expected one batch for the log table");
 
         unsafe { geneva_batches_free(batches_ptr) };
         let raw_handle = Box::into_raw(handle_box);

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -11,6 +11,7 @@
   to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`
   version and avoid duplicate `LogsDataView` trait errors. API-compatible;
   the view trait signatures are unchanged.
+- `GenevaClientConfig` now applies signal-specific defaults consistently on emitted batches: when `logs.default_event_name` / `spans.default_event_name` is set, encoded batches use that value as `event_name`; when unset, they fall back to `Log` and `Span` respectively.
 
 ## [0.5.0] - 2026-04-13
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
@@ -37,7 +37,7 @@
 //! records will appear in Geneva under the event name `"Log"`.
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use otap_df_pdata_views::views::{
     common::{AnyValueView, AttributeView, InstrumentationScopeView, ValueType},
     logs::{LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView},
@@ -344,6 +344,12 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     })
     .expect("Failed to create GenevaClient");

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
@@ -37,7 +37,7 @@
 //! records will appear in Geneva under the event name `"Log"`.
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use otap_df_pdata_views::views::{
     common::{AnyValueView, AttributeView, InstrumentationScopeView, ValueType},
     logs::{LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView},
@@ -344,10 +344,10 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, InstrumentationScope, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
@@ -142,10 +142,10 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, InstrumentationScope, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
@@ -142,6 +142,12 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     })
     .expect("Failed to create GenevaClient");

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -190,7 +190,12 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(black_box(&view), black_box(&metadata), "Log", None)
+                            .encode_logs_from_view(
+                                black_box(&view),
+                                black_box(&metadata),
+                                "Log",
+                                None,
+                            )
                             .unwrap();
                         black_box(res);
                     });
@@ -222,7 +227,12 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(black_box(&view), black_box(&metadata), "Log", None)
+                            .encode_logs_from_view(
+                                black_box(&view),
+                                black_box(&metadata),
+                                "Log",
+                                None,
+                            )
                             .unwrap();
                         black_box(res);
                     });

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -190,12 +190,7 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(
-                                black_box(&view),
-                                black_box(&metadata),
-                                "Log",
-                                None,
-                            )
+                            .encode_logs_from_view(black_box(&view), black_box(&metadata), "Log", None)
                             .unwrap();
                         black_box(res);
                     });
@@ -227,12 +222,7 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(
-                                black_box(&view),
-                                black_box(&metadata),
-                                "Log",
-                                None,
-                            )
+                            .encode_logs_from_view(black_box(&view), black_box(&metadata), "Log", None)
                             .unwrap();
                         black_box(res);
                     });

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -190,7 +190,12 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(black_box(&view), black_box(&metadata), None)
+                            .encode_logs_from_view(
+                                black_box(&view),
+                                black_box(&metadata),
+                                "Log",
+                                None,
+                            )
                             .unwrap();
                         black_box(res);
                     });
@@ -222,7 +227,12 @@ mod benchmarks {
                     b.iter(|| {
                         let view = RawLogsData::new(black_box(request_bytes.as_slice()));
                         let res = encoder
-                            .encode_logs_from_view(black_box(&view), black_box(&metadata), None)
+                            .encode_logs_from_view(
+                                black_box(&view),
+                                black_box(&metadata),
+                                "Log",
+                                None,
+                            )
                             .unwrap();
                         black_box(res);
                     });
@@ -249,7 +259,7 @@ mod benchmarks {
             b.iter(|| {
                 let view = RawLogsData::new(black_box(mixed_request_bytes.as_slice()));
                 let res = encoder
-                    .encode_logs_from_view(black_box(&view), black_box(&metadata), None)
+                    .encode_logs_from_view(black_box(&view), black_box(&metadata), "Log", None)
                     .unwrap();
                 black_box(res);
             });

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -111,23 +111,12 @@ pub struct GenevaClient {
     obo_event_map: Option<OboEventMap>,
 }
 
-fn effective_table_name<'a>(
-    default_event_name: Option<&'a str>,
-    fallback: &'static str,
-) -> &'a str {
-    let Some(default_event_name) = default_event_name else {
-        return fallback;
-    };
-
-    default_event_name
-}
-
 impl GenevaClient {
     pub fn new(cfg: GenevaClientConfig) -> Result<Self, String> {
         let log_table_name: Arc<str> =
-            effective_table_name(cfg.logs.default_event_name.as_deref(), "Log").into();
+            cfg.logs.default_event_name.as_deref().unwrap_or("Log").into();
         let span_table_name: Arc<str> =
-            effective_table_name(cfg.spans.default_event_name.as_deref(), "Span").into();
+            cfg.spans.default_event_name.as_deref().unwrap_or("Span").into();
 
         info!(
             name: "client.new",
@@ -434,9 +423,12 @@ mod tests {
     }
 
     #[test]
-    fn effective_table_name_prefers_override_and_falls_back() {
-        assert_eq!(effective_table_name(Some("AppLog"), "Log"), "AppLog");
-        assert_eq!(effective_table_name(None, "Log"), "Log");
+    fn default_event_name_unwrap_or_prefers_override_and_falls_back() {
+        let configured = Some("AppLog");
+        let missing: Option<&str> = None;
+
+        assert_eq!(configured.unwrap_or("Log"), "AppLog");
+        assert_eq!(missing.unwrap_or("Log"), "Log");
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -107,7 +107,8 @@ pub struct GenevaClient {
     uploader: Arc<GenevaUploader>,
     encoder: OtlpEncoder,
     metadata_fields: MetadataFields,
-    config: GenevaClientConfig,
+    log_table_name: Arc<str>,
+    span_table_name: Arc<str>,
     obo_event_map: Option<OboEventMap>,
 }
 
@@ -124,7 +125,10 @@ fn effective_table_name<'a>(
 
 impl GenevaClient {
     pub fn new(cfg: GenevaClientConfig) -> Result<Self, String> {
-        let client_config = cfg.clone();
+        let log_table_name: Arc<str> =
+            effective_table_name(cfg.logs.default_event_name.as_deref(), "Log").into();
+        let span_table_name: Arc<str> =
+            effective_table_name(cfg.spans.default_event_name.as_deref(), "Span").into();
 
         info!(
             name: "client.new",
@@ -234,7 +238,8 @@ impl GenevaClient {
             uploader: Arc::new(uploader),
             encoder: OtlpEncoder::new(),
             metadata_fields,
-            config: client_config,
+            log_table_name,
+            span_table_name,
             obo_event_map: cfg.obo_event_map,
         })
     }
@@ -281,14 +286,11 @@ impl GenevaClient {
             "Encoding and compressing logs"
         );
 
-        let table_name =
-            effective_table_name(self.config.logs.default_event_name.as_deref(), "Log");
-
         self.encoder
             .encode_logs_from_view(
                 view,
                 &self.metadata_fields,
-                table_name,
+                self.log_table_name.as_ref(),
                 self.obo_event_map.as_ref(),
             )
             .map_err(|e| {
@@ -319,14 +321,11 @@ impl GenevaClient {
             .flat_map(|resource_span| resource_span.scope_spans.iter())
             .flat_map(|scope_span| scope_span.spans.iter());
 
-        let table_name =
-            effective_table_name(self.config.spans.default_event_name.as_deref(), "Span");
-
         self.encoder
             .encode_span_batch(
                 span_iter,
                 &self.metadata_fields,
-                table_name,
+                self.span_table_name.as_ref(),
                 self.obo_event_map.as_ref(),
             )
             .map_err(|e| {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -47,8 +47,22 @@ pub struct GenevaClientConfig {
     pub role_name: String,
     pub role_instance: String,
     pub msi_resource: Option<String>, // Required for Managed Identity variants
+    pub logs: LogMethod,
+    pub spans: SpanMethod,
     pub obo_event_map: Option<OboEventMap>, // Per-event OBO config (None = no OBO)
 }
+
+#[derive(Clone, Debug)]
+pub struct LogMethod {
+    pub default_event_name: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SpanMethod {
+    pub default_event_name: Option<String>,
+}
+
+
 
 /// Error type returned by [`GenevaClient::upload_batch`].
 ///
@@ -95,11 +109,22 @@ pub struct GenevaClient {
     uploader: Arc<GenevaUploader>,
     encoder: OtlpEncoder,
     metadata_fields: MetadataFields,
+    config: GenevaClientConfig,
     obo_event_map: Option<OboEventMap>,
+}
+
+fn effective_table_name<'a>(default_event_name: Option<&'a str>, fallback: &'static str) -> &'a str {
+    let Some(default_event_name) = default_event_name else {
+        return fallback;
+    };
+
+    default_event_name
 }
 
 impl GenevaClient {
     pub fn new(cfg: GenevaClientConfig) -> Result<Self, String> {
+        let client_config = cfg.clone();
+
         info!(
             name: "client.new",
             target: "geneva-uploader",
@@ -107,6 +132,14 @@ impl GenevaClient {
             namespace = %cfg.namespace,
             account = %cfg.account,
             "Initializing GenevaClient"
+        );
+
+        info!(
+            name: "client.new.geneva_event_name",
+            target: "geneva-uploader",
+            logs_default_event_name = %cfg.logs.default_event_name.as_deref().unwrap_or("<none>"),
+            spans_default_event_name = %cfg.spans.default_event_name.as_deref().unwrap_or("<none>"),
+            "Using LogMethod and SpanMethod configuration"
         );
 
         // Validate MSI resource presence for managed identity variants
@@ -200,6 +233,7 @@ impl GenevaClient {
             uploader: Arc::new(uploader),
             encoder: OtlpEncoder::new(),
             metadata_fields,
+            config: client_config,
             obo_event_map: cfg.obo_event_map,
         })
     }
@@ -246,8 +280,18 @@ impl GenevaClient {
             "Encoding and compressing logs"
         );
 
+        let table_name = effective_table_name(
+            self.config.logs.default_event_name.as_deref(),
+            "Log",
+        );
+
         self.encoder
-            .encode_logs_from_view(view, &self.metadata_fields, self.obo_event_map.as_ref())
+            .encode_logs_from_view(
+                view,
+                &self.metadata_fields,
+                table_name,
+                self.obo_event_map.as_ref(),
+            )
             .map_err(|e| {
                 debug!(
                     name: "client.encode_and_compress_logs.error",
@@ -276,10 +320,16 @@ impl GenevaClient {
             .flat_map(|resource_span| resource_span.scope_spans.iter())
             .flat_map(|scope_span| scope_span.spans.iter());
 
+        let table_name = effective_table_name(
+            self.config.spans.default_event_name.as_deref(),
+            "Span",
+        );
+
         self.encoder
             .encode_span_batch(
                 span_iter,
                 &self.metadata_fields,
+                table_name,
                 self.obo_event_map.as_ref(),
             )
             .map_err(|e| {
@@ -349,3 +399,213 @@ impl GenevaClient {
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct OptionalMethodConfig {
+        logs: Option<LogMethod>,
+        spans: Option<SpanMethod>,
+    }
+
+    fn resolve_log_table_name(default_event_name: Option<&str>) -> String {
+        let logs = LogMethod {
+            default_event_name: default_event_name.map(str::to_owned),
+        };
+
+        effective_table_name(logs.default_event_name.as_deref(), "Log").to_string()
+    }
+
+    fn resolve_span_table_name(default_event_name: Option<&str>) -> String {
+        let spans = SpanMethod {
+            default_event_name: default_event_name.map(str::to_owned),
+        };
+
+        effective_table_name(spans.default_event_name.as_deref(), "Span").to_string()
+    }
+
+    fn build_config(logs: Option<LogMethod>, spans: Option<SpanMethod>) -> GenevaClientConfig {
+        build_config_from_optional(OptionalMethodConfig { logs, spans })
+    }
+
+    fn build_config_from_optional(optional: OptionalMethodConfig) -> GenevaClientConfig {
+        GenevaClientConfig {
+            endpoint: "https://example.test".to_string(),
+            environment: "Test".to_string(),
+            account: "acct".to_string(),
+            namespace: "ns".to_string(),
+            region: "eastus".to_string(),
+            config_major_version: 2,
+            auth_method: AuthMethod::WorkloadIdentity {
+                resource: "https://monitor.azure.com".to_string(),
+            },
+            tenant: "tenant".to_string(),
+            role_name: "role".to_string(),
+            role_instance: "instance".to_string(),
+            msi_resource: None,
+            logs: optional.logs.unwrap_or(LogMethod {
+                default_event_name: None,
+            }),
+            spans: optional.spans.unwrap_or(SpanMethod {
+                default_event_name: None,
+            }),
+            obo_event_map: Some(HashMap::new()),
+        }
+    }
+
+    fn build_config_with_logs_none(spans: Option<SpanMethod>) -> GenevaClientConfig {
+        build_config_from_optional(OptionalMethodConfig {
+            logs: None,
+            spans,
+        })
+    }
+
+    fn build_config_with_spans_none(logs: Option<LogMethod>) -> GenevaClientConfig {
+        build_config_from_optional(OptionalMethodConfig {
+            logs,
+            spans: None,
+        })
+    }
+
+    #[test]
+    fn logs_table_name_defaults_to_log_when_none() {
+        assert_eq!(resolve_log_table_name(None), "Log");
+    }
+
+    #[test]
+    fn config_logs_default_event_name_none_uses_log_table_name() {
+        let config = build_config_with_logs_none(Some(SpanMethod {
+            default_event_name: Some("SpanOverride".to_string()),
+        }));
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+
+        assert_eq!(log_table_name, "Log");
+    }
+
+    #[test]
+    fn config_logs_none_helper_keeps_span_override() {
+        let config = build_config_with_logs_none(Some(SpanMethod {
+            default_event_name: Some("SpanOverride".to_string()),
+        }));
+        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+
+        assert_eq!(span_table_name, "SpanOverride");
+    }
+
+    #[test]
+    fn config_logs_none_helper_uses_span_fallback_when_none() {
+        let config = build_config_with_logs_none(None);
+        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+
+        assert_eq!(span_table_name, "Span");
+    }
+
+    #[test]
+    fn config_spans_none_helper_keeps_log_override() {
+        let config = build_config_with_spans_none(Some(LogMethod {
+            default_event_name: Some("LogOverride".to_string()),
+        }));
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+
+        assert_eq!(log_table_name, "LogOverride");
+    }
+
+    #[test]
+    fn config_spans_none_helper_uses_log_fallback_when_none() {
+        let config = build_config_with_spans_none(None);
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+
+        assert_eq!(log_table_name, "Log");
+    }
+
+    #[test]
+    fn config_build_helper_none_and_override_works() {
+        let config = build_config(
+            None,
+            Some(SpanMethod {
+                default_event_name: Some("SpanOverride".to_string()),
+            }),
+        );
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+
+        assert_eq!(log_table_name, "Log");
+    }
+
+    #[test]
+    fn config_from_optional_logs_missing_uses_log_fallback() {
+        let config = build_config_from_optional(OptionalMethodConfig {
+            logs: None,
+            spans: Some(SpanMethod {
+                default_event_name: Some("SpanOverride".to_string()),
+            }),
+        });
+
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+
+        assert_eq!(log_table_name, "Log");
+        assert_eq!(span_table_name, "SpanOverride");
+    }
+
+    #[test]
+    fn config_from_optional_spans_missing_uses_span_fallback() {
+        let config = build_config_from_optional(OptionalMethodConfig {
+            logs: Some(LogMethod {
+                default_event_name: Some("LogOverride".to_string()),
+            }),
+            spans: None,
+        });
+
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+
+        assert_eq!(log_table_name, "LogOverride");
+        assert_eq!(span_table_name, "Span");
+    }
+
+    #[test]
+    fn logs_table_name_uses_default_event_name_when_set() {
+        assert_eq!(resolve_log_table_name(Some("UserEvent")), "UserEvent");
+    }
+
+    #[test]
+    fn spans_table_name_defaults_to_span_when_none() {
+        assert_eq!(resolve_span_table_name(None), "Span");
+    }
+
+    #[test]
+    fn config_spans_default_event_name_none_uses_span_table_name() {
+        let config = build_config_with_spans_none(Some(LogMethod {
+            default_event_name: Some("LogOverride".to_string()),
+        }));
+        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+
+        assert_eq!(span_table_name, "Span");
+    }
+
+    #[test]
+    fn spans_table_name_uses_default_event_name_when_set() {
+        assert_eq!(resolve_span_table_name(Some("SpanEvent")), "SpanEvent");
+    }
+
+    #[test]
+    fn config_logs_and_spans_default_event_name_set_use_overrides() {
+        let config = build_config(
+            Some(LogMethod {
+                default_event_name: Some("LogOverride".to_string()),
+            }),
+            Some(SpanMethod {
+                default_event_name: Some("SpanOverride".to_string()),
+            }),
+        );
+
+        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+
+        assert_eq!(log_table_name, "LogOverride");
+        assert_eq!(span_table_name, "SpanOverride");
+    }
+}
+

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -61,7 +61,6 @@ pub struct LogsConfig {
 pub struct TracesConfig {
     pub default_event_name: Option<String>,
 }
-
 /// Error type returned by [`GenevaClient::upload_batch`].
 ///
 /// Provides enough information for callers to implement retry strategies:

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -47,18 +47,18 @@ pub struct GenevaClientConfig {
     pub role_name: String,
     pub role_instance: String,
     pub msi_resource: Option<String>, // Required for Managed Identity variants
-    pub logs: LogMethod,
-    pub spans: SpanMethod,
+    pub logs: LogsConfig,
+    pub spans: TracesConfig,
     pub obo_event_map: Option<OboEventMap>, // Per-event OBO config (None = no OBO)
 }
 
 #[derive(Clone, Debug)]
-pub struct LogMethod {
+pub struct LogsConfig {
     pub default_event_name: Option<String>,
 }
 
 #[derive(Clone, Debug)]
-pub struct SpanMethod {
+pub struct TracesConfig {
     pub default_event_name: Option<String>,
 }
 
@@ -144,7 +144,7 @@ impl GenevaClient {
             target: "geneva-uploader",
             logs_default_event_name = %cfg.logs.default_event_name.as_deref().unwrap_or("<none>"),
             spans_default_event_name = %cfg.spans.default_event_name.as_deref().unwrap_or("<none>"),
-            "Using LogMethod and SpanMethod configuration"
+            "Using LogsConfig and TracesConfig configuration"
         );
 
         // Validate MSI resource presence for managed identity variants
@@ -402,12 +402,12 @@ mod tests {
     use std::collections::HashMap;
 
     struct OptionalMethodConfig {
-        logs: Option<LogMethod>,
-        spans: Option<SpanMethod>,
+        logs: Option<LogsConfig>,
+        spans: Option<TracesConfig>,
     }
 
     fn resolve_log_table_name(default_event_name: Option<&str>) -> String {
-        let logs = LogMethod {
+        let logs = LogsConfig {
             default_event_name: default_event_name.map(str::to_owned),
         };
 
@@ -415,14 +415,14 @@ mod tests {
     }
 
     fn resolve_span_table_name(default_event_name: Option<&str>) -> String {
-        let spans = SpanMethod {
+        let spans = TracesConfig {
             default_event_name: default_event_name.map(str::to_owned),
         };
 
         effective_table_name(spans.default_event_name.as_deref(), "Span").to_string()
     }
 
-    fn build_config(logs: Option<LogMethod>, spans: Option<SpanMethod>) -> GenevaClientConfig {
+    fn build_config(logs: Option<LogsConfig>, spans: Option<TracesConfig>) -> GenevaClientConfig {
         build_config_from_optional(OptionalMethodConfig { logs, spans })
     }
 
@@ -441,21 +441,21 @@ mod tests {
             role_name: "role".to_string(),
             role_instance: "instance".to_string(),
             msi_resource: None,
-            logs: optional.logs.unwrap_or(LogMethod {
+            logs: optional.logs.unwrap_or(LogsConfig {
                 default_event_name: None,
             }),
-            spans: optional.spans.unwrap_or(SpanMethod {
+            spans: optional.spans.unwrap_or(TracesConfig {
                 default_event_name: None,
             }),
             obo_event_map: Some(HashMap::new()),
         }
     }
 
-    fn build_config_with_logs_none(spans: Option<SpanMethod>) -> GenevaClientConfig {
+    fn build_config_with_logs_none(spans: Option<TracesConfig>) -> GenevaClientConfig {
         build_config_from_optional(OptionalMethodConfig { logs: None, spans })
     }
 
-    fn build_config_with_spans_none(logs: Option<LogMethod>) -> GenevaClientConfig {
+    fn build_config_with_spans_none(logs: Option<LogsConfig>) -> GenevaClientConfig {
         build_config_from_optional(OptionalMethodConfig { logs, spans: None })
     }
 
@@ -466,7 +466,7 @@ mod tests {
 
     #[test]
     fn config_logs_default_event_name_none_uses_log_table_name() {
-        let config = build_config_with_logs_none(Some(SpanMethod {
+        let config = build_config_with_logs_none(Some(TracesConfig {
             default_event_name: Some("SpanOverride".to_string()),
         }));
         let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn config_logs_none_helper_keeps_span_override() {
-        let config = build_config_with_logs_none(Some(SpanMethod {
+        let config = build_config_with_logs_none(Some(TracesConfig {
             default_event_name: Some("SpanOverride".to_string()),
         }));
         let span_table_name =
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn config_spans_none_helper_keeps_log_override() {
-        let config = build_config_with_spans_none(Some(LogMethod {
+        let config = build_config_with_spans_none(Some(LogsConfig {
             default_event_name: Some("LogOverride".to_string()),
         }));
         let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
@@ -516,7 +516,7 @@ mod tests {
     fn config_build_helper_none_and_override_works() {
         let config = build_config(
             None,
-            Some(SpanMethod {
+            Some(TracesConfig {
                 default_event_name: Some("SpanOverride".to_string()),
             }),
         );
@@ -529,7 +529,7 @@ mod tests {
     fn config_from_optional_logs_missing_uses_log_fallback() {
         let config = build_config_from_optional(OptionalMethodConfig {
             logs: None,
-            spans: Some(SpanMethod {
+            spans: Some(TracesConfig {
                 default_event_name: Some("SpanOverride".to_string()),
             }),
         });
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn config_from_optional_spans_missing_uses_span_fallback() {
         let config = build_config_from_optional(OptionalMethodConfig {
-            logs: Some(LogMethod {
+            logs: Some(LogsConfig {
                 default_event_name: Some("LogOverride".to_string()),
             }),
             spans: None,
@@ -571,7 +571,7 @@ mod tests {
 
     #[test]
     fn config_spans_default_event_name_none_uses_span_table_name() {
-        let config = build_config_with_spans_none(Some(LogMethod {
+        let config = build_config_with_spans_none(Some(LogsConfig {
             default_event_name: Some("LogOverride".to_string()),
         }));
         let span_table_name =
@@ -588,10 +588,10 @@ mod tests {
     #[test]
     fn config_logs_and_spans_default_event_name_set_use_overrides() {
         let config = build_config(
-            Some(LogMethod {
+            Some(LogsConfig {
                 default_event_name: Some("LogOverride".to_string()),
             }),
-            Some(SpanMethod {
+            Some(TracesConfig {
                 default_event_name: Some("SpanOverride".to_string()),
             }),
         );

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -432,11 +432,19 @@ mod tests {
 
     #[test]
     fn default_event_name_unwrap_or_prefers_override_and_falls_back() {
-        let configured = Some("AppLog");
-        let missing: Option<&str> = None;
+        let configured = maybe_event_name(true);
+        let missing = maybe_event_name(false);
 
         assert_eq!(configured.unwrap_or("Log"), "AppLog");
         assert_eq!(missing.unwrap_or("Log"), "Log");
+    }
+
+    fn maybe_event_name(configured: bool) -> Option<&'static str> {
+        if configured {
+            Some("AppLog")
+        } else {
+            None
+        }
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -398,34 +398,13 @@ impl GenevaClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+    use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+    use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+    use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
+    use prost::Message as _;
 
-    struct OptionalMethodConfig {
-        logs: Option<LogsConfig>,
-        spans: Option<TracesConfig>,
-    }
-
-    fn resolve_log_table_name(default_event_name: Option<&str>) -> String {
-        let logs = LogsConfig {
-            default_event_name: default_event_name.map(str::to_owned),
-        };
-
-        effective_table_name(logs.default_event_name.as_deref(), "Log").to_string()
-    }
-
-    fn resolve_span_table_name(default_event_name: Option<&str>) -> String {
-        let spans = TracesConfig {
-            default_event_name: default_event_name.map(str::to_owned),
-        };
-
-        effective_table_name(spans.default_event_name.as_deref(), "Span").to_string()
-    }
-
-    fn build_config(logs: Option<LogsConfig>, spans: Option<TracesConfig>) -> GenevaClientConfig {
-        build_config_from_optional(OptionalMethodConfig { logs, spans })
-    }
-
-    fn build_config_from_optional(optional: OptionalMethodConfig) -> GenevaClientConfig {
+    fn build_config(logs: Option<&str>, spans: Option<&str>) -> GenevaClientConfig {
         GenevaClientConfig {
             endpoint: "https://example.test".to_string(),
             environment: "Test".to_string(),
@@ -440,166 +419,70 @@ mod tests {
             role_name: "role".to_string(),
             role_instance: "instance".to_string(),
             msi_resource: None,
-            logs: optional.logs.unwrap_or(LogsConfig {
-                default_event_name: None,
-            }),
-            spans: optional.spans.unwrap_or(TracesConfig {
-                default_event_name: None,
-            }),
-            obo_event_map: Some(HashMap::new()),
+            logs: LogsConfig {
+                default_event_name: logs.map(str::to_owned),
+            },
+            spans: TracesConfig {
+                default_event_name: spans.map(str::to_owned),
+            },
+            obo_event_map: None,
         }
     }
 
-    fn build_config_with_logs_none(spans: Option<TracesConfig>) -> GenevaClientConfig {
-        build_config_from_optional(OptionalMethodConfig { logs: None, spans })
-    }
-
-    fn build_config_with_spans_none(logs: Option<LogsConfig>) -> GenevaClientConfig {
-        build_config_from_optional(OptionalMethodConfig { logs, spans: None })
+    fn build_client(logs: Option<&str>, spans: Option<&str>) -> GenevaClient {
+        GenevaClient::new(build_config(logs, spans)).expect("client should initialize")
     }
 
     #[test]
-    fn logs_table_name_defaults_to_log_when_none() {
-        assert_eq!(resolve_log_table_name(None), "Log");
+    fn effective_table_name_prefers_override_and_falls_back() {
+        assert_eq!(effective_table_name(Some("AppLog"), "Log"), "AppLog");
+        assert_eq!(effective_table_name(None, "Log"), "Log");
     }
 
     #[test]
-    fn config_logs_default_event_name_none_uses_log_table_name() {
-        let config = build_config_with_logs_none(Some(TracesConfig {
-            default_event_name: Some("SpanOverride".to_string()),
-        }));
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
+    fn encode_and_compress_logs_uses_configured_default_event_name() {
+        let client = build_client(Some("AppLog"), None);
 
-        assert_eq!(log_table_name, "Log");
+        let request = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord::default()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let bytes = request.encode_to_vec();
+        let view = RawLogsData::new(&bytes);
+        let batches = client
+            .encode_and_compress_logs(&view)
+            .expect("log encoding should succeed");
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].event_name, "AppLog");
     }
 
     #[test]
-    fn config_logs_none_helper_keeps_span_override() {
-        let config = build_config_with_logs_none(Some(TracesConfig {
-            default_event_name: Some("SpanOverride".to_string()),
-        }));
-        let span_table_name =
-            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+    fn encode_and_compress_spans_uses_configured_default_event_name() {
+        let client = build_client(None, Some("AppTrace"));
 
-        assert_eq!(span_table_name, "SpanOverride");
-    }
+        let spans = vec![ResourceSpans {
+            scope_spans: vec![ScopeSpans {
+                spans: vec![Span {
+                    name: "span-name".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
 
-    #[test]
-    fn config_logs_none_helper_uses_span_fallback_when_none() {
-        let config = build_config_with_logs_none(None);
-        let span_table_name =
-            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let batches = client
+            .encode_and_compress_spans(&spans)
+            .expect("span encoding should succeed");
 
-        assert_eq!(span_table_name, "Span");
-    }
-
-    #[test]
-    fn config_spans_none_helper_keeps_log_override() {
-        let config = build_config_with_spans_none(Some(LogsConfig {
-            default_event_name: Some("LogOverride".to_string()),
-        }));
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-
-        assert_eq!(log_table_name, "LogOverride");
-    }
-
-    #[test]
-    fn config_spans_none_helper_uses_log_fallback_when_none() {
-        let config = build_config_with_spans_none(None);
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-
-        assert_eq!(log_table_name, "Log");
-    }
-
-    #[test]
-    fn config_build_helper_none_and_override_works() {
-        let config = build_config(
-            None,
-            Some(TracesConfig {
-                default_event_name: Some("SpanOverride".to_string()),
-            }),
-        );
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-
-        assert_eq!(log_table_name, "Log");
-    }
-
-    #[test]
-    fn config_from_optional_logs_missing_uses_log_fallback() {
-        let config = build_config_from_optional(OptionalMethodConfig {
-            logs: None,
-            spans: Some(TracesConfig {
-                default_event_name: Some("SpanOverride".to_string()),
-            }),
-        });
-
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-        let span_table_name =
-            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
-
-        assert_eq!(log_table_name, "Log");
-        assert_eq!(span_table_name, "SpanOverride");
-    }
-
-    #[test]
-    fn config_from_optional_spans_missing_uses_span_fallback() {
-        let config = build_config_from_optional(OptionalMethodConfig {
-            logs: Some(LogsConfig {
-                default_event_name: Some("LogOverride".to_string()),
-            }),
-            spans: None,
-        });
-
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-        let span_table_name =
-            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
-
-        assert_eq!(log_table_name, "LogOverride");
-        assert_eq!(span_table_name, "Span");
-    }
-
-    #[test]
-    fn logs_table_name_uses_default_event_name_when_set() {
-        assert_eq!(resolve_log_table_name(Some("UserEvent")), "UserEvent");
-    }
-
-    #[test]
-    fn spans_table_name_defaults_to_span_when_none() {
-        assert_eq!(resolve_span_table_name(None), "Span");
-    }
-
-    #[test]
-    fn config_spans_default_event_name_none_uses_span_table_name() {
-        let config = build_config_with_spans_none(Some(LogsConfig {
-            default_event_name: Some("LogOverride".to_string()),
-        }));
-        let span_table_name =
-            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
-
-        assert_eq!(span_table_name, "Span");
-    }
-
-    #[test]
-    fn spans_table_name_uses_default_event_name_when_set() {
-        assert_eq!(resolve_span_table_name(Some("SpanEvent")), "SpanEvent");
-    }
-
-    #[test]
-    fn config_logs_and_spans_default_event_name_set_use_overrides() {
-        let config = build_config(
-            Some(LogsConfig {
-                default_event_name: Some("LogOverride".to_string()),
-            }),
-            Some(TracesConfig {
-                default_event_name: Some("SpanOverride".to_string()),
-            }),
-        );
-
-        let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-        let span_table_name =
-            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
-
-        assert_eq!(log_table_name, "LogOverride");
-        assert_eq!(span_table_name, "SpanOverride");
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].event_name, "AppTrace");
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -62,8 +62,6 @@ pub struct SpanMethod {
     pub default_event_name: Option<String>,
 }
 
-
-
 /// Error type returned by [`GenevaClient::upload_batch`].
 ///
 /// Provides enough information for callers to implement retry strategies:
@@ -113,7 +111,10 @@ pub struct GenevaClient {
     obo_event_map: Option<OboEventMap>,
 }
 
-fn effective_table_name<'a>(default_event_name: Option<&'a str>, fallback: &'static str) -> &'a str {
+fn effective_table_name<'a>(
+    default_event_name: Option<&'a str>,
+    fallback: &'static str,
+) -> &'a str {
     let Some(default_event_name) = default_event_name else {
         return fallback;
     };
@@ -280,10 +281,8 @@ impl GenevaClient {
             "Encoding and compressing logs"
         );
 
-        let table_name = effective_table_name(
-            self.config.logs.default_event_name.as_deref(),
-            "Log",
-        );
+        let table_name =
+            effective_table_name(self.config.logs.default_event_name.as_deref(), "Log");
 
         self.encoder
             .encode_logs_from_view(
@@ -320,10 +319,8 @@ impl GenevaClient {
             .flat_map(|resource_span| resource_span.scope_spans.iter())
             .flat_map(|scope_span| scope_span.spans.iter());
 
-        let table_name = effective_table_name(
-            self.config.spans.default_event_name.as_deref(),
-            "Span",
-        );
+        let table_name =
+            effective_table_name(self.config.spans.default_event_name.as_deref(), "Span");
 
         self.encoder
             .encode_span_batch(
@@ -456,17 +453,11 @@ mod tests {
     }
 
     fn build_config_with_logs_none(spans: Option<SpanMethod>) -> GenevaClientConfig {
-        build_config_from_optional(OptionalMethodConfig {
-            logs: None,
-            spans,
-        })
+        build_config_from_optional(OptionalMethodConfig { logs: None, spans })
     }
 
     fn build_config_with_spans_none(logs: Option<LogMethod>) -> GenevaClientConfig {
-        build_config_from_optional(OptionalMethodConfig {
-            logs,
-            spans: None,
-        })
+        build_config_from_optional(OptionalMethodConfig { logs, spans: None })
     }
 
     #[test]
@@ -489,7 +480,8 @@ mod tests {
         let config = build_config_with_logs_none(Some(SpanMethod {
             default_event_name: Some("SpanOverride".to_string()),
         }));
-        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let span_table_name =
+            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
 
         assert_eq!(span_table_name, "SpanOverride");
     }
@@ -497,7 +489,8 @@ mod tests {
     #[test]
     fn config_logs_none_helper_uses_span_fallback_when_none() {
         let config = build_config_with_logs_none(None);
-        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let span_table_name =
+            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
 
         assert_eq!(span_table_name, "Span");
     }
@@ -543,7 +536,8 @@ mod tests {
         });
 
         let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let span_table_name =
+            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
 
         assert_eq!(log_table_name, "Log");
         assert_eq!(span_table_name, "SpanOverride");
@@ -559,7 +553,8 @@ mod tests {
         });
 
         let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let span_table_name =
+            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
 
         assert_eq!(log_table_name, "LogOverride");
         assert_eq!(span_table_name, "Span");
@@ -580,7 +575,8 @@ mod tests {
         let config = build_config_with_spans_none(Some(LogMethod {
             default_event_name: Some("LogOverride".to_string()),
         }));
-        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let span_table_name =
+            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
 
         assert_eq!(span_table_name, "Span");
     }
@@ -602,10 +598,10 @@ mod tests {
         );
 
         let log_table_name = effective_table_name(config.logs.default_event_name.as_deref(), "Log");
-        let span_table_name = effective_table_name(config.spans.default_event_name.as_deref(), "Span");
+        let span_table_name =
+            effective_table_name(config.spans.default_event_name.as_deref(), "Span");
 
         assert_eq!(log_table_name, "LogOverride");
         assert_eq!(span_table_name, "SpanOverride");
     }
 }
-

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -113,10 +113,18 @@ pub struct GenevaClient {
 
 impl GenevaClient {
     pub fn new(cfg: GenevaClientConfig) -> Result<Self, String> {
-        let log_table_name: Arc<str> =
-            cfg.logs.default_event_name.as_deref().unwrap_or("Log").into();
-        let span_table_name: Arc<str> =
-            cfg.spans.default_event_name.as_deref().unwrap_or("Span").into();
+        let log_table_name: Arc<str> = cfg
+            .logs
+            .default_event_name
+            .as_deref()
+            .unwrap_or("Log")
+            .into();
+        let span_table_name: Arc<str> = cfg
+            .spans
+            .default_event_name
+            .as_deref()
+            .unwrap_or("Span")
+            .into();
 
         info!(
             name: "client.new",

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -344,6 +344,12 @@ mod tests {
             }
 
             let request = String::from_utf8_lossy(&request);
+            if request.trim().is_empty() {
+                // Some failure-path tests (for example, untrusted CA) can
+                // establish/tear down the socket without sending an HTTP
+                // request body. Do not fail those tests on an empty request.
+                return;
+            }
             assert!(
                 request.starts_with("GET /api/agent/v3/mockenv/mockacct/MonitoringStorageKeys/?"),
                 "unexpected request: {request}",

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -18,5 +18,5 @@ pub(crate) use ingestion_service::uploader::{
 };
 
 pub use client::EncodedBatch;
-pub use client::{GenevaClient, GenevaClientConfig, LogMethod, SpanMethod, UploadError};
+pub use client::{GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig, UploadError};
 pub use config_service::client::AuthMethod;

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -18,5 +18,5 @@ pub(crate) use ingestion_service::uploader::{
 };
 
 pub use client::EncodedBatch;
-pub use client::{GenevaClient, GenevaClientConfig, UploadError};
+pub use client::{GenevaClient, GenevaClientConfig, LogMethod, SpanMethod, UploadError};
 pub use config_service::client::AuthMethod;

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -3258,7 +3258,7 @@ mod tests {
         };
         let result = encode_log_batch_via_proto_with_obo(
             &OtlpEncoder::new(),
-            [log].iter(),
+            [log.clone()].iter(),
             &metadata,
             Some(&obo_map),
         );
@@ -3277,7 +3277,7 @@ mod tests {
         };
         let result = encode_log_batch_via_proto_with_obo(
             &OtlpEncoder::new(),
-            [log].iter(),
+            [log.clone()].iter(),
             &metadata,
             Some(&obo_map),
         );
@@ -3296,7 +3296,7 @@ mod tests {
         };
         let result = encode_log_batch_via_proto_with_obo(
             &OtlpEncoder::new(),
-            [log].iter(),
+            [log.clone()].iter(),
             &metadata,
             Some(&obo_map),
         );
@@ -3314,7 +3314,7 @@ mod tests {
     fn test_obo_fields_in_log_schema() {
         let metadata = make_metadata("TestNamespace");
         let obo_map = make_obo_event_map(
-            "TestEvent",
+            "Log",
             "Microsoft.SomeService",
             Some(r#"<Config onBehalfFields="resourceId" priority="Normal"/>"#),
         );
@@ -3326,7 +3326,7 @@ mod tests {
         };
         let result = encode_log_batch_via_proto_with_obo(
             &OtlpEncoder::new(),
-            [log].iter(),
+            [log.clone()].iter(),
             &metadata,
             Some(&obo_map),
         );
@@ -3334,6 +3334,13 @@ mod tests {
         let batches = result.unwrap();
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].row_count, 1);
+
+        let without_obo = encode_log_batch_via_proto(&OtlpEncoder::new(), [log.clone()].iter(), &metadata)
+            .unwrap();
+        assert_ne!(
+            batches[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
+            "table-keyed OBO config should change the encoded schema"
+        );
     }
 
     #[test]
@@ -3355,7 +3362,7 @@ mod tests {
     #[test]
     fn test_obo_identity_only_no_annotations() {
         let metadata = make_metadata("TestNamespace");
-        let obo_map = make_obo_event_map("TestEvent", "Microsoft.SomeService", None);
+        let obo_map = make_obo_event_map("Log", "Microsoft.SomeService", None);
         let log = LogRecord {
             observed_time_unix_nano: 1_700_000_000_000_000_000,
             event_name: "TestEvent".to_string(),
@@ -3364,7 +3371,7 @@ mod tests {
         };
         let result = encode_log_batch_via_proto_with_obo(
             &OtlpEncoder::new(),
-            [log].iter(),
+            [log.clone()].iter(),
             &metadata,
             Some(&obo_map),
         );
@@ -3408,7 +3415,7 @@ mod tests {
     fn test_encode_log_batch_with_obo() {
         let metadata = make_metadata("TestNamespace");
         let obo_map = make_obo_event_map(
-            "TestEvent",
+            "Log",
             "Microsoft.BatchService",
             Some(r#"<Config onBehalfFields="resourceId"/>"#),
         );
@@ -3421,7 +3428,7 @@ mod tests {
         };
         let result = encode_log_batch_via_proto_with_obo(
             &OtlpEncoder::new(),
-            [log].iter(),
+            [log.clone()].iter(),
             &metadata,
             Some(&obo_map),
         );
@@ -3429,6 +3436,13 @@ mod tests {
         let batches = result.unwrap();
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].row_count, 1);
+
+        let without_obo = encode_log_batch_via_proto(&OtlpEncoder::new(), [log.clone()].iter(), &metadata)
+            .unwrap();
+        assert_ne!(
+            batches[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
+            "table-keyed OBO should be visible in the encoded schema"
+        );
     }
 
     #[test]
@@ -3460,7 +3474,7 @@ mod tests {
     fn test_mixed_batch_obo_and_non_obo_events() {
         let metadata = make_metadata("TestNamespace");
         let obo_map = make_obo_event_map(
-            "OboEvent",
+            "Log",
             "Microsoft.OboService",
             Some(r#"<Config onBehalfFields="resourceId"/>"#),
         );
@@ -3489,6 +3503,7 @@ mod tests {
             1,
             "Routing table is fixed; events share one batch"
         );
+        assert_eq!(batches[0].event_name, "Log");
     }
 
     #[test]
@@ -3509,7 +3524,7 @@ mod tests {
         let metadata = make_metadata("TestNamespace");
         let mut obo_map = HashMap::new();
         obo_map.insert(
-            "TestEvent".to_string(),
+            "Log".to_string(),
             OboEventConfig {
                 identity: "".to_string(),
                 annotations: Some("some annotations".to_string()),
@@ -3535,7 +3550,7 @@ mod tests {
         let metadata = make_metadata("TestNamespace");
         let mut obo_map = HashMap::new();
         obo_map.insert(
-            "TestEvent".to_string(),
+            "Log".to_string(),
             OboEventConfig {
                 identity: "   ".to_string(),
                 annotations: None,
@@ -3561,7 +3576,7 @@ mod tests {
         let metadata = make_metadata("TestNamespace");
         let mut obo_map = HashMap::new();
         obo_map.insert(
-            "TestEvent".to_string(),
+            "Log".to_string(),
             OboEventConfig {
                 identity: "Microsoft.TestService".to_string(),
                 annotations: Some("   ".to_string()),
@@ -3616,6 +3631,7 @@ mod tests {
 
         assert_eq!(with_obo.len(), 1);
         assert_eq!(with_obo[0].event_name, "Log");
+        assert_eq!(with_obo[0].row_count, 1);
         assert_ne!(
             with_obo[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
             "OBO config should apply when the routing table matches the OBO map key"

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -187,6 +187,7 @@ impl<'a> LogRecordParts<'a> {
     fn new<R: LogRecordView>(
         record: &'a R,
         metadata_fields: &'a MetadataFields,
+        table_name: &'a str,
         resource_role: &'a RoleOverrides,
         obo_event_map: Option<&'a OboEventMap>,
     ) -> Self {
@@ -202,9 +203,9 @@ impl<'a> LogRecordParts<'a> {
             .unwrap_or_else(|| Cow::Borrowed(&metadata_fields.role_instance));
 
         let mut parts = if is_common_schema_record(record) {
-            CommonSchemaParts::parse(record, role, role_instance).finish()
+            CommonSchemaParts::parse(record, role, role_instance, table_name).finish()
         } else {
-            Self::from_canonical(record, role, role_instance)
+            Self::from_canonical(record, role, role_instance, table_name)
         };
         parts.obo_config = lookup_obo_config(obo_event_map, parts.routing_event_name.as_ref());
         parts.finish_fields();
@@ -215,12 +216,11 @@ impl<'a> LogRecordParts<'a> {
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
+        table_name: &'a str,
     ) -> Self {
         let event_name = normalized_event_name(record);
         let name = event_name.map(Cow::Borrowed);
-        let routing_event_name = event_name
-            .map(Cow::Borrowed)
-            .unwrap_or_else(|| Cow::Borrowed(CS_LOG_TYPENAME));
+        let routing_event_name = Cow::Borrowed(table_name);
         let severity_text = record
             .severity_text()
             .and_then(|b| std::str::from_utf8(b).ok())
@@ -276,10 +276,11 @@ impl<'a> LogRecordParts<'a> {
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
+        table_name: &'a str,
     ) -> Self {
         Self {
             timestamp: record_timestamp(record),
-            routing_event_name: Cow::Borrowed(CS_LOG_TYPENAME),
+            routing_event_name: Cow::Borrowed(table_name),
             name: None,
             severity_number: record.severity_number().unwrap_or(0),
             severity_text: record
@@ -422,9 +423,10 @@ impl<'a> CommonSchemaParts<'a> {
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
+        table_name: &'a str,
     ) -> Self {
         Self {
-            parts: LogRecordParts::common_schema_base(record, role, role_instance),
+            parts: LogRecordParts::common_schema_base(record, role, role_instance, table_name),
             part_a_name: None,
             part_b_name: None,
         }
@@ -434,8 +436,9 @@ impl<'a> CommonSchemaParts<'a> {
         record: &'a R,
         role: Cow<'a, str>,
         role_instance: Cow<'a, str>,
+        table_name: &'a str,
     ) -> Self {
-        let mut common_schema = Self::new(record, role, role_instance);
+        let mut common_schema = Self::new(record, role, role_instance, table_name);
         let mut seen_common_schema_key = false;
 
         for attr in record.attributes() {
@@ -572,9 +575,6 @@ impl<'a> CommonSchemaParts<'a> {
 
     fn finish(mut self) -> LogRecordParts<'a> {
         self.parts.name = self.part_b_name.or(self.part_a_name);
-        if let Some(name) = &self.parts.name {
-            self.parts.routing_event_name = Cow::Owned(name.to_string());
-        }
         self.parts
     }
 }
@@ -827,10 +827,12 @@ impl LogBatchAccumulator {
         &mut self,
         record: &R,
         metadata_fields: &MetadataFields,
+        table_name: &str,
         resource_role: &RoleOverrides,
         obo_event_map: Option<&OboEventMap>,
     ) {
-        let parts = LogRecordParts::new(record, metadata_fields, resource_role, obo_event_map);
+        let parts =
+            LogRecordParts::new(record, metadata_fields, table_name, resource_role, obo_event_map);
         let timestamp = parts.timestamp;
         let routing_event_name = parts.routing_event_name.as_ref();
         // Role identity is included because the central blob metadata is batch-level.
@@ -990,6 +992,7 @@ impl OtlpEncoder {
         &self,
         view: &T,
         metadata_fields: &MetadataFields,
+        table_name: &str,
         obo_event_map: Option<&OboEventMap>,
     ) -> Result<Vec<EncodedBatch>, String> {
         let mut acc = LogBatchAccumulator::new();
@@ -1001,27 +1004,32 @@ impl OtlpEncoder {
                 .unwrap_or_default();
             for scope_logs in resource_logs.scopes() {
                 for log_record in scope_logs.log_records() {
-                    acc.push(&log_record, metadata_fields, &resource_role, obo_event_map);
+                    acc.push(
+                        &log_record,
+                        metadata_fields,
+                        table_name,
+                        &resource_role,
+                        obo_event_map,
+                    );
                 }
             }
         }
         acc.finalize()
     }
 
-    /// Encode a batch of spans into a single payload
-    /// All spans are grouped into a single batch with event_name "Span" for routing
+    /// Encode a batch of spans into a single payload.
+    /// All spans are grouped into a single batch using `table_name` for routing.
     /// The returned `data` field contains LZ4 chunked compressed bytes.
     /// On compression failure, the error is returned (no logging, no fallback).
     pub(crate) fn encode_span_batch<'a>(
         &self,
         spans: impl IntoIterator<Item = &'a Span>,
         metadata_fields: &MetadataFields,
+        table_name: &str,
         obo_event_map: Option<&OboEventMap>,
     ) -> Result<Vec<EncodedBatch>, String> {
-        // All spans use "Span" as event name for routing - no grouping by span name
-        const EVENT_NAME: &str = "Span";
-
-        let obo_config = lookup_obo_config(obo_event_map, EVENT_NAME);
+        // Spans are batched into one event table (no grouping by span name).
+        let obo_config = lookup_obo_config(obo_event_map, table_name);
         let mut schemas = Vec::new();
         let mut events = Vec::new();
         let mut start_time = u64::MAX;
@@ -1029,7 +1037,7 @@ impl OtlpEncoder {
 
         for span in spans {
             // 1. Get schema fields
-            let field_info = Self::determine_span_fields(span, EVENT_NAME, obo_config);
+            let field_info = Self::determine_span_fields(span, table_name, obo_config);
 
             // 2. Update timestamp range
             if span.start_time_unix_nano != 0 {
@@ -1070,7 +1078,7 @@ impl OtlpEncoder {
             let central_event = CentralEventEntry {
                 schema_id,
                 level,
-                event_name: Arc::from(EVENT_NAME),
+                event_name: Arc::from(table_name),
                 row: row_buffer,
             };
             events.push(central_event);
@@ -1142,7 +1150,7 @@ impl OtlpEncoder {
         debug!(
             name: "encoder.encode_span_batch",
             target: "geneva-uploader",
-            event_name = EVENT_NAME,
+            event_name = table_name,
             schemas = schemas_count,
             spans = events_count,
             uncompressed_size = uncompressed.len(),
@@ -1151,7 +1159,7 @@ impl OtlpEncoder {
         );
 
         Ok(vec![EncodedBatch {
-            event_name: EVENT_NAME.to_string(),
+            event_name: table_name.to_string(),
             data: compressed,
             metadata: batch_metadata,
             row_count: events_count,
@@ -1175,7 +1183,8 @@ impl OtlpEncoder {
             String::new(),
         );
         let role_overrides = RoleOverrides::default();
-        let parts = LogRecordParts::new(record, &metadata_fields, &role_overrides, None);
+        let parts =
+            LogRecordParts::new(record, &metadata_fields, CS_LOG_TYPENAME, &role_overrides, None);
         (parts.fields, parts.dynamic_fields_start)
     }
 
@@ -1188,7 +1197,8 @@ impl OtlpEncoder {
         metadata_fields: &MetadataFields,
     ) -> Vec<u8> {
         let role_overrides = RoleOverrides::default();
-        let parts = LogRecordParts::new(record, metadata_fields, &role_overrides, None);
+        let parts =
+            LogRecordParts::new(record, metadata_fields, CS_LOG_TYPENAME, &role_overrides, None);
         debug_assert_eq!(fields.len(), parts.fields.len());
         debug_assert_eq!(dynamic_fields_start, parts.dynamic_fields_start);
         Self::write_row_parts(&parts, metadata_fields)
@@ -1691,7 +1701,7 @@ mod tests {
             }],
         }
         .encode_to_vec();
-        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, obo_event_map)
+        encoder.encode_logs_from_view(&RawLogsData::new(&bytes), metadata, "Log", obo_event_map)
     }
 
     fn string_attr(key: &str, value: &str) -> KeyValue {
@@ -1856,10 +1866,10 @@ mod tests {
         let result =
             encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata).unwrap();
 
-        // Should create one batch (same event_name = "user_action")
+        // Should create one batch; routing table is fixed by encoder input.
         assert_eq!(result.len(), 1);
         let batch = &result[0];
-        assert_eq!(batch.event_name, "user_action");
+        assert_eq!(batch.event_name, "Log");
 
         // Verify that multiple schemas were created within the same batch
         // schema_ids should contain multiple semicolon-separated MD5 hashes
@@ -1907,7 +1917,7 @@ mod tests {
         let result = encode_log_batch_via_proto(&encoder, [log].iter(), &metadata).unwrap();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].event_name, "test_event");
+        assert_eq!(result[0].event_name, "Log");
         assert_eq!(result[0].compressed_size(), result[0].data.len());
         assert!(result[0].compressed_size() > 0);
     }
@@ -1966,7 +1976,7 @@ mod tests {
             encode_log_batch_via_proto(&encoder, [log.clone()].iter(), &metadata).unwrap();
         // Smoke test: a rich proto-backed view encodes to a single non-empty batch.
         assert_eq!(encoded.len(), 1);
-        assert_eq!(encoded[0].event_name, "view_event");
+        assert_eq!(encoded[0].event_name, "Log");
         assert!(!encoded[0].data.is_empty());
     }
 
@@ -2221,7 +2231,7 @@ mod tests {
         assert_eq!(encoded.len(), 2);
         assert!(encoded
             .iter()
-            .all(|batch| batch.event_name == "SharedEvent" && batch.row_count == 1));
+            .all(|batch| batch.event_name == "Log" && batch.row_count == 1));
     }
 
     #[test]
@@ -2405,7 +2415,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(encoded.len(), 1);
-        assert_eq!(encoded[0].event_name, "SharedEvent");
+        assert_eq!(encoded[0].event_name, "Log");
         assert_eq!(encoded[0].row_count, 2);
         assert!(!encoded[0].metadata.schema_ids.is_empty());
     }
@@ -2538,7 +2548,7 @@ mod tests {
         let export_bytes = wrap_log_record_bytes(&log_bytes);
 
         let actual = encoder
-            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, None)
+            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, "Log", None)
             .unwrap();
         assert_single_batch_equal(&expected, &actual);
     }
@@ -2570,7 +2580,7 @@ mod tests {
         let export_bytes = wrap_log_record_bytes(&log_bytes);
 
         let actual = encoder
-            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, None)
+            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, "Log", None)
             .unwrap();
         assert_single_batch_equal(&expected, &actual);
     }
@@ -2605,7 +2615,7 @@ mod tests {
         let export_bytes = wrap_log_record_bytes(&log_bytes);
 
         let actual = encoder
-            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, None)
+            .encode_logs_from_view(&RawLogsData::new(&export_bytes), &metadata, "Log", None)
             .unwrap();
         assert_single_batch_equal(&expected, &actual);
     }
@@ -2696,9 +2706,9 @@ mod tests {
         let result =
             encode_log_batch_via_proto(&encoder, [log1, log2, log3].iter(), &metadata).unwrap();
 
-        // All should be in one batch with same event_name
+        // All should be in one batch with the configured routing table.
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].event_name, "user_action");
+        assert_eq!(result[0].event_name, "Log");
         assert!(!result[0].data.is_empty());
         // Should have 3 different schema IDs (semicolon-separated)
         assert_eq!(result[0].metadata.schema_ids.matches(';').count(), 2); // 3 schemas = 2 semicolons
@@ -2723,12 +2733,10 @@ mod tests {
         let metadata = make_metadata("test");
         let result = encode_log_batch_via_proto(&encoder, [log1, log2].iter(), &metadata).unwrap();
 
-        // Should create 2 separate batches
-        assert_eq!(result.len(), 2);
-
-        let event_names: Vec<&String> = result.iter().map(|batch| &batch.event_name).collect();
-        assert!(event_names.contains(&&"login".to_string()));
-        assert!(event_names.contains(&&"logout".to_string()));
+        // Routing is fixed by table_name, so different record event names coalesce.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].event_name, "Log");
+        assert_eq!(result[0].row_count, 2);
 
         assert!(result.iter().all(|batch| !batch.data.is_empty()));
     }
@@ -2796,28 +2804,14 @@ mod tests {
             encode_log_batch_via_proto(&encoder, [log1, log2, log3, log4].iter(), &metadata)
                 .unwrap();
 
-        // Should create 3 batches: "user_action", "system_alert", "Log"
-        assert_eq!(result.len(), 3);
+        // Routing is fixed by table_name, so all rows are emitted in one batch.
+        assert_eq!(result.len(), 1);
 
-        let user_action = result
-            .iter()
-            .find(|batch| batch.event_name == "user_action")
-            .unwrap();
-        let system_alert = result
-            .iter()
-            .find(|batch| batch.event_name == "system_alert")
-            .unwrap();
-        let log_batch = result
-            .iter()
-            .find(|batch| batch.event_name == "Log")
-            .unwrap();
-
-        assert!(!user_action.data.is_empty());
-        assert_eq!(user_action.metadata.schema_ids.matches(';').count(), 1); // 2 schemas = 1 semicolon
-        assert!(!system_alert.data.is_empty());
-        assert_eq!(system_alert.metadata.schema_ids.matches(';').count(), 0); // 1 schema = 0 semicolons
-        assert!(!log_batch.data.is_empty());
-        assert_eq!(log_batch.metadata.schema_ids.matches(';').count(), 0); // 1 schema = 0 semicolons
+        let batch = &result[0];
+        assert_eq!(batch.event_name, "Log");
+        assert_eq!(batch.row_count, 4);
+        assert!(!batch.data.is_empty());
+        assert_eq!(batch.metadata.schema_ids.matches(';').count(), 2); // 3 schemas = 2 semicolons
     }
 
     #[test]
@@ -2855,7 +2849,7 @@ mod tests {
 
         let metadata = make_metadata("testNamespace");
         let result = encoder
-            .encode_span_batch([span].iter(), &metadata, None)
+            .encode_span_batch([span].iter(), &metadata, "Span", None)
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -2893,7 +2887,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result = encoder
-            .encode_span_batch([span].iter(), &metadata, None)
+            .encode_span_batch([span].iter(), &metadata, "Span", None)
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -2924,7 +2918,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result = encoder
-            .encode_span_batch([span].iter(), &metadata, None)
+            .encode_span_batch([span].iter(), &metadata, "Span", None)
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -2970,7 +2964,7 @@ mod tests {
 
         let metadata = make_metadata("test");
         let result = encoder
-            .encode_span_batch([span1, span2].iter(), &metadata, None)
+            .encode_span_batch([span1, span2].iter(), &metadata, "Span", None)
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -3074,7 +3068,7 @@ mod tests {
         ];
 
         let span_result = encoder
-            .encode_span_batch(spans.iter(), &metadata, None)
+            .encode_span_batch(spans.iter(), &metadata, "Span", None)
             .unwrap();
 
         assert_eq!(span_result.len(), 1);
@@ -3135,7 +3129,7 @@ mod tests {
 
         use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
         let encoded = encoder
-            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata, None)
+            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata, "Log", None)
             .unwrap();
 
         assert_eq!(encoded.len(), 1);
@@ -3206,24 +3200,17 @@ mod tests {
         .encode_to_vec();
 
         let result = encoder
-            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata, None)
+            .encode_logs_from_view(&RawLogsData::new(&bytes), &metadata, "Log", None)
             .unwrap();
 
-        // Two event names → two batches
-        assert_eq!(result.len(), 2);
+        // Routing is fixed by table_name; all records land in one batch.
+        assert_eq!(result.len(), 1);
 
-        let alpha = result.iter().find(|b| b.event_name == "alpha").unwrap();
-        let beta = result.iter().find(|b| b.event_name == "beta").unwrap();
-
-        // Each batch should contain records from both resources
-        assert_eq!(alpha.row_count, 2);
-        assert_eq!(beta.row_count, 2);
-
-        // Timestamp ranges should span across resources
-        assert_eq!(alpha.metadata.start_time, 1_000);
-        assert_eq!(alpha.metadata.end_time, 3_000);
-        assert_eq!(beta.metadata.start_time, 2_000);
-        assert_eq!(beta.metadata.end_time, 4_000);
+        let batch = &result[0];
+        assert_eq!(batch.event_name, "Log");
+        assert_eq!(batch.row_count, 4);
+        assert_eq!(batch.metadata.start_time, 1_000);
+        assert_eq!(batch.metadata.end_time, 4_000);
     }
 
     // ==================== OBO (On Behalf Of) Per-Event Tests ====================
@@ -3447,7 +3434,7 @@ mod tests {
             end_time_unix_nano: 1_700_000_001_000_000_000,
             ..Default::default()
         };
-        let result = encoder.encode_span_batch([span].iter(), &metadata, Some(&obo_map));
+        let result = encoder.encode_span_batch([span].iter(), &metadata, "Span", Some(&obo_map));
         assert!(result.is_ok(), "encode_span_batch with OBO should succeed");
         let batches = result.unwrap();
         assert_eq!(batches.len(), 1);
@@ -3482,11 +3469,7 @@ mod tests {
         );
         assert!(result.is_ok(), "Mixed batch should succeed");
         let batches = result.unwrap();
-        assert_eq!(
-            batches.len(),
-            2,
-            "Should have separate batches for different event names"
-        );
+        assert_eq!(batches.len(), 1, "Routing table is fixed; events share one batch");
     }
 
     #[test]
@@ -3587,7 +3570,7 @@ mod tests {
     fn test_common_schema_part_b_name_drives_obo_lookup() {
         let metadata = make_metadata("TestNamespace");
         let obo_map = make_obo_event_map(
-            "CommonSchemaEvent",
+            "Log",
             "Microsoft.CommonSchemaService",
             Some(r#"<Config onBehalfFields="resourceId"/>"#),
         );
@@ -3613,10 +3596,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(with_obo.len(), 1);
-        assert_eq!(with_obo[0].event_name, "CommonSchemaEvent");
+        assert_eq!(with_obo[0].event_name, "Log");
         assert_ne!(
             with_obo[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
-            "Common Schema PartB.name should select the OBO config for that event"
+            "OBO config should apply when the routing table matches the OBO map key"
         );
     }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -3335,8 +3335,9 @@ mod tests {
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].row_count, 1);
 
-        let without_obo = encode_log_batch_via_proto(&OtlpEncoder::new(), [log.clone()].iter(), &metadata)
-            .unwrap();
+        let without_obo =
+            encode_log_batch_via_proto(&OtlpEncoder::new(), [log.clone()].iter(), &metadata)
+                .unwrap();
         assert_ne!(
             batches[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
             "table-keyed OBO config should change the encoded schema"
@@ -3437,8 +3438,9 @@ mod tests {
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].row_count, 1);
 
-        let without_obo = encode_log_batch_via_proto(&OtlpEncoder::new(), [log.clone()].iter(), &metadata)
-            .unwrap();
+        let without_obo =
+            encode_log_batch_via_proto(&OtlpEncoder::new(), [log.clone()].iter(), &metadata)
+                .unwrap();
         assert_ne!(
             batches[0].metadata.schema_ids, without_obo[0].metadata.schema_ids,
             "table-keyed OBO should be visible in the encoded schema"

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -831,8 +831,13 @@ impl LogBatchAccumulator {
         resource_role: &RoleOverrides,
         obo_event_map: Option<&OboEventMap>,
     ) {
-        let parts =
-            LogRecordParts::new(record, metadata_fields, table_name, resource_role, obo_event_map);
+        let parts = LogRecordParts::new(
+            record,
+            metadata_fields,
+            table_name,
+            resource_role,
+            obo_event_map,
+        );
         let timestamp = parts.timestamp;
         let routing_event_name = parts.routing_event_name.as_ref();
         // Role identity is included because the central blob metadata is batch-level.
@@ -1183,8 +1188,13 @@ impl OtlpEncoder {
             String::new(),
         );
         let role_overrides = RoleOverrides::default();
-        let parts =
-            LogRecordParts::new(record, &metadata_fields, CS_LOG_TYPENAME, &role_overrides, None);
+        let parts = LogRecordParts::new(
+            record,
+            &metadata_fields,
+            CS_LOG_TYPENAME,
+            &role_overrides,
+            None,
+        );
         (parts.fields, parts.dynamic_fields_start)
     }
 
@@ -1197,8 +1207,13 @@ impl OtlpEncoder {
         metadata_fields: &MetadataFields,
     ) -> Vec<u8> {
         let role_overrides = RoleOverrides::default();
-        let parts =
-            LogRecordParts::new(record, metadata_fields, CS_LOG_TYPENAME, &role_overrides, None);
+        let parts = LogRecordParts::new(
+            record,
+            metadata_fields,
+            CS_LOG_TYPENAME,
+            &role_overrides,
+            None,
+        );
         debug_assert_eq!(fields.len(), parts.fields.len());
         debug_assert_eq!(dynamic_fields_start, parts.dynamic_fields_start);
         Self::write_row_parts(&parts, metadata_fields)
@@ -3469,7 +3484,11 @@ mod tests {
         );
         assert!(result.is_ok(), "Mixed batch should succeed");
         let batches = result.unwrap();
-        assert_eq!(batches.len(), 1, "Routing table is fixed; events share one batch");
+        assert_eq!(
+            batches.len(),
+            1,
+            "Routing table is fixed; events share one batch"
+        );
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -59,7 +59,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
 
     let detail = upload_single_batch_and_wait(&client, &server, &request_view).await;
     assert_eq!(detail["decode_status"], "decoded");
-    assert_eq!(detail["event_name"], "CheckoutEvent");
+    assert_eq!(detail["event_name"], "Log");
     assert_eq!(detail["row_count"], 1);
 
     let records = detail["records"].as_array().expect("records array");
@@ -102,10 +102,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     let common_schema_detail =
         upload_single_batch_and_wait(&client, &server, &common_schema_request_view).await;
     assert_eq!(common_schema_detail["decode_status"], "decoded");
-    assert_eq!(
-        common_schema_detail["event_name"],
-        "CommonSchemaCheckoutEvent"
-    );
+    assert_eq!(common_schema_detail["event_name"], "Log");
     assert_eq!(common_schema_detail["row_count"], 1);
 
     let records = common_schema_detail["records"]

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -1,5 +1,5 @@
 use geneva_test_server::testing::TestServer;
-use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value::Value, AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
@@ -22,10 +22,10 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
         role_name: "checkout".to_string(),
         role_instance: "instance-1".to_string(),
         msi_resource: None,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -5,6 +5,7 @@ use opentelemetry_proto::tonic::common::v1::{any_value::Value, AnyValue, KeyValu
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 use otap_df_pdata::views::otlp::bytes::logs::RawLogsData;
 use prost::Message as _;
+use std::collections::HashSet;
 
 #[tokio::test]
 #[ignore = "run by the dedicated geneva-uploader test-server CI job"]
@@ -57,7 +58,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     let request_bytes = request.encode_to_vec();
     let request_view = RawLogsData::new(&request_bytes);
 
-    let detail = upload_single_batch_and_wait(&client, &server, &request_view).await;
+    let detail = upload_single_batch_and_wait(&client, &server, &request_view, &[]).await;
     assert_eq!(detail["decode_status"], "decoded");
     assert_eq!(detail["event_name"], "Log");
     assert_eq!(detail["row_count"], 1);
@@ -70,6 +71,10 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     assert_eq!(payload["body"], "checkout failed");
     assert_eq!(payload["operation"], "checkout");
     assert_eq!(payload["result"], 127);
+    let first_request_id = detail["request_id"]
+        .as_str()
+        .expect("first request id")
+        .to_string();
 
     let common_schema_request = ExportLogsServiceRequest {
         resource_logs: vec![ResourceLogs {
@@ -99,8 +104,13 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     let common_schema_request_bytes = common_schema_request.encode_to_vec();
     let common_schema_request_view = RawLogsData::new(&common_schema_request_bytes);
 
-    let common_schema_detail =
-        upload_single_batch_and_wait(&client, &server, &common_schema_request_view).await;
+    let common_schema_detail = upload_single_batch_and_wait(
+        &client,
+        &server,
+        &common_schema_request_view,
+        &[first_request_id.as_str()],
+    )
+    .await;
     assert_eq!(common_schema_detail["decode_status"], "decoded");
     assert_eq!(common_schema_detail["event_name"], "Log");
     assert_eq!(common_schema_detail["row_count"], 1);
@@ -123,6 +133,7 @@ async fn upload_single_batch_and_wait(
     client: &GenevaClient,
     server: &TestServer,
     request_view: &RawLogsData<'_>,
+    exclude_request_ids: &[&str],
 ) -> serde_json::Value {
     let batches = client
         .encode_and_compress_logs(request_view)
@@ -133,7 +144,49 @@ async fn upload_single_batch_and_wait(
         .await
         .expect("batch should upload");
 
-    server.wait_for_request(&batches[0].event_name).await
+    let excluded: HashSet<&str> = exclude_request_ids.iter().copied().collect();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let http = reqwest::Client::new();
+    loop {
+        let list = http
+            .get(format!(
+                "{}/api/v1/debug/requests?event={}",
+                server.base_url(),
+                batches[0].event_name
+            ))
+            .send()
+            .await
+            .expect("list requests")
+            .json::<serde_json::Value>()
+            .await
+            .expect("decode request list");
+
+        if let Some(request_id) = list["items"].as_array().and_then(|items| {
+            items
+                .iter()
+                .filter_map(|item| item["request_id"].as_str())
+                .find(|id| !excluded.contains(*id))
+        }) {
+            let detail = http
+                .get(format!(
+                    "{}/api/v1/debug/requests/{request_id}/wait",
+                    server.base_url()
+                ))
+                .send()
+                .await
+                .expect("wait request")
+                .json::<serde_json::Value>()
+                .await
+                .expect("decode request detail");
+            return detail;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "request was not observed before timeout"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
 }
 
 fn string_attr(key: &str, value: &str) -> KeyValue {

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -1,5 +1,5 @@
 use geneva_test_server::testing::TestServer;
-use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig};
+use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogMethod, SpanMethod};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value::Value, AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
@@ -22,6 +22,12 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
         role_name: "checkout".to_string(),
         role_instance: "instance-1".to_string(),
         msi_resource: None,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     })
     .expect("client should initialize");

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -27,7 +27,7 @@
 //! ```
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -89,6 +89,12 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     };
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -27,7 +27,7 @@
 //! ```
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -89,10 +89,10 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic_msi_test`
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -105,6 +105,12 @@ async fn main() {
         role_instance,
         auth_method,
         msi_resource,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     };
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic_msi_test`
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -105,10 +105,10 @@ async fn main() {
         role_instance,
         auth_method,
         msi_resource,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic_workload_identity_test`
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -84,6 +84,12 @@ async fn main() {
         role_instance,
         auth_method,
         msi_resource: None, // Not used for Workload Identity
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     };
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic_workload_identity_test`
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -84,10 +84,10 @@ async fn main() {
         role_instance,
         auth_method,
         msi_resource: None, // Not used for Workload Identity
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example trace_basic
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry::{global, trace::Tracer, KeyValue};
 use opentelemetry_exporter_geneva::GenevaTraceExporter;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SimpleSpanProcessor};
@@ -57,10 +57,10 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
-        logs: LogMethod {
+        logs: LogsConfig {
             default_event_name: None,
         },
-        spans: SpanMethod {
+        spans: TracesConfig {
             default_event_name: None,
         },
         obo_event_map: None,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example trace_basic
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::AuthMethod;
+use geneva_uploader::{AuthMethod, LogMethod, SpanMethod};
 use opentelemetry::{global, trace::Tracer, KeyValue};
 use opentelemetry_exporter_geneva::GenevaTraceExporter;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SimpleSpanProcessor};
@@ -57,6 +57,12 @@ async fn main() {
         role_name,
         role_instance,
         msi_resource: None,
+        logs: LogMethod {
+            default_event_name: None,
+        },
+        spans: SpanMethod {
+            default_event_name: None,
+        },
         obo_event_map: None,
     };
 

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -130,8 +130,12 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             msi_resource: None,
-            logs: LogsConfig { default_event_name: None },
-            spans: TracesConfig { default_event_name: None },
+            logs: LogsConfig {
+                default_event_name: None,
+            },
+            spans: TracesConfig {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 
@@ -152,8 +156,12 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
-            logs: LogsConfig { default_event_name: None },
-            spans: TracesConfig { default_event_name: None },
+            logs: LogsConfig {
+                default_event_name: None,
+            },
+            spans: TracesConfig {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 
@@ -210,8 +218,12 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
-            logs: LogsConfig { default_event_name: None },
-            spans: TracesConfig { default_event_name: None },
+            logs: LogsConfig {
+                default_event_name: None,
+            },
+            spans: TracesConfig {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -33,7 +33,7 @@
         Progress: 449360 ops completed (449360 successful, 100.0%) in 30.01s = 14976.14 ops/sec
 
 */
-use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig};
+use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogMethod, SpanMethod};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
@@ -130,6 +130,12 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 
@@ -150,6 +156,12 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 
@@ -206,6 +218,12 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
+            logs: LogMethod {
+                default_event_name: None,
+            },
+            spans: SpanMethod {
+                default_event_name: None,
+            },
             obo_event_map: None,
         };
 

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -130,12 +130,8 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             msi_resource: None,
-            logs: LogsConfig {
-                default_event_name: None,
-            },
-            spans: TracesConfig {
-                default_event_name: None,
-            },
+            logs: LogsConfig { default_event_name: None },
+            spans: TracesConfig { default_event_name: None },
             obo_event_map: None,
         };
 
@@ -156,12 +152,8 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
-            logs: LogsConfig {
-                default_event_name: None,
-            },
-            spans: TracesConfig {
-                default_event_name: None,
-            },
+            logs: LogsConfig { default_event_name: None },
+            spans: TracesConfig { default_event_name: None },
             obo_event_map: None,
         };
 
@@ -218,12 +210,8 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
-            logs: LogsConfig {
-                default_event_name: None,
-            },
-            spans: TracesConfig {
-                default_event_name: None,
-            },
+            logs: LogsConfig { default_event_name: None },
+            spans: TracesConfig { default_event_name: None },
             obo_event_map: None,
         };
 

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -33,7 +33,7 @@
         Progress: 449360 ops completed (449360 successful, 100.0%) in 30.01s = 14976.14 ops/sec
 
 */
-use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogMethod, SpanMethod};
+use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
@@ -130,10 +130,10 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: std::env::var("GENEVA_ROLE").unwrap_or_else(|_| "test".to_string()),
             role_instance: std::env::var("GENEVA_INSTANCE").unwrap_or_else(|_| "test".to_string()),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -156,10 +156,10 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,
@@ -218,10 +218,10 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             role_name: "test".to_string(),
             role_instance: "test".to_string(),
             msi_resource: None,
-            logs: LogMethod {
+            logs: LogsConfig {
                 default_event_name: None,
             },
-            spans: SpanMethod {
+            spans: TracesConfig {
                 default_event_name: None,
             },
             obo_event_map: None,


### PR DESCRIPTION
This PR updates Geneva uploader routing so logs and spans use explicit table names from GenevaClientConfig via LogMethod and SpanMethod.

If default_event_name is not set, logs fall back to Log and spans fall back to Span. The change is applied through the uploader client, encoder, examples, FFI layer, stress harness, and integration tests. I also added unit coverage for the fallback and override behavior.

Validation:
- cargo build --workspace
- cargo test -p geneva-uploader --lib
- cargo test --workspace --all-targets

Note: this change also updates Geneva OBO lookup behavior to follow the fixed routing table name.