### PR TITLE
chore(tower): prepare release 0.18.0

### DIFF
--- a/opentelemetry-instrumentation-tower/CHANGELOG.md
+++ b/opentelemetry-instrumentation-tower/CHANGELOG.md
@@ -8,6 +8,7 @@ Released 2026-Jul-28
 
 ### Added
 
+* Added OpenTelemetry trace support
 * Configurable route extraction with built-in extractors:
   - `NoRouteExtractor` - No route, uses only HTTP method (e.g., `GET`), safest for cardinality
   - `PathExtractor` - Uses the URL path without query params (e.g., `/users/123`)
@@ -28,7 +29,6 @@ Released 2026-Jul-28
     - `HTTPMetricsService` → `HTTPService`
     - `HTTPMetricsResponseFuture` → `ResponseFuture`
     - `HTTPMetricsLayerBuilder` → `HTTPLayerBuilder`
-* Added OpenTelemetry trace support
 * **BREAKING**: Update default  `http.server.request.duration` histogram boundaries to OTel semantic conventions.
 * **BREAKING**: Remove `with_request_duration_bounds` builder method.
   Alternate histogram bucket boundaries can be applied with the standard OpenTelemetry Views; see `examples` directory in crate for usage.

--- a/opentelemetry-instrumentation-tower/CHANGELOG.md
+++ b/opentelemetry-instrumentation-tower/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## v0.18.0
+
+Released 2026-Jul-28
+
 ### Added
 
 * Configurable route extraction with built-in extractors:
@@ -22,7 +26,7 @@
 * **BREAKING**: Renamed types. Use the new names:
     - `HTTPMetricsLayer` → `HTTPLayer`
     - `HTTPMetricsService` → `HTTPService`
-    - `HTTPMetricsResponseFuture` → `HTTPResponseFuture`
+    - `HTTPMetricsResponseFuture` → `ResponseFuture`
     - `HTTPMetricsLayerBuilder` → `HTTPLayerBuilder`
 * Added OpenTelemetry trace support
 * **BREAKING**: Update default  `http.server.request.duration` histogram boundaries to OTel semantic conventions.
@@ -92,7 +96,7 @@ let layer = HTTPLayer::new();
 - Replace `HTTPMetricsLayerBuilder` with `HTTPLayerBuilder`
 - Replace `HTTPMetricsLayer` with `HTTPLayer`
 - Replace `HTTPMetricsService` with `HTTPService`
-- Replace `HTTPMetricsResponseFuture` with `HTTPResponseFuture`
+- Replace `HTTPMetricsResponseFuture` with `ResponseFuture`
 
 ## v0.17.0
 

--- a/opentelemetry-instrumentation-tower/CHANGELOG.md
+++ b/opentelemetry-instrumentation-tower/CHANGELOG.md
@@ -10,14 +10,14 @@ Released 2026-Jul-28
 
 * Added OpenTelemetry trace support
 * Configurable route extraction with built-in extractors:
-  - `NoRouteExtractor` - No route, uses only HTTP method (e.g., `GET`), safest for cardinality
+  - `NoRouteExtractor` - No route, safest for cardinality
   - `PathExtractor` - Uses the URL path without query params (e.g., `/users/123`)
   - `AxumMatchedPathExtractor` - Uses Axum's `MatchedPath` for route templates (requires `axum` feature)
   - `FnRouteExtractor` - Custom function-based extraction via `with_route_extractor_fn()`
 * Default route extractor depends on features:
   - With `axum` feature: Uses `AxumMatchedPathExtractor` (route templates, low cardinality)
-  - Without `axum` feature: Uses `NoRouteExtractor` (method only, safest)
-* Route extraction now provides both span names and `http.route` metric attribute from the same source
+  - Without `axum` feature: Uses `NoRouteExtractor` (safest)
+* If a route is extracted, the same value is used for both the `http.route` attribute and the tracing span name. If no route is extracted, the span name is the HTTP method only, per semantic conventions.
 
 ### Changed
 

--- a/opentelemetry-instrumentation-tower/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/Cargo.toml
@@ -3,7 +3,7 @@ name = "opentelemetry-instrumentation-tower"
 edition = "2021"
 rust-version = "1.75.0"
 
-version = "0.17.0"
+version = "0.18.0"
 license = "Apache-2.0"
 description = "OpenTelemetry Middleware for Tower-compatible Rust HTTP servers"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib"


### PR DESCRIPTION
Prepares opentelemetry-instrumentation-tower v0.18.0 for release.