### PR TITLE
chore(aws): Rename `subsegment-nesting` feature

### DIFF
--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -7,10 +7,7 @@
 - Read `cloud.account.id` from symlink created by the OTel Lambda Extension in the Lambda resource detector
 - `XrayExtractor` has been added to extract the X-Ray Trace ID from the `x-amzn-trace-id` HTTP header or the `_X_AMZN_TRACE_ID` environment variable as a fallback.
 - `MissingSampledBehavior` enum and `XrayPropagator::with_missing_sampled_behavior()` to configure behavior when the `Sampled` field is absent from the trace header
-
-### Changed
-
-- AWS X-Ray span exporter (`xray-exporter` feature) for converting OpenTelemetry spans into X-Ray segment documents. Includes `XrayExporter`, `SegmentTranslator`, `SegmentDocumentExporter` trait, `XrayDaemonClient` (`xray-daemon-client` feature), `StdoutClient` (`xray-stdout-client` feature), and optional subsegment nesting (`subsegment-nesting` feature).
+- AWS X-Ray span exporter (`xray-exporter` feature) for converting OpenTelemetry spans into X-Ray segment documents. Includes `XrayExporter`, `SegmentTranslator`, `SegmentDocumentExporter` trait, `XrayDaemonClient` (`xray-daemon-client` feature), `StdoutClient` (`xray-stdout-client` feature), and optional subsegment nesting (`xray-subsegment-nesting` feature).
 
 ## v0.20.0
 

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -37,7 +37,7 @@ xray-exporter = [
 ]
 xray-daemon-client = ["xray-exporter"]
 xray-stdout-client = ["xray-exporter"]
-subsegment-nesting = []
+xray-subsegment-nesting = ["xray-exporter"]
 
 [dependencies]
 http = { version = "1.4.0", optional = true }
@@ -54,7 +54,7 @@ regex = {version = "1.0", optional = true}
 rand = {version = "0.9", optional = true}
 
 [dev-dependencies]
-opentelemetry-aws = {path = ".", features = ["xray-exporter", "subsegment-nesting", "xray-daemon-client"] }
+opentelemetry-aws = {path = ".", features = ["xray-exporter", "xray-subsegment-nesting", "xray-daemon-client"] }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 opentelemetry-http = { workspace = true }
 opentelemetry-stdout = { workspace = true, features = ["trace"] }

--- a/opentelemetry-aws/README.md
+++ b/opentelemetry-aws/README.md
@@ -68,12 +68,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `trace` | Yes | X-Ray propagator and ID generator |
+| `internal-logs` | Yes | Internal instrumentation via the `tracing` crate |
 | `xray-exporter` | No | X-Ray span exporter with `SegmentTranslator` and `SegmentDocumentExporter` trait |
 | `xray-daemon-client` | No | `XrayDaemonClient` — UDP client for the [X-Ray daemon] |
 | `xray-stdout-client` | No | `StdoutClient` — writes segment documents to stdout (useful for debugging) |
-| `subsegment-nesting` | No | Enables subsegment nesting within parent segments during translation |
+| `xray-subsegment-nesting` | No | Enables subsegment nesting within parent segments during translation |
 | `detector-aws-lambda` | No | AWS Lambda resource detector |
-| `internal-logs` | Yes | Internal instrumentation via the `tracing` crate |
 
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [X-Ray daemon]: https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html

--- a/opentelemetry-aws/src/xray_exporter/mod.rs
+++ b/opentelemetry-aws/src/xray_exporter/mod.rs
@@ -81,8 +81,7 @@
 //! | `xray-exporter` | Enables this module |
 //! | `xray-daemon-client` | Enables the [`daemon_client`] sub-module with [`XrayDaemonClient`] for sending segments to the X-Ray daemon over UDP |
 //! | `xray-stdout-client` | Enables the [`stdout_client`] sub-module with [`StdoutClient`] for writing segments to stdout (useful for debugging) |
-//! | `subsegment-nesting` | Enables the use of subsegment nesting via [`SegmentTranslator::always_nest_subsegments`] |
-//! | `internal-logs` | Enables internal `tracing` instrumentation throughout the module |
+//! | `xray-subsegment-nesting` | Enables the use of subsegment nesting via [`SegmentTranslator::always_nest_subsegments`] |
 //!
 //! [`XrayDaemonClient`]: daemon_client::XrayDaemonClient
 //! [`StdoutClient`]: stdout_client::StdoutClient

--- a/opentelemetry-aws/src/xray_exporter/translator/mod.rs
+++ b/opentelemetry-aws/src/xray_exporter/translator/mod.rs
@@ -6,9 +6,9 @@
 
 mod attribute_processing;
 
-#[cfg(feature = "subsegment-nesting")]
+#[cfg(feature = "xray-subsegment-nesting")]
 mod document_builder_tree;
-#[cfg(feature = "subsegment-nesting")]
+#[cfg(feature = "xray-subsegment-nesting")]
 use document_builder_tree::DocumentBuilderHeaderTree;
 
 pub(crate) mod error;
