### PR TITLE
fix(resource-detectors): generate UUIDv7 for service.instance.id

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add `ContainerResourceDetector` to detect `container.id` from `/proc/self/cgroup`, with fallback to `/proc/self/mountinfo`.
 - Add host.name attribute to `HostResourceDetector`
-- Add `ServiceInstanceIdResourceDetector` to generate a random UUIDv4 `service.instance.id`.
+- Add `ServiceInstanceIdResourceDetector` to generate a random UUIDv7 `service.instance.id`.
 
 ## v0.11.0
 

--- a/opentelemetry-resource-detectors/src/service_instance.rs
+++ b/opentelemetry-resource-detectors/src/service_instance.rs
@@ -10,7 +10,10 @@ use std::sync::OnceLock;
 /// Detect the `service.instance.id` resource attribute.
 ///
 /// The [OpenTelemetry specification] recommends `service.instance.id` be a
-/// random UUIDv4 when no inherently unique identifier is available.
+/// random UUID when no inherently unique identifier is available. This detector
+/// generates a UUIDv7, which embeds a millisecond-precision timestamp in the
+/// first 48 bits followed by random data, so IDs sort chronologically on
+/// backends that index by this field.
 ///
 /// The id is generated once and reused for the lifetime of the process, so every
 /// resource built from this detector shares the same instance id.
@@ -21,7 +24,7 @@ pub struct ServiceInstanceIdResourceDetector;
 
 fn instance_id() -> &'static str {
     static INSTANCE_ID: OnceLock<String> = OnceLock::new();
