### PR TITLE
feat(geneva-uploader): add agent-fed credential source

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - New `tls-rustls` feature flag enables a pure-Rust TLS backend (rustls + p12-keystore) as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. No built-in crypto provider (e.g. ring) is compiled in; consumers **must** install a `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start. The uploader returns a clear error if no provider is found.
+- Agent-fed credential source: `GenevaClient::with_agent_fed_source` builds an uploader that pulls a host-provisioned GIG token and routing (endpoint, moniker) from an `AgentFedCredentialSource` on each upload, skipping the GCS config-service handshake. New public API: `AgentFedCredentialSource`, `AgentFedCredential`, `AgentFedCredentialFuture`.
 
 ### Changed
 - Bump opentelemetry-proto version to 0.32.

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -13,7 +13,6 @@ license = "Apache-2.0"
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
-bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
+bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -168,7 +168,7 @@ struct ClientParts {
 impl GenevaClient {
     /// Derive the shared uploader config + stored parts; constructors differ
     /// only in how they build the `GenevaUploader` from the returned config.
-    fn derive_parts(cfg: &GenevaClientConfig) -> (GenevaUploaderConfig, ClientParts) {
+    fn derive_parts(cfg: GenevaClientConfig) -> (GenevaUploaderConfig, ClientParts) {
         let log_table_name: Arc<str> = cfg
             .logs
             .default_event_name
@@ -190,12 +190,12 @@ impl GenevaClient {
 
         // Metadata fields that will appear as Bond schema fields in Geneva.
         let metadata_fields = MetadataFields::new(
-            cfg.environment.clone(),
+            cfg.environment,
             config_version.clone(),
-            cfg.tenant.clone(),
-            cfg.role_name.clone(),
-            cfg.role_instance.clone(),
-            cfg.namespace.clone(),
+            cfg.tenant,
+            cfg.role_name,
+            cfg.role_instance,
+            cfg.namespace,
             config_version,
         );
 
@@ -212,7 +212,7 @@ impl GenevaClient {
                 log_table_name,
                 span_table_name,
                 metadata_fields,
-                obo_event_map: cfg.obo_event_map.clone(),
+                obo_event_map: cfg.obo_event_map,
             },
         )
     }
@@ -270,17 +270,15 @@ impl GenevaClient {
             AuthMethod::MockAuth => {}
         }
 
-        let (uploader_config, parts) = Self::derive_parts(&cfg);
-
         let config_client_config = GenevaConfigClientConfig {
-            endpoint: cfg.endpoint,
-            environment: cfg.environment,
-            account: cfg.account,
-            namespace: cfg.namespace,
-            region: cfg.region,
+            endpoint: cfg.endpoint.clone(),
+            environment: cfg.environment.clone(),
+            account: cfg.account.clone(),
+            namespace: cfg.namespace.clone(),
+            region: cfg.region.clone(),
             config_major_version: cfg.config_major_version,
-            auth_method: cfg.auth_method,
-            msi_resource: cfg.msi_resource,
+            auth_method: cfg.auth_method.clone(),
+            msi_resource: cfg.msi_resource.clone(),
             #[cfg(test)]
             test_root_ca_pem: None,
         };
@@ -294,6 +292,8 @@ impl GenevaClient {
                 );
                 format!("GenevaConfigClient init failed: {e}")
             })?);
+
+        let (uploader_config, parts) = Self::derive_parts(cfg);
 
         let uploader =
             GenevaUploader::from_config_client(config_client, uploader_config).map_err(|e| {
@@ -332,7 +332,7 @@ impl GenevaClient {
             "Initializing GenevaClient (agent-fed credential source)"
         );
 
-        let (uploader_config, parts) = Self::derive_parts(&cfg);
+        let (uploader_config, parts) = Self::derive_parts(cfg);
 
         let uploader = GenevaUploader::from_agent_fed(source, uploader_config).map_err(|e| {
             debug!(

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -156,8 +156,19 @@ pub struct GenevaClient {
     obo_event_map: Option<OboEventMap>,
 }
 
+/// Stored client pieces shared by every constructor (all of `Self` except the
+/// uploader and encoder), derived once so the constructors can't drift.
+struct ClientParts {
+    log_table_name: Arc<str>,
+    span_table_name: Arc<str>,
+    metadata_fields: MetadataFields,
+    obo_event_map: Option<OboEventMap>,
+}
+
 impl GenevaClient {
-    pub fn new(cfg: GenevaClientConfig) -> Result<Self, String> {
+    /// Derive the shared uploader config + stored parts; constructors differ
+    /// only in how they build the `GenevaUploader` from the returned config.
+    fn derive_parts(cfg: &GenevaClientConfig) -> (GenevaUploaderConfig, ClientParts) {
         let log_table_name: Arc<str> = cfg
             .logs
             .default_event_name
@@ -171,6 +182,54 @@ impl GenevaClient {
             .unwrap_or("Span")
             .into();
 
+        let source_identity = format!(
+            "Tenant={}/Role={}/RoleInstance={}",
+            cfg.tenant, cfg.role_name, cfg.role_instance
+        );
+        let config_version = format!("Ver{}v0", cfg.config_major_version);
+
+        // Metadata fields that will appear as Bond schema fields in Geneva.
+        let metadata_fields = MetadataFields::new(
+            cfg.environment.clone(),
+            config_version.clone(),
+            cfg.tenant.clone(),
+            cfg.role_name.clone(),
+            cfg.role_instance.clone(),
+            cfg.namespace.clone(),
+            config_version,
+        );
+
+        let uploader_config = GenevaUploaderConfig {
+            namespace: metadata_fields.namespace.clone(),
+            source_identity,
+            environment: metadata_fields.env_name.clone(),
+            config_version: metadata_fields.event_version.clone(),
+        };
+
+        (
+            uploader_config,
+            ClientParts {
+                log_table_name,
+                span_table_name,
+                metadata_fields,
+                obo_event_map: cfg.obo_event_map.clone(),
+            },
+        )
+    }
+
+    /// Assemble the final client from a built uploader and the shared parts.
+    fn assemble(uploader: GenevaUploader, parts: ClientParts) -> Self {
+        Self {
+            uploader: Arc::new(uploader),
+            encoder: OtlpEncoder::new(),
+            metadata_fields: parts.metadata_fields,
+            log_table_name: parts.log_table_name,
+            span_table_name: parts.span_table_name,
+            obo_event_map: parts.obo_event_map,
+        }
+    }
+
+    pub fn new(cfg: GenevaClientConfig) -> Result<Self, String> {
         info!(
             name: "client.new",
             target: "geneva-uploader",
@@ -210,11 +269,14 @@ impl GenevaClient {
             #[cfg(feature = "mock_auth")]
             AuthMethod::MockAuth => {}
         }
+
+        let (uploader_config, parts) = Self::derive_parts(&cfg);
+
         let config_client_config = GenevaConfigClientConfig {
             endpoint: cfg.endpoint,
-            environment: cfg.environment.clone(),
+            environment: cfg.environment,
             account: cfg.account,
-            namespace: cfg.namespace.clone(),
+            namespace: cfg.namespace,
             region: cfg.region,
             config_major_version: cfg.config_major_version,
             auth_method: cfg.auth_method,
@@ -233,31 +295,6 @@ impl GenevaClient {
                 format!("GenevaConfigClient init failed: {e}")
             })?);
 
-        let source_identity = format!(
-            "Tenant={}/Role={}/RoleInstance={}",
-            cfg.tenant, cfg.role_name, cfg.role_instance
-        );
-
-        let config_version = format!("Ver{}v0", cfg.config_major_version);
-
-        // Create metadata fields that will appear as Bond schema fields in Geneva
-        let metadata_fields = MetadataFields::new(
-            cfg.environment,
-            config_version.clone(),
-            cfg.tenant,
-            cfg.role_name,
-            cfg.role_instance,
-            cfg.namespace,
-            config_version,
-        );
-
-        let uploader_config = GenevaUploaderConfig {
-            namespace: metadata_fields.namespace.clone(),
-            source_identity,
-            environment: metadata_fields.env_name.clone(),
-            config_version: metadata_fields.event_version.clone(),
-        };
-
         let uploader =
             GenevaUploader::from_config_client(config_client, uploader_config).map_err(|e| {
                 debug!(
@@ -275,14 +312,7 @@ impl GenevaClient {
             "GenevaClient initialized successfully"
         );
 
-        Ok(Self {
-            uploader: Arc::new(uploader),
-            encoder: OtlpEncoder::new(),
-            metadata_fields,
-            log_table_name,
-            span_table_name,
-            obo_event_map: cfg.obo_event_map,
-        })
+        Ok(Self::assemble(uploader, parts))
     }
 
     /// Agent-fed construction: the host supplies the GIG credential via
@@ -302,39 +332,7 @@ impl GenevaClient {
             "Initializing GenevaClient (agent-fed credential source)"
         );
 
-        let log_table_name: Arc<str> = cfg
-            .logs
-            .default_event_name
-            .as_deref()
-            .unwrap_or("Log")
-            .into();
-        let span_table_name: Arc<str> = cfg
-            .spans
-            .default_event_name
-            .as_deref()
-            .unwrap_or("Span")
-            .into();
-
-        let source_identity = format!(
-            "Tenant={}/Role={}/RoleInstance={}",
-            cfg.tenant, cfg.role_name, cfg.role_instance
-        );
-        let config_version = format!("Ver{}v0", cfg.config_major_version);
-        let metadata_fields = MetadataFields::new(
-            cfg.environment.clone(),
-            config_version.clone(),
-            cfg.tenant.clone(),
-            cfg.role_name.clone(),
-            cfg.role_instance.clone(),
-            cfg.namespace.clone(),
-            config_version,
-        );
-        let uploader_config = GenevaUploaderConfig {
-            namespace: metadata_fields.namespace.clone(),
-            source_identity,
-            environment: metadata_fields.env_name.clone(),
-            config_version: metadata_fields.event_version.clone(),
-        };
+        let (uploader_config, parts) = Self::derive_parts(&cfg);
 
         let uploader = GenevaUploader::from_agent_fed(source, uploader_config).map_err(|e| {
             debug!(
@@ -346,14 +344,7 @@ impl GenevaClient {
             format!("GenevaUploader init failed: {e}")
         })?;
 
-        Ok(Self {
-            uploader: Arc::new(uploader),
-            encoder: OtlpEncoder::new(),
-            metadata_fields,
-            log_table_name,
-            span_table_name,
-            obo_event_map: cfg.obo_event_map,
-        })
+        Ok(Self::assemble(uploader, parts))
     }
 
     /// Encode logs from any [`LogsDataView`] implementation into LZ4-chunked
@@ -608,5 +599,63 @@ mod tests {
 
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].event_name, "AppTrace");
+    }
+
+    #[test]
+    fn with_agent_fed_source_builds_usable_client() {
+        #[derive(Debug)]
+        struct StubSource;
+        impl AgentFedCredentialSource for StubSource {
+            fn current(&self) -> AgentFedCredentialFuture<'_> {
+                Box::pin(async {
+                    Some(AgentFedCredential {
+                        token: "secret-token".to_string(),
+                        endpoint: "https://ingest.example".to_string(),
+                        moniker: "moniker".to_string(),
+                    })
+                })
+            }
+        }
+
+        let client = GenevaClient::with_agent_fed_source(
+            build_config(Some("AppLog"), None),
+            Arc::new(StubSource),
+        )
+        .expect("agent-fed client should initialize");
+
+        // Prove the agent-fed client is usable end-to-end for encoding, just
+        // like a config-service client.
+        let request = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord::default()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        let bytes = request.encode_to_vec();
+        let view = RawLogsData::new(&bytes);
+        let batches = client
+            .encode_and_compress_logs(&view)
+            .expect("log encoding should succeed");
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].event_name, "AppLog");
+    }
+
+    #[test]
+    fn agent_fed_credential_debug_redacts_token() {
+        let cred = AgentFedCredential {
+            token: "top-secret".to_string(),
+            endpoint: "https://ingest.example".to_string(),
+            moniker: "moniker".to_string(),
+        };
+        let rendered = format!("{cred:?}");
+        assert!(
+            !rendered.contains("top-secret"),
+            "token must be redacted: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains("moniker"));
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -93,11 +93,6 @@ pub struct AgentFedCredential {
     pub endpoint: String,
     /// Account moniker for the upload.
     pub moniker: String,
-    /// Monitoring endpoint hint from the host. For agent-fed uploads the
-    /// `endpoint=` query parameter is normally derived from the token's
-    /// `Endpoint` claim; this value is only a fallback when that claim is
-    /// absent.
-    pub monitoring_endpoint: String,
 }
 
 impl std::fmt::Debug for AgentFedCredential {
@@ -107,7 +102,6 @@ impl std::fmt::Debug for AgentFedCredential {
             .field("token", &"<redacted>")
             .field("endpoint", &self.endpoint)
             .field("moniker", &self.moniker)
-            .field("monitoring_endpoint", &self.monitoring_endpoint)
             .finish()
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -11,6 +11,8 @@ pub use crate::payload_encoder::otlp_encoder::{OboEventConfig, OboEventMap};
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use otap_df_pdata_views::views::logs::LogsDataView;
 use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info};
@@ -61,6 +63,55 @@ pub struct LogsConfig {
 pub struct TracesConfig {
     pub default_event_name: Option<String>,
 }
+
+/// Agent-fed credential source: the host agent resolves the
+/// GIG token + endpoint + moniker and supplies them here, so the uploader skips
+/// its own GCS config-service handshake. Queried per upload, so host token
+/// rotation is observed without reconstructing the client.
+pub trait AgentFedCredentialSource: Send + Sync + std::fmt::Debug {
+    /// The current credential, or `None` if the host has not provisioned one yet.
+    ///
+    /// Async so an agent-fed source can resolve the token through an awaitable
+    /// capability (e.g. otap's `bearer_token_provider`, whose `get_token` may
+    /// perform a credential call on a cache miss) by awaiting it, rather than
+    /// polling the future once and dropping it if it is not immediately ready.
+    /// Returning a boxed future (instead of `async fn`) keeps the trait
+    /// object-safe for `Arc<dyn AgentFedCredentialSource>`.
+    fn current(&self) -> AgentFedCredentialFuture<'_>;
+}
+
+/// Future returned by [`AgentFedCredentialSource::current`].
+pub type AgentFedCredentialFuture<'a> =
+    Pin<Box<dyn Future<Output = Option<AgentFedCredential>> + Send + 'a>>;
+
+/// A host-provided GIG credential snapshot (see [`AgentFedCredentialSource`]).
+#[derive(Clone)]
+pub struct AgentFedCredential {
+    /// GIG bearer token (sent as `Authorization: Bearer`).
+    pub token: String,
+    /// GIG ingestion endpoint (base URL the upload POSTs to).
+    pub endpoint: String,
+    /// Account moniker for the upload.
+    pub moniker: String,
+    /// Monitoring endpoint hint from the host. For agent-fed uploads the
+    /// `endpoint=` query parameter is normally derived from the token's
+    /// `Endpoint` claim; this value is only a fallback when that claim is
+    /// absent.
+    pub monitoring_endpoint: String,
+}
+
+impl std::fmt::Debug for AgentFedCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redact the bearer token; expose only the non-secret routing fields.
+        f.debug_struct("AgentFedCredential")
+            .field("token", &"<redacted>")
+            .field("endpoint", &self.endpoint)
+            .field("moniker", &self.moniker)
+            .field("monitoring_endpoint", &self.monitoring_endpoint)
+            .finish()
+    }
+}
+
 /// Error type returned by [`GenevaClient::upload_batch`].
 ///
 /// Provides enough information for callers to implement retry strategies:
@@ -229,6 +280,77 @@ impl GenevaClient {
             target: "geneva-uploader",
             "GenevaClient initialized successfully"
         );
+
+        Ok(Self {
+            uploader: Arc::new(uploader),
+            encoder: OtlpEncoder::new(),
+            metadata_fields,
+            log_table_name,
+            span_table_name,
+            obo_event_map: cfg.obo_event_map,
+        })
+    }
+
+    /// Agent-fed construction: the host supplies the GIG credential via
+    /// `source`, so the uploader skips the GCS config-service handshake entirely.
+    /// `cfg.auth_method` / `cfg.msi_resource` are ignored (no `GenevaConfigClient`
+    /// is created). The source is queried per upload, so host token rotation is
+    /// observed without rebuilding the client.
+    pub fn with_agent_fed_source(
+        cfg: GenevaClientConfig,
+        source: Arc<dyn AgentFedCredentialSource>,
+    ) -> Result<Self, String> {
+        info!(
+            name: "client.new.agent_fed",
+            target: "geneva-uploader",
+            namespace = %cfg.namespace,
+            account = %cfg.account,
+            "Initializing GenevaClient (agent-fed credential source)"
+        );
+
+        let log_table_name: Arc<str> = cfg
+            .logs
+            .default_event_name
+            .as_deref()
+            .unwrap_or("Log")
+            .into();
+        let span_table_name: Arc<str> = cfg
+            .spans
+            .default_event_name
+            .as_deref()
+            .unwrap_or("Span")
+            .into();
+
+        let source_identity = format!(
+            "Tenant={}/Role={}/RoleInstance={}",
+            cfg.tenant, cfg.role_name, cfg.role_instance
+        );
+        let config_version = format!("Ver{}v0", cfg.config_major_version);
+        let metadata_fields = MetadataFields::new(
+            cfg.environment.clone(),
+            config_version.clone(),
+            cfg.tenant.clone(),
+            cfg.role_name.clone(),
+            cfg.role_instance.clone(),
+            cfg.namespace.clone(),
+            config_version,
+        );
+        let uploader_config = GenevaUploaderConfig {
+            namespace: metadata_fields.namespace.clone(),
+            source_identity,
+            environment: metadata_fields.env_name.clone(),
+            config_version: metadata_fields.event_version.clone(),
+        };
+
+        let uploader = GenevaUploader::from_agent_fed(source, uploader_config).map_err(|e| {
+            debug!(
+                name: "client.new.agent_fed.uploader_init",
+                target: "geneva-uploader",
+                error = %e,
+                "GenevaUploader (agent-fed) init failed"
+            );
+            format!("GenevaUploader init failed: {e}")
+        })?;
 
         Ok(Self {
             uploader: Arc::new(uploader),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -840,8 +840,12 @@ impl GenevaConfigClient {
                 Ok(ep) => ep,
                 Err(err) => {
                     // Fallback: some tokens legitimately omit the Endpoint claim; use server endpoint.
-                    #[cfg(debug_assertions)]
-                    eprintln!("[geneva][debug] token Endpoint claim missing or unparsable: {err}");
+                    tracing::debug!(
+                        name: "config_client.get_ingestion_info.endpoint_claim_missing",
+                        target: "geneva-uploader",
+                        error = %err,
+                        "Token Endpoint claim missing or unparsable; using server endpoint"
+                    );
                     fresh_ingestion_gateway_info.endpoint.clone()
                 }
             };
@@ -1022,7 +1026,7 @@ fn get_os_type() -> &'static str {
     }
 }
 
-fn extract_endpoint_from_token(token: &str) -> Result<String> {
+pub(crate) fn extract_endpoint_from_token(token: &str) -> Result<String> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         return Err(GenevaConfigClientError::JwtTokenError(

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -111,13 +111,12 @@ mod tests {
         let blob_size = ctx.data.len();
         println!("✅ Loaded blob ({blob_size} bytes)");
         // below call is only for logging purposes, to get endpoint and auth info.
-        let (auth_info, _, _) = ctx
-            .uploader
-            .config_client
-            .get_ingestion_info()
-            .await
-            .unwrap();
-        println!("🚀 Uploading to: {}", auth_info.endpoint);
+        if let crate::ingestion_service::uploader::IngestionSource::ConfigClient(config_client) =
+            &ctx.uploader.source
+        {
+            let (auth_info, _, _) = config_client.get_ingestion_info().await.unwrap();
+            println!("🚀 Uploading to: {}", auth_info.endpoint);
+        }
 
         let start = Instant::now();
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -24,6 +24,8 @@ pub(crate) enum GenevaUploaderError {
     SerdeJson(#[from] serde_json::Error),
     #[error("Config service error: {0}")]
     ConfigClient(String),
+    #[error("Agent-fed credential not provisioned: {0}")]
+    CredentialNotProvisioned(String),
     #[allow(dead_code)]
     #[error("Upload failed with status {status}: {message}")]
     UploadFailed {
@@ -150,8 +152,8 @@ impl IngestionSource {
             }
             IngestionSource::AgentFed(source) => {
                 let cred = source.current().await.ok_or_else(|| {
-                    GenevaUploaderError::ConfigClient(
-                        "agent-fed credential not yet provisioned by host".to_string(),
+                    GenevaUploaderError::CredentialNotProvisioned(
+                        "host has not provisioned a credential yet".to_string(),
                     )
                 })?;
                 // The GIG ingestion gateway rejects the upload (HTTP 403,
@@ -713,9 +715,10 @@ mod tests {
         let uploader = agent_fed_uploader(Arc::new(EmptyAgentFedSource));
         let metadata = make_test_metadata();
         let resp = uploader.upload(vec![1], "Log", &metadata, 1, None).await;
+        let err = resp.expect_err("upload must error when no credential is provisioned");
         assert!(
-            resp.is_err(),
-            "upload must error when the host has not provisioned a credential"
+            matches!(err, GenevaUploaderError::CredentialNotProvisioned(_)),
+            "expected CredentialNotProvisioned, got: {err:?}"
         );
     }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -2,7 +2,6 @@ use crate::config_service::client::{
     extract_endpoint_from_token, GenevaConfigClient, GenevaConfigClientError,
 };
 use crate::payload_encoder::central_blob::BatchMetadata;
-use bytes::Bytes;
 use reqwest::{header, Client};
 use serde::Deserialize;
 use serde_json::Value;
@@ -284,7 +283,6 @@ impl GenevaUploader {
             "Starting upload"
         );
 
-        let data = Bytes::from(data);
         // `endpoint_query_param` becomes the `endpoint=` query param (see
         // `create_upload_uri`).
         let (auth_token, gig_endpoint, moniker, endpoint_query_param) = match &self.source {
@@ -310,18 +308,11 @@ impl GenevaUploader {
                 // claim embedded in the auth token. The native GCS config-service
                 // path derives that value from the token itself (see
                 // get_ingestion_info -> extract_endpoint_from_token), so the
-                // agent-fed path must do the same. The host-supplied monitoring
-                // endpoint is a different value (the QOS/telemetry endpoint) and
-                // must NOT be used here. Fall back to the host-supplied value
-                // (then the data endpoint) only if the token omits the claim.
-                let endpoint_query_param =
-                    extract_endpoint_from_token(&cred.token).unwrap_or_else(|_| {
-                        if cred.monitoring_endpoint.is_empty() {
-                            cred.endpoint.clone()
-                        } else {
-                            cred.monitoring_endpoint.clone()
-                        }
-                    });
+                // agent-fed path must do the same. Some valid tokens legitimately
+                // omit the claim; mirror the GCS path and fall back to the
+                // credential's own endpoint rather than rejecting the upload.
+                let endpoint_query_param = extract_endpoint_from_token(&cred.token)
+                    .unwrap_or_else(|_| cred.endpoint.clone());
                 (
                     cred.token,
                     cred.endpoint,
@@ -354,7 +345,7 @@ impl GenevaUploader {
             .http_client
             .post(&full_url)
             .header(header::AUTHORIZATION, format!("Bearer {auth_token}"))
-            .body(data.clone())
+            .body(data)
             .send()
             .await?;
         let status = response.status();
@@ -399,7 +390,6 @@ impl GenevaUploader {
             event_name = %event_name,
             status = status.as_u16(),
             moniker = %moniker,
-            url = %full_url,
             body = %body,
             "Upload failed"
         );
@@ -564,16 +554,14 @@ mod tests {
         token: std::sync::Mutex<String>,
         endpoint: String,
         moniker: String,
-        monitoring_endpoint: String,
     }
 
     impl TestAgentFedSource {
-        fn new(token: &str, endpoint: &str, moniker: &str, monitoring_endpoint: &str) -> Self {
+        fn new(token: &str, endpoint: &str, moniker: &str) -> Self {
             Self {
                 token: std::sync::Mutex::new(token.to_string()),
                 endpoint: endpoint.to_string(),
                 moniker: moniker.to_string(),
-                monitoring_endpoint: monitoring_endpoint.to_string(),
             }
         }
         fn set_token(&self, token: &str) {
@@ -587,7 +575,6 @@ mod tests {
                 token: self.token.lock().unwrap().clone(),
                 endpoint: self.endpoint.clone(),
                 moniker: self.moniker.clone(),
-                monitoring_endpoint: self.monitoring_endpoint.clone(),
             };
             Box::pin(async move { Some(cred) })
         }
@@ -619,22 +606,25 @@ mod tests {
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
+        // A claimless host token is valid: with no `Endpoint` claim to extract,
+        // the upload falls back to the credential's endpoint for the `endpoint=`
+        // query param (mirroring the GCS path), so a plain token still uploads.
+        let token = "host-token-AAA";
         // The GCS config-service is intentionally NOT mocked. If the agent-fed
         // path attempted the handshake it would fail; a 202 here proves it was
         // skipped and the host-supplied token was used directly.
         Mock::given(method("POST"))
             .and(path("/api/v1/ingestion/ingest"))
-            .and(header("authorization", "Bearer host-token-AAA"))
+            .and(header("authorization", format!("Bearer {token}")))
             .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"t-1"}"#))
             .expect(1)
             .mount(&mock_server)
             .await;
 
         let source = Arc::new(TestAgentFedSource::new(
-            "host-token-AAA",
+            token,
             &mock_server.uri(),
             "test-moniker",
-            &mock_server.uri(),
         ));
         let uploader = agent_fed_uploader(source);
         let metadata = make_test_metadata();
@@ -643,7 +633,7 @@ mod tests {
             .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
             .await;
         assert!(resp.is_ok(), "agent-fed upload should succeed: {resp:?}");
-        // mock_server drop verifies exactly one POST carrying `Bearer host-token-AAA`.
+        // mock_server drop verifies exactly one POST carrying the host token.
     }
 
     #[tokio::test]
@@ -652,27 +642,24 @@ mod tests {
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
+        let token_a = "tok-A";
+        let token_b = "tok-B";
         Mock::given(method("POST"))
             .and(path("/api/v1/ingestion/ingest"))
-            .and(header("authorization", "Bearer tok-A"))
+            .and(header("authorization", format!("Bearer {token_a}")))
             .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"a"}"#))
             .expect(1)
             .mount(&mock_server)
             .await;
         Mock::given(method("POST"))
             .and(path("/api/v1/ingestion/ingest"))
-            .and(header("authorization", "Bearer tok-B"))
+            .and(header("authorization", format!("Bearer {token_b}")))
             .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"b"}"#))
             .expect(1)
             .mount(&mock_server)
             .await;
 
-        let source = Arc::new(TestAgentFedSource::new(
-            "tok-A",
-            &mock_server.uri(),
-            "m",
-            &mock_server.uri(),
-        ));
+        let source = Arc::new(TestAgentFedSource::new(token_a, &mock_server.uri(), "m"));
         let uploader = agent_fed_uploader(source.clone());
         let metadata = make_test_metadata();
 
@@ -681,7 +668,7 @@ mod tests {
             .await
             .expect("upload A");
         // Host rotates the credential; the next upload must use the new token.
-        source.set_token("tok-B");
+        source.set_token(token_b);
         uploader
             .upload(vec![2], "Log", &metadata, 1, None)
             .await

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -124,6 +124,58 @@ pub(crate) enum IngestionSource {
     AgentFed(Arc<dyn crate::client::AgentFedCredentialSource>),
 }
 
+/// Credential + routing resolved for a single upload, independent of source.
+struct ResolvedIngestion {
+    token: String,
+    gig_endpoint: String,
+    moniker: String,
+    endpoint_query_param: String,
+}
+
+impl IngestionSource {
+    /// Resolve the per-upload credential and routing. Centralizes the
+    /// source-specific branching (and the agent-fed endpoint-claim fallback)
+    /// here so `upload` sees a single uniform shape and never branches.
+    async fn resolve(&self) -> Result<ResolvedIngestion> {
+        match self {
+            IngestionSource::ConfigClient(config_client) => {
+                let (auth_info, moniker_info, endpoint_query_param) =
+                    config_client.get_ingestion_info().await?;
+                Ok(ResolvedIngestion {
+                    token: auth_info.auth_token,
+                    gig_endpoint: auth_info.endpoint,
+                    moniker: moniker_info.name,
+                    endpoint_query_param,
+                })
+            }
+            IngestionSource::AgentFed(source) => {
+                let cred = source.current().await.ok_or_else(|| {
+                    GenevaUploaderError::ConfigClient(
+                        "agent-fed credential not yet provisioned by host".to_string(),
+                    )
+                })?;
+                // The GIG ingestion gateway rejects the upload (HTTP 403,
+                // "Token must have 'Endpoint' claim set to ...") unless the
+                // request's `endpoint` query parameter matches the `Endpoint`
+                // claim embedded in the auth token. The native GCS config-service
+                // path derives that value from the token itself (see
+                // get_ingestion_info -> extract_endpoint_from_token), so the
+                // agent-fed path must do the same. Some valid tokens legitimately
+                // omit the claim; mirror the GCS path and fall back to the
+                // credential's own endpoint rather than rejecting the upload.
+                let endpoint_query_param = extract_endpoint_from_token(&cred.token)
+                    .unwrap_or_else(|_| cred.endpoint.clone());
+                Ok(ResolvedIngestion {
+                    token: cred.token,
+                    gig_endpoint: cred.endpoint,
+                    moniker: cred.moniker,
+                    endpoint_query_param,
+                })
+            }
+        }
+    }
+}
+
 /// Client for uploading data to Geneva Ingestion Gateway (GIG)
 #[derive(Debug, Clone)]
 pub(crate) struct GenevaUploader {
@@ -284,43 +336,14 @@ impl GenevaUploader {
         );
 
         // `endpoint_query_param` becomes the `endpoint=` query param (see
-        // `create_upload_uri`).
-        let (auth_token, gig_endpoint, moniker, endpoint_query_param) = match &self.source {
-            IngestionSource::ConfigClient(config_client) => {
-                let (auth_info, moniker_info, monitoring_endpoint) =
-                    config_client.get_ingestion_info().await?;
-                (
-                    auth_info.auth_token,
-                    auth_info.endpoint,
-                    moniker_info.name,
-                    monitoring_endpoint,
-                )
-            }
-            IngestionSource::AgentFed(source) => {
-                let cred = source.current().await.ok_or_else(|| {
-                    GenevaUploaderError::ConfigClient(
-                        "agent-fed credential not yet provisioned by host".to_string(),
-                    )
-                })?;
-                // The GIG ingestion gateway rejects the upload (HTTP 403,
-                // "Token must have 'Endpoint' claim set to ...") unless the
-                // request's `endpoint` query parameter matches the `Endpoint`
-                // claim embedded in the auth token. The native GCS config-service
-                // path derives that value from the token itself (see
-                // get_ingestion_info -> extract_endpoint_from_token), so the
-                // agent-fed path must do the same. Some valid tokens legitimately
-                // omit the claim; mirror the GCS path and fall back to the
-                // credential's own endpoint rather than rejecting the upload.
-                let endpoint_query_param = extract_endpoint_from_token(&cred.token)
-                    .unwrap_or_else(|_| cred.endpoint.clone());
-                (
-                    cred.token,
-                    cred.endpoint,
-                    cred.moniker,
-                    endpoint_query_param,
-                )
-            }
-        };
+        // `create_upload_uri`). Both credential sources resolve to the same
+        // shape via `IngestionSource::resolve`, so this path stays branch-free.
+        let ResolvedIngestion {
+            token: auth_token,
+            gig_endpoint,
+            moniker,
+            endpoint_query_param,
+        } = self.source.resolve().await?;
         let data_size = data.len();
         let upload_uri = self.create_upload_uri(
             &endpoint_query_param,
@@ -600,6 +623,15 @@ mod tests {
         GenevaUploader::from_agent_fed(source, uploader_config).expect("agent-fed uploader builds")
     }
 
+    /// Build a minimal JWT (`header.payload.signature`) whose payload carries
+    /// the given `Endpoint` claim. Only the payload is meaningful to
+    /// `extract_endpoint_from_token`; the header and signature are placeholders.
+    fn agent_fed_token_with_endpoint(endpoint: &str) -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"Endpoint":"{endpoint}"}}"#));
+        format!("hdr.{payload}.sig")
+    }
+
     #[tokio::test]
     async fn agent_fed_upload_uses_host_token_and_skips_gcs() {
         use wiremock::matchers::{header, method, path};
@@ -684,6 +716,68 @@ mod tests {
         assert!(
             resp.is_err(),
             "upload must error when the host has not provisioned a credential"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_fed_upload_endpoint_query_uses_token_claim() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        // The token carries an `Endpoint` claim that differs from the
+        // credential endpoint; the `endpoint=` query param must be derived from
+        // that claim, overriding the credential endpoint. The mock only matches
+        // (and returns 202) when `endpoint=` equals the claim, so a successful
+        // upload proves the routing.
+        let token = agent_fed_token_with_endpoint("https://claim.endpoint.example");
+        Mock::given(method("POST"))
+            .and(path("/api/v1/ingestion/ingest"))
+            .and(query_param("endpoint", "https://claim.endpoint.example"))
+            .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"t"}"#))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let source = Arc::new(TestAgentFedSource::new(&token, &mock_server.uri(), "m"));
+        let uploader = agent_fed_uploader(source);
+        let metadata = make_test_metadata();
+        let resp = uploader
+            .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
+            .await;
+        assert!(
+            resp.is_ok(),
+            "`endpoint=` must come from the token's Endpoint claim: {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_fed_upload_endpoint_query_falls_back_to_cred_endpoint() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        // A claimless token has no `Endpoint` claim, so the `endpoint=` query
+        // param must fall back to the credential's own endpoint. The mock only
+        // matches when `endpoint=` equals that endpoint.
+        let endpoint = mock_server.uri();
+        Mock::given(method("POST"))
+            .and(path("/api/v1/ingestion/ingest"))
+            .and(query_param("endpoint", endpoint.as_str()))
+            .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"t"}"#))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let source = Arc::new(TestAgentFedSource::new("claimless-token", &endpoint, "m"));
+        let uploader = agent_fed_uploader(source);
+        let metadata = make_test_metadata();
+        let resp = uploader
+            .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
+            .await;
+        assert!(
+            resp.is_ok(),
+            "`endpoint=` must fall back to the credential endpoint: {resp:?}"
         );
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -1,5 +1,8 @@
-use crate::config_service::client::{GenevaConfigClient, GenevaConfigClientError};
+use crate::config_service::client::{
+    extract_endpoint_from_token, GenevaConfigClient, GenevaConfigClientError,
+};
 use crate::payload_encoder::central_blob::BatchMetadata;
+use bytes::Bytes;
 use reqwest::{header, Client};
 use serde::Deserialize;
 use serde_json::Value;
@@ -113,10 +116,19 @@ pub(crate) struct GenevaUploaderConfig {
     pub config_version: String,
 }
 
+/// Where the uploader gets the GIG credential per upload.
+#[derive(Debug, Clone)]
+pub(crate) enum IngestionSource {
+    /// Fetch from the Geneva Config Service (the default cert/MSI path).
+    ConfigClient(Arc<GenevaConfigClient>),
+    /// Use an agent-fed credential; no GCS handshake.
+    AgentFed(Arc<dyn crate::client::AgentFedCredentialSource>),
+}
+
 /// Client for uploading data to Geneva Ingestion Gateway (GIG)
 #[derive(Debug, Clone)]
 pub(crate) struct GenevaUploader {
-    pub(crate) config_client: Arc<GenevaConfigClient>,
+    pub(crate) source: IngestionSource,
     pub(crate) config: GenevaUploaderConfig,
     pub(crate) http_client: Client,
 }
@@ -143,7 +155,27 @@ impl GenevaUploader {
         let client = Self::build_h1_client(headers)?;
 
         Ok(Self {
-            config_client,
+            source: IngestionSource::ConfigClient(config_client),
+            config: uploader_config,
+            http_client: client,
+        })
+    }
+
+    /// Constructs a GenevaUploader from an agent-fed credential source.
+    /// No `GenevaConfigClient` is created; `source` is queried per upload.
+    pub(crate) fn from_agent_fed(
+        source: Arc<dyn crate::client::AgentFedCredentialSource>,
+        uploader_config: GenevaUploaderConfig,
+    ) -> Result<Self> {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::ACCEPT,
+            header::HeaderValue::from_static("application/json"),
+        );
+        let client = Self::build_h1_client(headers)?;
+
+        Ok(Self {
+            source: IngestionSource::AgentFed(source),
             config: uploader_config,
             http_client: client,
         })
@@ -163,7 +195,7 @@ impl GenevaUploader {
     #[allow(clippy::too_many_arguments)]
     fn create_upload_uri(
         &self,
-        monitoring_endpoint: &str,
+        endpoint_query_param: &str,
         moniker: &str,
         data_size: usize,
         event_name: &str,
@@ -178,8 +210,8 @@ impl GenevaUploader {
 
         // URL encode parameters
         // TODO - Maintain this as url-encoded in config service to avoid conversion here
-        let encoded_monitoring_endpoint: String =
-            byte_serialize(monitoring_endpoint.as_bytes()).collect();
+        let encoded_endpoint_query_param: String =
+            byte_serialize(endpoint_query_param.as_bytes()).collect();
         let encoded_source_identity: String =
             byte_serialize(self.config.source_identity.as_bytes()).collect();
 
@@ -189,7 +221,7 @@ impl GenevaUploader {
         // Create the query string
         let mut query = String::with_capacity(512); // Preallocate enough space for the query string (decided based on expected size)
         write!(&mut query, "api/v1/ingestion/ingest?endpoint={}&moniker={}&namespace={}&event={}&version={}&sourceUniqueId={}&sourceIdentity={}&startTime={}&endTime={}&format=centralbond/lz4hc&dataSize={}&minLevel={}&schemaIds={}&rowCount={}",
-            encoded_monitoring_endpoint,
+            encoded_endpoint_query_param,
             moniker,
             self.config.namespace,
             event_name,
@@ -252,45 +284,81 @@ impl GenevaUploader {
             "Starting upload"
         );
 
-        // Always get fresh auth info
-        let (auth_info, moniker_info, monitoring_endpoint) =
-            self.config_client.get_ingestion_info().await?;
+        let data = Bytes::from(data);
+        // `endpoint_query_param` becomes the `endpoint=` query param (see
+        // `create_upload_uri`).
+        let (auth_token, gig_endpoint, moniker, endpoint_query_param) = match &self.source {
+            IngestionSource::ConfigClient(config_client) => {
+                let (auth_info, moniker_info, monitoring_endpoint) =
+                    config_client.get_ingestion_info().await?;
+                (
+                    auth_info.auth_token,
+                    auth_info.endpoint,
+                    moniker_info.name,
+                    monitoring_endpoint,
+                )
+            }
+            IngestionSource::AgentFed(source) => {
+                let cred = source.current().await.ok_or_else(|| {
+                    GenevaUploaderError::ConfigClient(
+                        "agent-fed credential not yet provisioned by host".to_string(),
+                    )
+                })?;
+                // The GIG ingestion gateway rejects the upload (HTTP 403,
+                // "Token must have 'Endpoint' claim set to ...") unless the
+                // request's `endpoint` query parameter matches the `Endpoint`
+                // claim embedded in the auth token. The native GCS config-service
+                // path derives that value from the token itself (see
+                // get_ingestion_info -> extract_endpoint_from_token), so the
+                // agent-fed path must do the same. The host-supplied monitoring
+                // endpoint is a different value (the QOS/telemetry endpoint) and
+                // must NOT be used here. Fall back to the host-supplied value
+                // (then the data endpoint) only if the token omits the claim.
+                let endpoint_query_param =
+                    extract_endpoint_from_token(&cred.token).unwrap_or_else(|_| {
+                        if cred.monitoring_endpoint.is_empty() {
+                            cred.endpoint.clone()
+                        } else {
+                            cred.monitoring_endpoint.clone()
+                        }
+                    });
+                (
+                    cred.token,
+                    cred.endpoint,
+                    cred.moniker,
+                    endpoint_query_param,
+                )
+            }
+        };
         let data_size = data.len();
         let upload_uri = self.create_upload_uri(
-            &monitoring_endpoint,
-            &moniker_info.name,
+            &endpoint_query_param,
+            &moniker,
             data_size,
             event_name,
             metadata,
             row_count,
             obo_config,
         )?;
-        let full_url = format!(
-            "{}/{}",
-            auth_info.endpoint.trim_end_matches('/'),
-            upload_uri
-        );
+        let full_url = format!("{}/{}", gig_endpoint.trim_end_matches('/'), upload_uri);
 
         debug!(
             name: "uploader.upload.post",
             target: "geneva-uploader",
             event_name = %event_name,
-            moniker = %moniker_info.name,
+            moniker = %moniker,
             "Posting to ingestion gateway"
         );
 
-        // Send the upload request
         let response = self
             .http_client
             .post(&full_url)
-            .header(
-                header::AUTHORIZATION,
-                format!("Bearer {}", auth_info.auth_token),
-            )
-            .body(data)
+            .header(header::AUTHORIZATION, format!("Bearer {auth_token}"))
+            .body(data.clone())
             .send()
             .await?;
         let status = response.status();
+
         // TODO: Only the delay-seconds form of Retry-After is parsed here.
         // The HTTP-date form (e.g., "Fri, 31 Dec 2027 23:59:59 GMT") is
         // silently ignored and results in None. Add support if the ingestion
@@ -322,22 +390,24 @@ impl GenevaUploader {
                 "Upload successful"
             );
 
-            Ok(ingest_response)
-        } else {
-            debug!(
-                name: "uploader.upload.failed",
-                target: "geneva-uploader",
-                event_name = %event_name,
-                status = status.as_u16(),
-                body = %body,
-                "Upload failed"
-            );
-            Err(GenevaUploaderError::UploadFailed {
-                status: status.as_u16(),
-                retry_after,
-                message: body,
-            })
+            return Ok(ingest_response);
         }
+
+        tracing::warn!(
+            name: "uploader.upload.failed",
+            target: "geneva-uploader",
+            event_name = %event_name,
+            status = status.as_u16(),
+            moniker = %moniker,
+            url = %full_url,
+            body = %body,
+            "Upload failed"
+        );
+        Err(GenevaUploaderError::UploadFailed {
+            status: status.as_u16(),
+            retry_after,
+            message: body,
+        })
     }
 }
 
@@ -377,7 +447,7 @@ mod tests {
                 .expect("Config client should init"),
         );
         GenevaUploader {
-            config_client,
+            source: IngestionSource::ConfigClient(config_client),
             config: uploader_config,
             http_client,
         }
@@ -480,6 +550,153 @@ mod tests {
         assert!(
             !uri.contains("onbehalfannotations"),
             "URI should NOT contain onbehalfannotations"
+        );
+    }
+
+    // ── Agent-fed upload path ────────────────────────────────────────────
+    // These exercise the full uploader wire path against a local mock GIG: the
+    // agent-fed token must land in the `Authorization: Bearer` header, the GCS
+    // config-service handshake must be skipped, and token rotation must be
+    // observed per upload.
+
+    #[derive(Debug)]
+    struct TestAgentFedSource {
+        token: std::sync::Mutex<String>,
+        endpoint: String,
+        moniker: String,
+        monitoring_endpoint: String,
+    }
+
+    impl TestAgentFedSource {
+        fn new(token: &str, endpoint: &str, moniker: &str, monitoring_endpoint: &str) -> Self {
+            Self {
+                token: std::sync::Mutex::new(token.to_string()),
+                endpoint: endpoint.to_string(),
+                moniker: moniker.to_string(),
+                monitoring_endpoint: monitoring_endpoint.to_string(),
+            }
+        }
+        fn set_token(&self, token: &str) {
+            *self.token.lock().unwrap() = token.to_string();
+        }
+    }
+
+    impl crate::client::AgentFedCredentialSource for TestAgentFedSource {
+        fn current(&self) -> crate::client::AgentFedCredentialFuture<'_> {
+            let cred = crate::client::AgentFedCredential {
+                token: self.token.lock().unwrap().clone(),
+                endpoint: self.endpoint.clone(),
+                moniker: self.moniker.clone(),
+                monitoring_endpoint: self.monitoring_endpoint.clone(),
+            };
+            Box::pin(async move { Some(cred) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct EmptyAgentFedSource;
+    impl crate::client::AgentFedCredentialSource for EmptyAgentFedSource {
+        fn current(&self) -> crate::client::AgentFedCredentialFuture<'_> {
+            Box::pin(async { None })
+        }
+    }
+
+    fn agent_fed_uploader(
+        source: Arc<dyn crate::client::AgentFedCredentialSource>,
+    ) -> GenevaUploader {
+        let uploader_config = GenevaUploaderConfig {
+            namespace: "TestNamespace".to_string(),
+            source_identity: "Tenant=Test/Role=R/RoleInstance=I".to_string(),
+            environment: "TestEnv".to_string(),
+            config_version: "Ver2v0".to_string(),
+        };
+        GenevaUploader::from_agent_fed(source, uploader_config).expect("agent-fed uploader builds")
+    }
+
+    #[tokio::test]
+    async fn agent_fed_upload_uses_host_token_and_skips_gcs() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        // The GCS config-service is intentionally NOT mocked. If the agent-fed
+        // path attempted the handshake it would fail; a 202 here proves it was
+        // skipped and the host-supplied token was used directly.
+        Mock::given(method("POST"))
+            .and(path("/api/v1/ingestion/ingest"))
+            .and(header("authorization", "Bearer host-token-AAA"))
+            .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"t-1"}"#))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let source = Arc::new(TestAgentFedSource::new(
+            "host-token-AAA",
+            &mock_server.uri(),
+            "test-moniker",
+            &mock_server.uri(),
+        ));
+        let uploader = agent_fed_uploader(source);
+        let metadata = make_test_metadata();
+
+        let resp = uploader
+            .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
+            .await;
+        assert!(resp.is_ok(), "agent-fed upload should succeed: {resp:?}");
+        // mock_server drop verifies exactly one POST carrying `Bearer host-token-AAA`.
+    }
+
+    #[tokio::test]
+    async fn agent_fed_upload_reflects_token_rotation() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/ingestion/ingest"))
+            .and(header("authorization", "Bearer tok-A"))
+            .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"a"}"#))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/ingestion/ingest"))
+            .and(header("authorization", "Bearer tok-B"))
+            .respond_with(ResponseTemplate::new(202).set_body_string(r#"{"ticket":"b"}"#))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let source = Arc::new(TestAgentFedSource::new(
+            "tok-A",
+            &mock_server.uri(),
+            "m",
+            &mock_server.uri(),
+        ));
+        let uploader = agent_fed_uploader(source.clone());
+        let metadata = make_test_metadata();
+
+        uploader
+            .upload(vec![1], "Log", &metadata, 1, None)
+            .await
+            .expect("upload A");
+        // Host rotates the credential; the next upload must use the new token.
+        source.set_token("tok-B");
+        uploader
+            .upload(vec![2], "Log", &metadata, 1, None)
+            .await
+            .expect("upload B");
+        // Both `.expect(1)` mocks verify each token was used exactly once.
+    }
+
+    #[tokio::test]
+    async fn agent_fed_upload_errors_when_not_provisioned() {
+        let uploader = agent_fed_uploader(Arc::new(EmptyAgentFedSource));
+        let metadata = make_test_metadata();
+        let resp = uploader.upload(vec![1], "Log", &metadata, 1, None).await;
+        assert!(
+            resp.is_err(),
+            "upload must error when the host has not provisioned a credential"
         );
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -18,5 +18,6 @@ pub(crate) use ingestion_service::uploader::{
 };
 
 pub use client::EncodedBatch;
+pub use client::{AgentFedCredential, AgentFedCredentialFuture, AgentFedCredentialSource};
 pub use client::{GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig, UploadError};
 pub use config_service::client::AuthMethod;


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) # open-telemetry/otel-arrow#3275

## Changes

Adds an agent-fed credential source to `geneva-uploader` so a host agent can supply the GIG token and routing (endpoint/moniker) directly, letting the
uploader skip its GCS config-service handshake.

- `AgentFedCredentialSource` trait - async `current()` returning an
  `AgentFedCredential` snapshot (token + endpoint + moniker). `AgentFedCredential` has a `Debug` impl that redacts the token.
- `GenevaClient::with_agent_fed_source(...)` / `GenevaUploader::from_agent_fed(...)` build path: queries the source per upload (so host token rotation is observed without rebuilding the client) and creates no `GenevaConfigClient`.
- The `endpoint=` query parameter is derived from the token's `Endpoint` claim (same as the GCS path), so it can't drift from the token.

Consumed by the otel-arrow Geneva exporter (separate PR).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