@@ -122,7 +122,7 @@ pub struct SegmentTranslator {
     metadata_all_attrs: bool,
     log_group_names: Vec<String>,
     skip_timestamp_validation: bool,
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     always_nest_subsegments: bool,
     resource: Option<Resource>,
     dispatch_table: DispatchTable,
@@ -192,7 +192,7 @@ impl SegmentTranslator {
             metadata_all_attrs: Default::default(),
             log_group_names: Default::default(),
             skip_timestamp_validation: Default::default(),
-            #[cfg(feature = "subsegment-nesting")]
+            #[cfg(feature = "xray-subsegment-nesting")]
             always_nest_subsegments: Default::default(),
             resource: Default::default(),
             dispatch_table: Default::default(),
@@ -275,7 +275,7 @@ impl SegmentTranslator {
         self
     }
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     /// Enables nesting of subsegments within their parent segments.
     ///
     /// When enabled, subsegments are nested within their parent segments or subsegments
@@ -544,14 +544,14 @@ impl SegmentTranslator {
         #[cfg(feature = "internal-logs")]
         tracing::debug!("Received {} spans", batch.len());
 
-        #[cfg(feature = "subsegment-nesting")]
+        #[cfg(feature = "xray-subsegment-nesting")]
         if self.always_nest_subsegments {
             self._translate_spans_nested(batch)
         } else {
             self._translate_spans_simple(batch)
         }
 
-        #[cfg(not(feature = "subsegment-nesting"))]
+        #[cfg(not(feature = "xray-subsegment-nesting"))]
         self._translate_spans_simple(batch)
     }
 
@@ -579,7 +579,7 @@ impl SegmentTranslator {
             .collect()
     }
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     fn _translate_spans_nested<'span, 'translator: 'span>(
         &'translator self,
         batch: &'span [SpanData],

--- a/opentelemetry-aws/src/xray_exporter/types/mod.rs
+++ b/opentelemetry-aws/src/xray_exporter/types/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use segment_document::{
 
 pub use id::{Id, TraceId};
 
-#[cfg(feature = "subsegment-nesting")]
+#[cfg(feature = "xray-subsegment-nesting")]
 pub(crate) use segment_document::DocumentBuilderHeader;
 
 pub(crate) use value::{AnnotationValue, AnySlice, AnyValue, Namespace, Origin, StrList};

--- a/opentelemetry-aws/src/xray_exporter/types/segment_document.rs
+++ b/opentelemetry-aws/src/xray_exporter/types/segment_document.rs
@@ -156,12 +156,12 @@ pub struct SegmentDocument<'a> {
     #[serde(skip_serializing_if = "VectorMap::is_empty")]
     metadata: VectorMap<&'a str, AnyValue<'a>>,
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     /// Array of subsegment objects
     #[serde(skip_serializing_if = "Vec::is_empty")]
     subsegments: Vec<SegmentDocument<'a>>,
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     /// Array of subsegment IDs that identifies subsegments with the same parent that completed prior to this subsegment
     #[serde(skip_serializing_if = "Vec::is_empty")]
     precursor_ids: Vec<Id>,
@@ -279,9 +279,9 @@ pub(crate) struct DocumentBuilder<'a, DBT: DocumentBuilderType> {
     error_details: ErrorDetailsBuilder<'a>,
     annotations: VectorMap<Cow<'a, str>, AnnotationValue<'a>>,
     metadata: VectorMap<&'a str, AnyValue<'a>>,
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     subsegments: Vec<SubsegmentDocumentBuilder<'a>>,
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     precursor_ids: Vec<Id>,
 }
 
@@ -291,7 +291,7 @@ pub(crate) type SegmentDocumentBuilder<'a> = DocumentBuilder<'a, builder_type::S
 /// Builder for X-Ray subsegment documents.
 pub(crate) type SubsegmentDocumentBuilder<'a> = DocumentBuilder<'a, builder_type::Subsegment>;
 
-#[cfg(feature = "subsegment-nesting")]
+#[cfg(feature = "xray-subsegment-nesting")]
 /// Core identifying and timing information for segment/subsegment builders.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DocumentBuilderHeader {
@@ -343,7 +343,7 @@ impl<'a, DBT: DocumentBuilderType> DocumentBuilder<'a, DBT> {
         &mut self.error_details
     }
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     pub fn header(&self) -> DocumentBuilderHeader {
         DocumentBuilderHeader {
             id: self.id,
@@ -441,7 +441,7 @@ impl<'a, DBT: DocumentBuilderType> DocumentBuilder<'a, DBT> {
         self
     }
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     /// Adds a subsegment to the segment by consuming a [SubsegmentBuilder].
     pub fn subsegment(
         &mut self,
@@ -464,7 +464,7 @@ impl<'a, DBT: DocumentBuilderType> DocumentBuilder<'a, DBT> {
 
         DBT::verify_constraints(&self)?;
 
-        #[cfg(feature = "subsegment-nesting")]
+        #[cfg(feature = "xray-subsegment-nesting")]
         let subsegments = self
             .subsegments
             .into_iter()
@@ -490,9 +490,9 @@ impl<'a, DBT: DocumentBuilderType> DocumentBuilder<'a, DBT> {
             sql: self.sql.build(),
             annotations: self.annotations,
             metadata: self.metadata,
-            #[cfg(feature = "subsegment-nesting")]
+            #[cfg(feature = "xray-subsegment-nesting")]
             subsegments,
-            #[cfg(feature = "subsegment-nesting")]
+            #[cfg(feature = "xray-subsegment-nesting")]
             precursor_ids: self.precursor_ids,
         })
     }
@@ -568,7 +568,7 @@ impl<'a> SubsegmentDocumentBuilder<'a> {
         Ok(self)
     }
 
-    #[cfg(feature = "subsegment-nesting")]
+    #[cfg(feature = "xray-subsegment-nesting")]
     /// Adds precursor IDs.
     ///
     /// Sets IDs of subsegments with the same parent that completed before this one.


### PR DESCRIPTION
## Changes

- `subsegment-nesting` feature renamed to `xray-subsegment-nesting` so it is clearer that it is part of the xray-* features.
- removed the `internal-logging` feature from the xray module documentation as it only take advantage of the feature but does not own it
- taking the opportunity to correct my mistake in CHANGELOG on the previous PR and correctly placed the XRay exporter in the 'Added' section instead of 'Changed' 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
