### PR TITLE
chore: Change Jaeger Docker image to latest version

### DIFF
--- a/opentelemetry-instrumentation-actix-web/README.md
+++ b/opentelemetry-instrumentation-actix-web/README.md
@@ -38,7 +38,7 @@ opentelemetry-zipkin = { version = "..", features = ["reqwest-client"], default-
 
 ```console
 # Run jaeger in background
-$ docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
+$ docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/jaeger:latest
 
 # Run server example with tracing middleware
 $ cargo run --example server


### PR DESCRIPTION
Updated Jaeger Docker image in README example.

Fixes #
Design discussion issue (if applicable) #

## Changes

The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
