### PR TITLE
fix(geneva-uploader): reduce bearer-token memory remanence

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -11,9 +11,10 @@
 - Corrected a misleading startup log message: when `logs.default_event_name` is set without an `event_name_mapping`, `GenevaClient::new` now logs `Configured logs event name routing [default_event_name=...]` instead of `Logs config not initialized; using default values for log events`. The default was always applied correctly; only the log line was wrong. This makes the logs message symmetric with the equivalent spans message.
 
 ### Changed
-- Minimize bearer-token memory remanence by storing resolved credentials in
-  zeroizing secret containers and backing sensitive `Authorization` headers
-  with application-owned memory that is zeroized when released.
+- Minimize GIG ingestion bearer-token memory remanence by storing resolved
+  credentials in zeroizing secret containers and backing sensitive
+  `Authorization` headers with application-owned memory that is zeroized when
+  released.
 - Bump opentelemetry-proto version to 0.32.
 - Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
   to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Agent-fed credential source: `GenevaClient::with_agent_fed_source` builds an uploader that pulls a host-provisioned GIG token and routing (endpoint, moniker) from an `AgentFedCredentialSource` on each upload, skipping the GCS config-service handshake. New public API: `AgentFedCredentialSource`, `AgentFedCredential`, `AgentFedCredentialFuture`.
 
 ### Changed
+- Minimize bearer-token memory remanence by storing resolved credentials in
+  zeroizing secret containers and backing sensitive `Authorization` headers
+  with application-owned memory that is zeroized when released.
 - Bump opentelemetry-proto version to 0.32.
 - Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
   to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -44,6 +44,8 @@ tracing = "0.1"
 # 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
 # (transitive via azure_core) and breaks the build (E0119). Not used directly.
 time = ">=0.3.47, <0.3.54"
+bytes = "1"
+secrecy = { version = "0.10", features = ["serde"] }
 
 [features]
 mock_auth = [] # Disabled by default. Not to be enabled in the prod release.

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -44,7 +44,7 @@ tracing = "0.1"
 # 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
 # (transitive via azure_core) and breaks the build (E0119). Not used directly.
 time = ">=0.3.47, <0.3.54"
-bytes = "1.5"
+bytes = "1.9"
 secrecy = { version = "0.10", features = ["serde"] }
 
 [features]

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -44,7 +44,7 @@ tracing = "0.1"
 # 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
 # (transitive via azure_core) and breaks the build (E0119). Not used directly.
 time = ">=0.3.47, <0.3.54"