-    INSTANCE_ID.get_or_init(uuid::v4)
+    INSTANCE_ID.get_or_init(uuid::v7)
 }
 
 impl ResourceDetector for ServiceInstanceIdResourceDetector {

--- a/opentelemetry-resource-detectors/src/uuid.rs
+++ b/opentelemetry-resource-detectors/src/uuid.rs
@@ -1,10 +1,10 @@
-//! Minimal UUIDv4 generation.
+//! Minimal UUIDv7 generation.
 //!
-//! In order to avoid third-party dependencies, we generate UUIDv4s using only
+//! In order to avoid third-party dependencies, we generate UUIDv7s using only
 //! the standard library. The result will be unique, but not cryptographically
 //! secure, which is sufficient for service instance IDs. Randomness comes
-//! from an OS-seeded [`RandomState`], with time, process id, and a counter
-//! mixed in so repeated calls are extremely unlikely to collide.
+//! from an OS-seeded [`RandomState`], with process id and a counter mixed in
+//! so repeated calls are extremely unlikely to collide.
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hasher};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -12,14 +12,35 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Generate a random UUIDv4 as a canonical hyphenated string,
-///  e.g. `"f47ac10b-58cc-4372-a567-0e02b2c3d479"`.
-pub(crate) fn v4() -> String {
-    let mut bytes = random_bytes();
+/// Generate a UUIDv7 as a canonical hyphenated string,
+/// e.g. `"017f22e2-79b0-7cc3-98c4-dc0c0c07398f"`.
+pub(crate) fn v7() -> String {
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    let rand_hi = seed_word();
+    let rand_lo = seed_word();
+
+    let mut bytes = [0u8; 16];
+
+    // https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-7
+    // Bytes 0-5: 48-bit Unix timestamp in milliseconds, big-endian.
+    bytes[0] = (ms >> 40) as u8;
+    bytes[1] = (ms >> 32) as u8;
+    bytes[2] = (ms >> 24) as u8;
+    bytes[3] = (ms >> 16) as u8;
+    bytes[4] = (ms >> 8) as u8;
+    bytes[5] = ms as u8;
+
+    // Bytes 6-15: random data.
+    bytes[6..14].copy_from_slice(&rand_hi.to_ne_bytes());
+    bytes[14..16].copy_from_slice(&rand_lo.to_ne_bytes()[..2]);
 
     // https://www.rfc-editor.org/rfc/rfc9562.html#name-version-field
-    // Set the high nibble of bytes[6] to 0100. This is the version.
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    // Set the high nibble of bytes[6] to 0111. This is the version.
+    bytes[6] = (bytes[6] & 0x0f) | 0x70;
 
     // https://www.rfc-editor.org/rfc/rfc9562.html#name-variant-field
     // Set the two most significant bits of bytes[8] to 10. This is the variant.
@@ -28,30 +49,17 @@ pub(crate) fn v4() -> String {
     format(&bytes)
 }
 
-/// Produce 128 random bits from two calls to `seed_word()`.
-fn random_bytes() -> [u8; 16] {
-    let mut out = [0u8; 16];
-    out[..8].copy_from_slice(&seed_word().to_ne_bytes());
-    out[8..].copy_from_slice(&seed_word().to_ne_bytes());
-    out
-}
-
 /// Produce 64 random bits. Each call uses an independently seeded RandomState.
-/// Time, process ID, and a counter are mixed in to ensure successive calls
-/// produce different output.
+/// Process ID and a counter are mixed in to ensure successive calls produce
+/// different output.
 fn seed_word() -> u64 {
     let mut hasher = RandomState::new().build_hasher();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0);
-    hasher.write_u64(nanos);
     hasher.write_u32(std::process::id());
     hasher.write_u64(COUNTER.fetch_add(1, Ordering::Relaxed));
     hasher.finish()
 }
 
-/// Format the bytes as a canonical hyphenated UUIDv4 string.
+/// Format the bytes as a canonical hyphenated UUID string.
 fn format(bytes: &[u8; 16]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut s = String::with_capacity(36);
@@ -68,11 +76,11 @@ fn format(bytes: &[u8; 16]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::v4;
+    use super::v7;
 
     #[test]
-    fn formats_canonical_v4() {
-        let uuid = v4();
+    fn formats_canonical_v7() {
+        let uuid = v7();
 
         // 32 hex digits + 4 hyphens.
         assert_eq!(uuid.len(), 36);
@@ -86,8 +94,8 @@ mod tests {
             }
         }
 
-        // Version nibble is 4.
-        assert_eq!(bytes[14], b'4');
+        // Version nibble is 7.
+        assert_eq!(bytes[14], b'7');
         // Variant nibble is one of 8, 9, a, b.
         assert!(matches!(bytes[19], b'8' | b'9' | b'a' | b'b'));
     }
@@ -95,7 +103,28 @@ mod tests {
     #[test]
     fn generates_distinct_values() {
         let count = 1000;
-        let unique: std::collections::HashSet<_> = (0..count).map(|_| v4()).collect();
+        let unique: std::collections::HashSet<_> = (0..count).map(|_| v7()).collect();
         assert_eq!(unique.len(), count);
+    }
+
+    #[test]
+    fn timestamp_is_recent() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let uuid = v7();
+        // Extract the 48-bit timestamp from the first 12 hex chars
+        let hex: String = uuid.chars().filter(|c| *c != '-').take(12).collect();
+
+        // Convert the hex string to a u64 timestamp in milliseconds.
+        let ts_ms = u64::from_str_radix(&hex, 16).expect("valid hex");
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        // Timestamp should be within 5 seconds of now.
+        assert!(ts_ms <= now_ms, "timestamp is in the future");
+        assert!(now_ms - ts_ms < 5_000, "timestamp is too old");
     }
 }


### PR DESCRIPTION
## Changes
Switch `ServiceInstanceIdResourceDetector` from UUIDv4 to UUIDv7.

I noticed that [otel-arrow](https://github.com/open-telemetry/otel-arrow/blob/df03b91737370ddb38fc93f8fe223281b7de41a7/rust/otap-dataflow/crates/engine/src/context.rs#L35) uses UUIDv7 for `service.instance.id` as it provides better sortability for backends that index on that field. I updated the resource detector to generate UUIDv7 for the same reason.
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
