### PR TITLE
ci: add cargo-semver-checks workflow

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,30 @@
+name: Semver Checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: stable
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -28,3 +28,5 @@ jobs:
         with:
           toolchain: stable
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+        with:
+          exclude: opentelemetry-config

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   semver:
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 10
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -28,5 +27,23 @@ jobs:
         with:
           toolchain: stable
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+        id: semver
+        # Informational only: components in this repo are alpha/beta and
+        # breaking changes are expected. Keep the job green either way.
+        continue-on-error: true
         with:
           exclude: opentelemetry-config
+      - name: Surface findings as a warning
+        if: steps.semver.outcome == 'failure'
+        run: echo "::warning::cargo-semver-checks found semver-breaking API changes (informational only — see the job summary for details)"
+      - name: Write findings to job summary
+        if: steps.semver.outcome == 'failure'
+        run: |
+          {
+            echo "## cargo-semver-checks findings (informational)"
+            echo "Breaking API changes exist relative to the latest published crates.io versions."
+            echo "These persist until the affected crates are released with an appropriate version bump."
+            echo '```'
+            cargo semver-checks check-release --exclude opentelemetry-config 2>&1 | grep -E -A 12 "^--- failure" || echo "See the cargo-semver-checks step logs for details."
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Changes

Adds a `cargo-semver-checks` CI workflow that runs on every PR to detect accidental semver-breaking API changes before merge. Uses `continue-on-error: true` so it's informational (non-blocking) while the team gets familiar with it.

Follows the same pattern as the upstream [opentelemetry-rust semver workflow](https://github.com/open-telemetry/opentelemetry-rust/blob/main/.github/workflows/semver.yml).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)