-bytes = "1"
+bytes = "1.5"
 secrecy = { version = "0.10", features = ["serde"] }
 
 [features]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -10,6 +10,7 @@ use crate::payload_encoder::otlp_encoder::{lookup_obo_config, MetadataFields};
 pub use crate::payload_encoder::otlp_encoder::{OboEventConfig, OboEventMap};
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use otap_df_pdata_views::views::logs::LogsDataView;
+use secrecy::{ExposeSecret, SecretString};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -88,11 +89,37 @@ pub type AgentFedCredentialFuture<'a> =
 #[derive(Clone)]
 pub struct AgentFedCredential {
     /// GIG bearer token (sent as `Authorization: Bearer`).
-    pub token: String,
+    token: SecretString,
     /// GIG ingestion endpoint (base URL the upload POSTs to).
     pub endpoint: String,
     /// Account moniker for the upload.
     pub moniker: String,
+}
+
+impl AgentFedCredential {
+    /// Creates an agent-fed credential with zeroizing token storage.
+    #[must_use]
+    pub fn new(
+        token: impl Into<SecretString>,
+        endpoint: impl Into<String>,
+        moniker: impl Into<String>,
+    ) -> Self {
+        Self {
+            token: token.into(),
+            endpoint: endpoint.into(),
+            moniker: moniker.into(),
+        }
+    }
+
+    /// Exposes the bearer token for explicit credential processing.
+    #[must_use]
+    pub fn expose_token(&self) -> &str {
+        self.token.expose_secret()
+    }
+
+    pub(crate) fn into_parts(self) -> (SecretString, String, String) {
+        (self.token, self.endpoint, self.moniker)
+    }
 }
 
 impl std::fmt::Debug for AgentFedCredential {
@@ -537,6 +564,8 @@ mod tests {
         GenevaClient::new(build_config(logs, spans)).expect("client should initialize")
     }
 
+    /// Scenario: A configured event-name override is present or absent.
+    /// Guarantees: Configuration wins when present and the signal default is used otherwise.
     #[test]
     fn default_event_name_unwrap_or_prefers_override_and_falls_back() {
         let configured = maybe_event_name(true);
@@ -554,6 +583,8 @@ mod tests {
         }
     }
 
+    /// Scenario: Log encoding has a configured default event name.
+    /// Guarantees: The emitted batch uses the configured log event name.
     #[test]
     fn encode_and_compress_logs_uses_configured_default_event_name() {
         let client = build_client(Some("AppLog"), None);
@@ -578,6 +609,8 @@ mod tests {
         assert_eq!(batches[0].event_name, "AppLog");
     }
 
+    /// Scenario: Span encoding has a configured default event name.
+    /// Guarantees: The emitted batch uses the configured span event name.
     #[test]
     fn encode_and_compress_spans_uses_configured_default_event_name() {
         let client = build_client(None, Some("AppTrace"));
@@ -601,6 +634,8 @@ mod tests {
         assert_eq!(batches[0].event_name, "AppTrace");
     }
 
+    /// Scenario: An agent-fed source is used to initialize a Geneva client.
+    /// Guarantees: The safer credential constructor remains usable by source implementations.
     #[test]
     fn with_agent_fed_source_builds_usable_client() {
         #[derive(Debug)]
@@ -608,11 +643,11 @@ mod tests {
         impl AgentFedCredentialSource for StubSource {
             fn current(&self) -> AgentFedCredentialFuture<'_> {
                 Box::pin(async {
-                    Some(AgentFedCredential {
-                        token: "secret-token".to_string(),
-                        endpoint: "https://ingest.example".to_string(),
-                        moniker: "moniker".to_string(),
-                    })
+                    Some(AgentFedCredential::new(
+                        "secret-token",
+                        "https://ingest.example",
+                        "moniker",
+                    ))
                 })
             }
         }
@@ -643,13 +678,12 @@ mod tests {
         assert_eq!(batches[0].event_name, "AppLog");
     }
 
+    /// Scenario: An agent-fed credential is rendered with Debug.
+    /// Guarantees: The bearer token is redacted while routing remains inspectable.
     #[test]
     fn agent_fed_credential_debug_redacts_token() {
-        let cred = AgentFedCredential {
-            token: "top-secret".to_string(),
-            endpoint: "https://ingest.example".to_string(),
-            moniker: "moniker".to_string(),
-        };
+        let cred = AgentFedCredential::new("top-secret", "https://ingest.example", "moniker");
+        assert_eq!(cred.expose_token(), "top-secret");
         let rendered = format!("{cred:?}");
         assert!(
             !rendered.contains("top-secret"),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -954,8 +954,6 @@ mod tests {
         assert!(err.contains("attribute name must not be blank"));
     }
 
-    /// Scenario: A configured event-name override is present or absent.
-    /// Guarantees: Configuration wins when present and the signal default is used otherwise.
     #[test]
     fn default_event_name_unwrap_or_prefers_override_and_falls_back() {
         let configured = maybe_event_name(true);
@@ -973,8 +971,6 @@ mod tests {
         }
     }
 
-    /// Scenario: Log encoding has a configured default event name.
-    /// Guarantees: The emitted batch uses the configured log event name.
     #[test]
     fn encode_and_compress_logs_uses_configured_default_event_name() {
         let client = build_client(Some("AppLog"), None);
@@ -999,8 +995,6 @@ mod tests {
         assert_eq!(batches[0].event_name, "AppLog");
     }
 
-    /// Scenario: Span encoding has a configured default event name.
-    /// Guarantees: The emitted batch uses the configured span event name.
     #[test]
     fn encode_and_compress_spans_uses_configured_default_event_name() {
         let client = build_client(None, Some("AppTrace"));
@@ -1024,8 +1018,6 @@ mod tests {
         assert_eq!(batches[0].event_name, "AppTrace");
     }
 
-    /// Scenario: An agent-fed source is used to initialize a Geneva client.
-    /// Guarantees: The safer credential constructor remains usable by source implementations.
     #[test]
     fn encode_and_compress_spans_no_mapping_shares_default_name_across_spans() {
         // No routing mapping: every span in the scope resolves to the default
@@ -1558,6 +1550,8 @@ mod tests {
         assert_eq!(batches[0].event_name, "Span");
     }
 
+    /// Scenario: An agent-fed source initializes a Geneva client with a protected token.
+    /// Guarantees: Source implementations can construct credentials through the hardened API.
     #[test]
     fn with_agent_fed_source_builds_usable_client() {
         #[derive(Debug)]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -5,6 +5,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
     Client, Url,
 };
+use secrecy::zeroize::Zeroizing;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::time::Duration;
 use thiserror::Error;
@@ -179,7 +181,7 @@ pub(crate) struct IngestionGatewayInfo {
     #[serde(rename = "Endpoint")]
     pub(crate) endpoint: String,
     #[serde(rename = "AuthToken")]
-    pub(crate) auth_token: String,
+    pub(crate) auth_token: SecretString,
     #[serde(rename = "AuthTokenExpiryTime")]
     pub(crate) auth_token_expiry_time: String,
 }
@@ -835,20 +837,21 @@ impl GenevaConfigClient {
                     GenevaConfigClientError::InternalError("Failed to parse token expiry".into())
                 })?;
 
-        let token_endpoint =
-            match extract_endpoint_from_token(&fresh_ingestion_gateway_info.auth_token) {
-                Ok(ep) => ep,
-                Err(err) => {
-                    // Fallback: some tokens legitimately omit the Endpoint claim; use server endpoint.
-                    tracing::debug!(
-                        name: "config_client.get_ingestion_info.endpoint_claim_missing",
-                        target: "geneva-uploader",
-                        error = %err,
-                        "Token Endpoint claim missing or unparsable; using server endpoint"
-                    );
-                    fresh_ingestion_gateway_info.endpoint.clone()
-                }
-            };
+        let token_endpoint = match extract_endpoint_from_token(
+            fresh_ingestion_gateway_info.auth_token.expose_secret(),
+        ) {
+            Ok(ep) => ep,
+            Err(err) => {
+                // Fallback: some tokens legitimately omit the Endpoint claim; use server endpoint.
+                tracing::debug!(
+                    name: "config_client.get_ingestion_info.endpoint_claim_missing",
+                    target: "geneva-uploader",
+                    error = %err,
+                    "Token Endpoint claim missing or unparsable; using server endpoint"
+                );
+                fresh_ingestion_gateway_info.endpoint.clone()
+            }
+        };
 
         // Now update the cache with exclusive write access
         let mut guard = self
@@ -952,6 +955,7 @@ impl GenevaConfigClient {
         let body = response.text().await?;
 
         if status.is_success() {
+            let body = Zeroizing::new(body);
             debug!(
                 name: "config_client.fetch_ingestion_info.response",
                 target: "geneva-uploader",

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -77,8 +77,6 @@ mod tests {
         Uuid::new_v4().to_string()
     }
 
-    /// Scenario: A config-service client is built with representative fields.
-    /// Guarantees: Construction preserves the configured authentication and routing values.
     #[test]
     fn config_fields() {
         let config = GenevaConfigClientConfig {
@@ -516,8 +514,6 @@ mod tests {
         assert_eq!(token_endpoint, jwt_endpoint);
     }
 
-    /// Scenario: Local managed-identity token acquisition returns a service error.
-    /// Guarantees: The config-service request is skipped and the MSI error is preserved.
     #[tokio::test(flavor = "current_thread")]
     async fn user_managed_identity_by_resource_id_returns_error_on_local_msi_failure() {
         let _env_lock = ENV_LOCK.lock().await;
@@ -574,8 +570,6 @@ mod tests {
         }
     }
 
-    /// Scenario: The config service presents a certificate from an untrusted CA.
-    /// Guarantees: TLS validation rejects the connection.
     #[tokio::test]
     async fn tls_rejects_untrusted_runtime_generated_ca() {
         #[cfg(feature = "tls-rustls")]
@@ -670,8 +664,6 @@ mod tests {
         tls_server.handle.join().unwrap();
     }
 
-    /// Scenario: The config service responds with HTTP 403.
-    /// Guarantees: The client surfaces the response status as a request failure.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn error_handling_with_non_success_status() {
@@ -719,8 +711,6 @@ mod tests {
         }
     }
 
-    /// Scenario: A successful response omits ingestion gateway information.
-    /// Guarantees: The client reports the missing authentication data.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn missing_ingestion_gateway_info() {
@@ -773,8 +763,6 @@ mod tests {
         }
     }
 
-    /// Scenario: Certificate authentication references a nonexistent PKCS#12 file.
-    /// Guarantees: Client initialization fails without attempting an upload.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn invalid_certificate_path() {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -20,6 +20,7 @@ mod tests {
         },
     };
     use rcgen::generate_simple_self_signed;
+    use secrecy::ExposeSecret;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::path::PathBuf;
@@ -76,6 +77,8 @@ mod tests {
         Uuid::new_v4().to_string()
     }
 
+    /// Scenario: A config-service client is built with representative fields.
+    /// Guarantees: Construction preserves the configured authentication and routing values.
     #[test]
     fn config_fields() {
         let config = GenevaConfigClientConfig {
@@ -390,6 +393,8 @@ mod tests {
         (response.to_string(), jwt_endpoint, valid_token)
     }
 
+    /// Scenario: Certificate auth retrieves ingestion routing from a mock config service.
+    /// Guarantees: The returned token and routing preserve the service response.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn get_ingestion_info_mocked() {
@@ -428,7 +433,8 @@ mod tests {
             client.get_ingestion_info().await.unwrap();
 
         assert_eq!(ingestion_info.endpoint, "https://mock.ingestion.endpoint");
-        assert_eq!(ingestion_info.auth_token, valid_token);
+        assert_eq!(ingestion_info.auth_token.expose_secret(), valid_token);
+        assert!(!format!("{ingestion_info:?}").contains(valid_token));
         assert_eq!(
             ingestion_info.auth_token_expiry_time,
             "2030-01-01T00:00:00Z"
@@ -440,6 +446,8 @@ mod tests {
         assert_eq!(token_endpoint, jwt_endpoint);
     }
 
+    /// Scenario: A resource-ID managed identity authenticates to the config service.
+    /// Guarantees: The resolved ingestion token remains correct after secret wrapping.
     #[tokio::test(flavor = "current_thread")]
     async fn user_managed_identity_by_resource_id_uses_local_msi_res_id_endpoint() {
         let _env_lock = ENV_LOCK.lock().await;
@@ -503,11 +511,13 @@ mod tests {
             client.get_ingestion_info().await.unwrap();
 
         assert_eq!(ingestion_info.endpoint, "https://mock.ingestion.endpoint");
-        assert_eq!(ingestion_info.auth_token, valid_token);
+        assert_eq!(ingestion_info.auth_token.expose_secret(), valid_token);
         assert_eq!(moniker_info.name, "mock-diag-moniker");
         assert_eq!(token_endpoint, jwt_endpoint);
     }
 
+    /// Scenario: Local managed-identity token acquisition returns a service error.
+    /// Guarantees: The config-service request is skipped and the MSI error is preserved.
     #[tokio::test(flavor = "current_thread")]
     async fn user_managed_identity_by_resource_id_returns_error_on_local_msi_failure() {
         let _env_lock = ENV_LOCK.lock().await;
@@ -564,6 +574,8 @@ mod tests {
         }
     }
 
+    /// Scenario: The config service presents a certificate from an untrusted CA.
+    /// Guarantees: TLS validation rejects the connection.
     #[tokio::test]
     async fn tls_rejects_untrusted_runtime_generated_ca() {
         #[cfg(feature = "tls-rustls")]
@@ -607,6 +619,8 @@ mod tests {
         tls_server.handle.join().unwrap();
     }
 
+    /// Scenario: A trusted runtime-generated CA secures the config-service response.
+    /// Guarantees: The secret-wrapped token and routing survive TLS retrieval.
     #[tokio::test]
     async fn tls_accepts_runtime_generated_ca() {
         #[cfg(feature = "tls-rustls")]
@@ -645,7 +659,7 @@ mod tests {
             client.get_ingestion_info().await.unwrap();
 
         assert_eq!(ingestion_info.endpoint, "https://mock.ingestion.endpoint");
-        assert_eq!(ingestion_info.auth_token, valid_token);
+        assert_eq!(ingestion_info.auth_token.expose_secret(), valid_token);
         assert_eq!(
             ingestion_info.auth_token_expiry_time,
             "2030-01-01T00:00:00Z"
@@ -656,6 +670,8 @@ mod tests {
         tls_server.handle.join().unwrap();
     }
 
+    /// Scenario: The config service responds with HTTP 403.
+    /// Guarantees: The client surfaces the response status as a request failure.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn error_handling_with_non_success_status() {
@@ -703,6 +719,8 @@ mod tests {
         }
     }
 
+    /// Scenario: A successful response omits ingestion gateway information.
+    /// Guarantees: The client reports the missing authentication data.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn missing_ingestion_gateway_info() {
@@ -755,6 +773,8 @@ mod tests {
         }
     }
 
+    /// Scenario: Certificate authentication references a nonexistent PKCS#12 file.
+    /// Guarantees: Client initialization fails without attempting an upload.
     #[cfg_attr(target_os = "macos", ignore)] // cert generated not compatible with macOS
     #[tokio::test]
     async fn invalid_certificate_path() {
@@ -802,6 +822,8 @@ mod tests {
     // cargo test get_ingestion_info_real_server -- --ignored
     // ```
     use std::env;
+    /// Scenario: An operator explicitly runs the real config-service smoke test.
+    /// Guarantees: Returned secret-wrapped credentials are non-empty without logging them.
     #[tokio::test]
     #[ignore] // This test is ignored by default to prevent running in CI pipelines
     async fn get_ingestion_info_real_server() {
@@ -854,7 +876,7 @@ mod tests {
             "Endpoint should not be empty"
         );
         assert!(
-            !ingestion_info.auth_token.is_empty(),
+            !ingestion_info.auth_token.expose_secret().is_empty(),
             "Auth token should not be empty"
         );
         assert!(!moniker.name.is_empty(), "Moniker name should not be empty");
@@ -865,7 +887,7 @@ mod tests {
 
         println!("Successfully connected to real server");
         println!("Endpoint: {}", ingestion_info.endpoint);
-        let token_len = ingestion_info.auth_token.len();
+        let token_len = ingestion_info.auth_token.expose_secret().len();
         println!("Auth token length: {token_len}");
         println!("Moniker name: {}", moniker.name);
     }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -2,7 +2,10 @@ use crate::config_service::client::{
     extract_endpoint_from_token, GenevaConfigClient, GenevaConfigClientError,
 };
 use crate::payload_encoder::central_blob::BatchMetadata;
+use bytes::Bytes;
 use reqwest::{header, Client};
+use secrecy::zeroize::Zeroizing;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -128,10 +131,29 @@ pub(crate) enum IngestionSource {
 
 /// Credential + routing resolved for a single upload, independent of source.
 struct ResolvedIngestion {
-    token: String,
+    token: SecretString,
     gig_endpoint: String,
     moniker: String,
     endpoint_query_param: String,
+}
+
+/// Builds a sensitive header whose application-owned buffer is zeroized after
+/// the last request/header clone is dropped. The HTTP/TLS stack may still copy
+/// the bytes into transport-owned buffers.
+fn bearer_authorization_header(token: &SecretString) -> Result<header::HeaderValue> {
+    let token = token.expose_secret().as_bytes();
+    let mut value = Zeroizing::new(Vec::with_capacity(b"Bearer ".len() + token.len()));
+    value.extend_from_slice(b"Bearer ");
+    value.extend_from_slice(token);
+
+    let mut header =
+        header::HeaderValue::from_maybe_shared(Bytes::from_owner(value)).map_err(|error| {
+            GenevaUploaderError::InternalError(format!(
+                "Invalid bearer token for Authorization header: {error}"
+            ))
+        })?;
+    header.set_sensitive(true);
+    Ok(header)
 }
 
 impl IngestionSource {
@@ -165,12 +187,13 @@ impl IngestionSource {
                 // agent-fed path must do the same. Some valid tokens legitimately
                 // omit the claim; mirror the GCS path and fall back to the
                 // credential's own endpoint rather than rejecting the upload.
-                let endpoint_query_param = extract_endpoint_from_token(&cred.token)
+                let endpoint_query_param = extract_endpoint_from_token(cred.expose_token())
                     .unwrap_or_else(|_| cred.endpoint.clone());
+                let (token, gig_endpoint, moniker) = cred.into_parts();
                 Ok(ResolvedIngestion {
-                    token: cred.token,
-                    gig_endpoint: cred.endpoint,
-                    moniker: cred.moniker,
+                    token,
+                    gig_endpoint,
+                    moniker,
                     endpoint_query_param,
                 })
             }
@@ -366,10 +389,12 @@ impl GenevaUploader {
             "Posting to ingestion gateway"
         );
 
+        let authorization_header = bearer_authorization_header(&auth_token)?;
+        drop(auth_token);
         let response = self
             .http_client
             .post(&full_url)
-            .header(header::AUTHORIZATION, format!("Bearer {auth_token}"))
+            .header(header::AUTHORIZATION, authorization_header)
             .body(data)
             .send()
             .await?;
@@ -476,6 +501,8 @@ mod tests {
         }
     }
 
+    /// Scenario: Upload routing includes an OBO identity without annotations.
+    /// Guarantees: The identity is encoded and the annotation parameter is omitted.
     #[test]
     fn test_upload_uri_with_obo_identity() {
         let uploader = make_uploader();
@@ -506,6 +533,8 @@ mod tests {
         );
     }
 
+    /// Scenario: Upload routing includes an OBO identity and XML annotations.
+    /// Guarantees: Both values are present and annotations are URL-encoded.
     #[test]
     fn test_upload_uri_with_obo_annotations() {
         let uploader = make_uploader();
@@ -542,6 +571,8 @@ mod tests {
         );
     }
 
+    /// Scenario: Upload routing has no OBO configuration.
+    /// Guarantees: Neither OBO query parameter is emitted.
     #[test]
     fn test_upload_uri_without_obo() {
         let uploader = make_uploader();
@@ -596,11 +627,11 @@ mod tests {
 
     impl crate::client::AgentFedCredentialSource for TestAgentFedSource {
         fn current(&self) -> crate::client::AgentFedCredentialFuture<'_> {
-            let cred = crate::client::AgentFedCredential {
-                token: self.token.lock().unwrap().clone(),
-                endpoint: self.endpoint.clone(),
-                moniker: self.moniker.clone(),
-            };
+            let cred = crate::client::AgentFedCredential::new(
+                self.token.lock().unwrap().clone(),
+                self.endpoint.clone(),
+                self.moniker.clone(),
+            );
             Box::pin(async move { Some(cred) })
         }
     }
@@ -634,6 +665,22 @@ mod tests {
         format!("hdr.{payload}.sig")
     }
 
+    /// Scenario: A bearer token is converted into an HTTP Authorization header.
+    /// Guarantees: The exact value is preserved and marked sensitive.
+    #[test]
+    fn bearer_authorization_header_is_sensitive() {
+        let token = SecretString::from("secret-token");
+        let header = bearer_authorization_header(&token).expect("valid bearer header");
+
+        assert_eq!(
+            header.to_str().expect("ASCII header"),
+            "Bearer secret-token"
+        );
+        assert!(header.is_sensitive());
+    }
+
+    /// Scenario: An agent-fed upload uses a claimless host credential.
+    /// Guarantees: The uploader skips GCS and sends the host token directly.
     #[tokio::test]
     async fn agent_fed_upload_uses_host_token_and_skips_gcs() {
         use wiremock::matchers::{header, method, path};
@@ -670,6 +717,8 @@ mod tests {
         // mock_server drop verifies exactly one POST carrying the host token.
     }
 
+    /// Scenario: The host rotates its agent-fed bearer token between uploads.
+    /// Guarantees: Each upload resolves and sends the currently provisioned token.
     #[tokio::test]
     async fn agent_fed_upload_reflects_token_rotation() {
         use wiremock::matchers::{header, method, path};
@@ -710,6 +759,8 @@ mod tests {
         // Both `.expect(1)` mocks verify each token was used exactly once.
     }
 
+    /// Scenario: The agent-fed source has no credential provisioned.
+    /// Guarantees: Upload fails with the specific not-provisioned error.
     #[tokio::test]
     async fn agent_fed_upload_errors_when_not_provisioned() {
         let uploader = agent_fed_uploader(Arc::new(EmptyAgentFedSource));
@@ -722,6 +773,8 @@ mod tests {
         );
     }
 
+    /// Scenario: The agent-fed token carries an Endpoint claim.
+    /// Guarantees: The claim overrides the credential endpoint query value.
     #[tokio::test]
     async fn agent_fed_upload_endpoint_query_uses_token_claim() {
         use wiremock::matchers::{method, path, query_param};
@@ -754,6 +807,8 @@ mod tests {
         );
     }
 
+    /// Scenario: The agent-fed token omits an Endpoint claim.
+    /// Guarantees: The query value falls back to the credential endpoint.
     #[tokio::test]
     async fn agent_fed_upload_endpoint_query_falls_back_to_cred_endpoint() {
         use wiremock::matchers::{method, path, query_param};

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -140,12 +140,10 @@ struct ResolvedIngestion {
 /// Builds a sensitive header whose application-owned buffer is zeroized after
 /// the last request/header clone is dropped. The HTTP/TLS stack may still copy
 /// the bytes into transport-owned buffers.
-fn bearer_authorization_header(token: &SecretString) -> Result<header::HeaderValue> {
-    let token = token.expose_secret().as_bytes();
-    let mut value = Zeroizing::new(Vec::with_capacity(b"Bearer ".len() + token.len()));
-    value.extend_from_slice(b"Bearer ");
-    value.extend_from_slice(token);
-
+fn header_value_from_zeroizing_buffer(value: Zeroizing<Vec<u8>>) -> Result<header::HeaderValue> {
+    // `HeaderValue::from_maybe_shared` avoids copying only for `http`'s
+    // internal `Bytes` type. Passing the zeroizing buffer directly would
+    // copy the token into non-zeroizing header storage.
     let mut header =
         header::HeaderValue::from_maybe_shared(Bytes::from_owner(value)).map_err(|error| {
             GenevaUploaderError::InternalError(format!(
@@ -154,6 +152,14 @@ fn bearer_authorization_header(token: &SecretString) -> Result<header::HeaderVal
         })?;
     header.set_sensitive(true);
     Ok(header)
+}
+
+fn bearer_authorization_header(token: &SecretString) -> Result<header::HeaderValue> {
+    let token = token.expose_secret().as_bytes();
+    let mut value = Zeroizing::new(Vec::with_capacity(b"Bearer ".len() + token.len()));
+    value.extend_from_slice(b"Bearer ");
+    value.extend_from_slice(token);
+    header_value_from_zeroizing_buffer(value)
 }
 
 impl IngestionSource {
@@ -501,8 +507,6 @@ mod tests {
         }
     }
 
-    /// Scenario: Upload routing includes an OBO identity without annotations.
-    /// Guarantees: The identity is encoded and the annotation parameter is omitted.
     #[test]
     fn test_upload_uri_with_obo_identity() {
         let uploader = make_uploader();
@@ -533,8 +537,6 @@ mod tests {
         );
     }
 
-    /// Scenario: Upload routing includes an OBO identity and XML annotations.
-    /// Guarantees: Both values are present and annotations are URL-encoded.
     #[test]
     fn test_upload_uri_with_obo_annotations() {
         let uploader = make_uploader();
@@ -571,8 +573,6 @@ mod tests {
         );
     }
 
-    /// Scenario: Upload routing has no OBO configuration.
-    /// Guarantees: Neither OBO query parameter is emitted.
     #[test]
     fn test_upload_uri_without_obo() {
         let uploader = make_uploader();
@@ -665,17 +665,19 @@ mod tests {
         format!("hdr.{payload}.sig")
     }
 
-    /// Scenario: A bearer token is converted into an HTTP Authorization header.
-    /// Guarantees: The exact value is preserved and marked sensitive.
+    /// Scenario: A zeroizing bearer buffer is converted into an Authorization header.
+    /// Guarantees: The header reuses the original allocation and remains marked sensitive.
     #[test]
-    fn bearer_authorization_header_is_sensitive() {
-        let token = SecretString::from("secret-token");
-        let header = bearer_authorization_header(&token).expect("valid bearer header");
+    fn bearer_authorization_header_reuses_zeroizing_buffer() {
+        let value = Zeroizing::new(b"Bearer secret-token".to_vec());
+        let original_buffer = value.as_ptr();
+        let header = header_value_from_zeroizing_buffer(value).expect("valid bearer header");
 
         assert_eq!(
             header.to_str().expect("ASCII header"),
             "Bearer secret-token"
         );
+        assert_eq!(header.as_bytes().as_ptr(), original_buffer);
         assert!(header.is_sensitive());
     }
 


### PR DESCRIPTION
Fixes # N/A
Design discussion issue (if applicable): open-telemetry/otel-arrow#3275

## Changes

Reduce GIG ingestion bearer-token memory remanence:

- Store agent-fed and GCS ingestion credentials in zeroizing secret containers.
- Zeroize successful GCS response bodies after parsing.
- Back sensitive `Authorization` headers with zeroizing application-owned memory.
- Make the agent-fed token private behind explicit construction and access APIs.
- Preserve redacted debug output and token-rotation behavior.
- Require `bytes` 1.9 for `Bytes::from_owner`.

HTTP and TLS implementations may still create transport-owned copies outside the uploader's control.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
