### PR TITLE
feat(aws): add EC2, ECS and EKS resource detectors

### DIFF
--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -8,6 +8,9 @@
 - `XrayExtractor` has been added to extract the X-Ray Trace ID from the `x-amzn-trace-id` HTTP header or the `_X_AMZN_TRACE_ID` environment variable as a fallback.
 - `MissingSampledBehavior` enum and `XrayPropagator::with_missing_sampled_behavior()` to configure behavior when the `Sampled` field is absent from the trace header
 - AWS X-Ray span exporter (`xray-exporter` feature) for converting OpenTelemetry spans into X-Ray segment documents. Includes `XrayExporter`, `SegmentTranslator`, `SegmentDocumentExporter` trait, `XrayDaemonClient` (`xray-daemon-client` feature), `StdoutClient` (`xray-stdout-client` feature), and optional subsegment nesting (`xray-subsegment-nesting` feature).
+- `Ec2ResourceDetector` (`detector-aws-ec2` feature)
+- `EcsResourceDetector` (`detector-aws-ecs` feature)
+- `EksResourceDetector` (`detector-aws-eks` feature)
 
 ## v0.20.0
 

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -23,7 +23,13 @@ default = ["trace", "internal-logs"]
 internal-logs = ["dep:tracing"]
 
 trace = ["http", "opentelemetry/trace", "opentelemetry_sdk/trace"]
-detector-aws-lambda = ["dep:opentelemetry-semantic-conventions"]
+
+_detector = ["dep:opentelemetry_sdk", "dep:opentelemetry-semantic-conventions"]
+_detector-http = ["dep:ureq", "dep:serde", "dep:thiserror"]
+detector-aws-lambda = ["_detector"]
+detector-aws-ec2 = ["_detector", "_detector-http"]
+detector-aws-ecs = ["_detector", "_detector-http"]
+detector-aws-eks = ["_detector", "_detector-http"]
 
 xray-exporter = [
     "opentelemetry/trace",
@@ -52,6 +58,7 @@ serde_json = {version = "1.0", optional = true}
 thiserror = {version = "2.0", optional = true}
 regex = {version = "1.0", optional = true}
 rand = {version = "0.9", optional = true}
+ureq = { version = "3.2", default-features = false, features = ["json"], optional = true }
 
 [dev-dependencies]
 opentelemetry-aws = {path = ".", features = ["xray-exporter", "xray-subsegment-nesting", "xray-daemon-client"] }

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -68,6 +68,7 @@ opentelemetry-stdout = { workspace = true, features = ["trace"] }
 hyper = { version = "1.4.1" }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 sealed_test = "1.1"
+serde_json = "1.0"
 temp-env = "0.3"
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
 rand = "0.9"

--- a/opentelemetry-aws/README.md
+++ b/opentelemetry-aws/README.md
@@ -31,6 +31,9 @@ to AWS's telemetry platform.
 | **X-Ray ID Generator** | `trace` | Generates X-Ray-compatible trace and span IDs (time-based trace IDs) |
 | **X-Ray Exporter** | `xray-exporter` | Exports OpenTelemetry spans as [X-Ray segment documents] |
 | **Lambda Resource Detector** | `detector-aws-lambda` | Detects AWS Lambda resource attributes from the environment |
+| **EC2 Resource Detector** | `detector-aws-ec2` | Detects AWS EC2 resource attributes via IMDSv2 |
+| **ECS Resource Detector** | `detector-aws-ecs` | Detects AWS ECS resource attributes via the task and container metadata endpoints |
+| **EKS Resource Detector** | `detector-aws-eks` | Detects AWS EKS resource attributes via the Kubernetes service-account mount and IMDSv2 |
 
 ## Quick Start
 
@@ -74,6 +77,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `xray-stdout-client` | No | `StdoutClient` — writes segment documents to stdout (useful for debugging) |
 | `xray-subsegment-nesting` | No | Enables subsegment nesting within parent segments during translation |
 | `detector-aws-lambda` | No | AWS Lambda resource detector |
+| `detector-aws-ec2` | No | AWS EC2 resource detector |
+| `detector-aws-ecs` | No | AWS ECS resource detector |
+| `detector-aws-eks` | No | AWS EKS resource detector |
 
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [X-Ray daemon]: https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html

--- a/opentelemetry-aws/src/detector/ec2.rs
+++ b/opentelemetry-aws/src/detector/ec2.rs
@@ -29,28 +29,13 @@ const DETECTOR: &str = "aws_ec2";
 /// | `host.arch`               | identity document `architecture`, mapped to `host.arch` values |
 /// | `host.name`               | `/latest/meta-data/hostname`                                   |
 ///
-/// All but `host.name` come from the instance identity document
-/// (`/latest/dynamic/instance-identity/document`), so detection costs three
-/// requests in total: the IMDSv2 token, the document and the hostname.
-///
 /// Values that cannot be found are skipped.
 ///
-/// # Feature flag
-///
-/// This type is only available when the `detector-aws-ec2` Cargo feature is
-/// enabled.
-///
-/// # Behavior
-///
-/// Detection is best-effort. Any IMDSv2 call that fails (network error, HTTP
-/// error, or JSON parse error) is silently skipped and the corresponding
-/// attribute is omitted from the returned [`Resource`].
+/// # Probing
 ///
 /// The platform probe is the acquisition of an IMDSv2 session token *and* the
 /// successful parse of the instance identity document. Unless both succeed the
-/// environment is assumed not to be EC2 and an empty [`Resource`] is returned,
-/// so that `cloud.provider` and `cloud.platform` are never asserted
-/// off-platform.
+/// environment is assumed not to be EC2 and an empty [`Resource`] is returned.
 ///
 /// # Blocking
 ///

--- a/opentelemetry-aws/src/detector/ec2.rs
+++ b/opentelemetry-aws/src/detector/ec2.rs
@@ -1,0 +1,116 @@
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::{resource::ResourceDetector, Resource};
+use opentelemetry_semantic_conventions::attribute as semco;
+
+use super::{
+    imds::ImdsClient,
+    utils::{opt_kv, warn_on_error},
+};
+
+/// Name reported in internal logs emitted by this detector.
+const DETECTOR: &str = "aws_ec2";
+
+/// EC2 resource detector (`detector-aws-ec2` feature).
+///
+/// Queries the EC2 Instance Metadata Service v2 (IMDSv2) at the link-local
+/// address `169.254.169.254` and returns an OTel [`Resource`] with the
+/// following attributes:
+///
+/// | OTel attribute            | Source                                                         |
+/// |---------------------------|----------------------------------------------------------------|
+/// | `cloud.provider`          | hardcoded `"aws"`                                              |
+/// | `cloud.platform`          | hardcoded `"aws_ec2"`                                          |
+/// | `cloud.account.id`        | identity document `accountId`                                  |
+/// | `cloud.region`            | identity document `region`                                     |
+/// | `cloud.availability_zone` | identity document `availabilityZone`                           |
+/// | `host.id`                 | identity document `instanceId`                                 |
+/// | `host.type`               | identity document `instanceType`                               |
+/// | `host.image.id`           | identity document `imageId`                                    |
+/// | `host.arch`               | identity document `architecture`, mapped to `host.arch` values |
+/// | `host.name`               | `/latest/meta-data/hostname`                                   |
+///
+/// All but `host.name` come from the instance identity document
+/// (`/latest/dynamic/instance-identity/document`), so detection costs three
+/// requests in total: the IMDSv2 token, the document and the hostname.
+///
+/// Values that cannot be found are skipped.
+///
+/// # Feature flag
+///
+/// This type is only available when the `detector-aws-ec2` Cargo feature is
+/// enabled.
+///
+/// # Behavior
+///
+/// Detection is best-effort. Any IMDSv2 call that fails (network error, HTTP
+/// error, or JSON parse error) is silently skipped and the corresponding
+/// attribute is omitted from the returned [`Resource`].
+///
+/// The platform probe is the acquisition of an IMDSv2 session token *and* the
+/// successful parse of the instance identity document. Unless both succeed the
+/// environment is assumed not to be EC2 and an empty [`Resource`] is returned,
+/// so that `cloud.provider` and `cloud.platform` are never asserted
+/// off-platform.
+///
+/// # Blocking
+///
+/// Detection performs blocking HTTP requests, each capped by a one second
+/// timeout, and will therefore stall the calling thread.
+///
+/// # Examples
+///
+/// Register the detector with the OpenTelemetry SDK so that EC2 attributes are
+/// automatically merged into the global resource:
+///
+/// ```no_run
+/// // Requires a running EC2 instance with IMDSv2 enabled.
+/// use opentelemetry_aws::detector::Ec2ResourceDetector;
+/// use opentelemetry_sdk::Resource;
+///
+/// let resource = Resource::builder()
+///     .with_detector(Box::new(Ec2ResourceDetector))
+///     .build();
+/// ```
+///
+/// [`Resource`]: opentelemetry_sdk::Resource
+pub struct Ec2ResourceDetector;
+
+impl ResourceDetector for Ec2ResourceDetector {
+    fn detect(&self) -> Resource {
+        // Platform probe. A session token only proves that *something* answers
+        // at the link-local address; a parsable identity document is what
+        // proves it is IMDSv2. Both failures are routine off-platform.
+        let Some(imds) = warn_on_error(DETECTOR, ImdsClient::new()) else {
+            // Not EC2, return empty resource
+            return Resource::builder_empty().build();
+        };
+        let Some(document) = warn_on_error(DETECTOR, imds.get_identity_document()) else {
+            // Not EC2, return empty resource
+            return Resource::builder_empty().build();
+        };
+
+        // Past this point the environment is believed to be EC2.
+        let attribute_options = [
+            Some(KeyValue::new(semco::CLOUD_PROVIDER, "aws")),
+            Some(KeyValue::new(semco::CLOUD_PLATFORM, "aws_ec2")),
+            document
+                .host_arch()
+                .map(|arch| KeyValue::new(semco::HOST_ARCH, arch)),
+            opt_kv(semco::CLOUD_ACCOUNT_ID, document.account_id),
+            opt_kv(semco::CLOUD_REGION, document.region),
+            opt_kv(semco::CLOUD_AVAILABILITY_ZONE, document.availability_zone),
+            opt_kv(semco::HOST_ID, document.instance_id),
+            opt_kv(semco::HOST_TYPE, document.instance_type),
+            opt_kv(semco::HOST_IMAGE_ID, document.image_id),
+            // Host name — the only attribute absent from the identity document
+            opt_kv(
+                semco::HOST_NAME,
+                warn_on_error(DETECTOR, imds.get("hostname")),
+            ),
+        ];
+
+        Resource::builder_empty()
+            .with_attributes(attribute_options.into_iter().flatten())
+            .build()
+    }
+}

--- a/opentelemetry-aws/src/detector/ec2.rs
+++ b/opentelemetry-aws/src/detector/ec2.rs
@@ -4,7 +4,7 @@ use opentelemetry_semantic_conventions::attribute as semco;
 
 use super::{
     imds::{ImdsClient, ImdsError, ImdsProvider},
-    utils::{opt_kv, warn_on_error},
+    utils::{info_on_error, opt_kv, warn_on_error},
 };
 
 /// Name reported in internal logs emitted by this detector.
@@ -83,14 +83,12 @@ impl ResourceDetector for Ec2ResourceDetector {
 
 impl Ec2ResourceDetector {
     fn detect_from<P: ImdsProvider>(imds: Result<P, ImdsError>) -> Resource {
-        // Platform probe. A session token only proves that *something* answers
-        // at the link-local address; a parsable identity document is what
-        // proves it is IMDSv2. Both failures are routine off-platform.
-        let Some(imds) = warn_on_error(DETECTOR, imds) else {
-            // Not EC2, return empty resource
+        // Platform probe.
+        let Some(imds) = info_on_error(DETECTOR, imds) else {
+            // Not EC2/IMDSv2, return empty resource
             return Resource::builder_empty().build();
         };
-        let Some(document) = warn_on_error(DETECTOR, imds.get_identity_document()) else {
+        let Some(document) = info_on_error(DETECTOR, imds.get_identity_document()) else {
             // Not EC2, return empty resource
             return Resource::builder_empty().build();
         };

--- a/opentelemetry-aws/src/detector/ec2.rs
+++ b/opentelemetry-aws/src/detector/ec2.rs
@@ -3,7 +3,7 @@ use opentelemetry_sdk::{resource::ResourceDetector, Resource};
 use opentelemetry_semantic_conventions::attribute as semco;
 
 use super::{
-    imds::ImdsClient,
+    imds::{ImdsClient, ImdsError, ImdsProvider},
     utils::{opt_kv, warn_on_error},
 };
 
@@ -77,10 +77,16 @@ pub struct Ec2ResourceDetector;
 
 impl ResourceDetector for Ec2ResourceDetector {
     fn detect(&self) -> Resource {
+        Self::detect_from(ImdsClient::new())
+    }
+}
+
+impl Ec2ResourceDetector {
+    fn detect_from<P: ImdsProvider>(imds: Result<P, ImdsError>) -> Resource {
         // Platform probe. A session token only proves that *something* answers
         // at the link-local address; a parsable identity document is what
         // proves it is IMDSv2. Both failures are routine off-platform.
-        let Some(imds) = warn_on_error(DETECTOR, ImdsClient::new()) else {
+        let Some(imds) = warn_on_error(DETECTOR, imds) else {
             // Not EC2, return empty resource
             return Resource::builder_empty().build();
         };
@@ -112,5 +118,140 @@ impl ResourceDetector for Ec2ResourceDetector {
         Resource::builder_empty()
             .with_attributes(attribute_options.into_iter().flatten())
             .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detector::imds::tests::FakeImdsClient;
+
+    // ── IMDS JSON fixtures ────────────────────────────────────────────────────
+
+    /// Identity document with all relevant fields.
+    const FULL_DOC: &str = r#"
+        {
+            "accountId":        "123456789012",
+            "region":           "us-east-1",
+            "availabilityZone": "us-east-1a",
+            "instanceId":       "i-0abcdef1234567890",
+            "instanceType":     "m5.xlarge",
+            "imageId":          "ami-0abcdef1234567890",
+            "architecture":     "x86_64"
+        }
+    "#;
+
+    /// Sparse document — only instanceId and arm64 architecture; all other
+    /// fields absent, so only host.id, host.arch and host.name should appear.
+    const SPARSE_DOC_ARM64: &str = r#"
+        {
+            "instanceId":   "i-0abcdef1234567890",
+            "architecture": "arm64"
+        }
+    "#;
+
+    /// Document with an unknown architecture — host.arch must be omitted.
+    const DOC_UNKNOWN_ARCH: &str = r#"
+        {
+            "accountId":    "123456789012",
+            "region":       "us-west-2",
+            "instanceId":   "i-0aaa",
+            "architecture": "mips"
+        }
+    "#;
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn detect_from_full_document_and_hostname() {
+        let fake = FakeImdsClient::new()
+            .with_document(FULL_DOC)
+            .with_get("hostname", "ip-10-0-1-2.ec2.internal");
+
+        let resource = Ec2ResourceDetector::detect_from(Ok(fake));
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ec2"),
+                KeyValue::new(semco::HOST_ARCH, "amd64"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1a"),
+                KeyValue::new(semco::HOST_ID, "i-0abcdef1234567890"),
+                KeyValue::new(semco::HOST_TYPE, "m5.xlarge"),
+                KeyValue::new(semco::HOST_IMAGE_ID, "ami-0abcdef1234567890"),
+                KeyValue::new(semco::HOST_NAME, "ip-10-0-1-2.ec2.internal"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── Construction failure → empty resource ─────────────────────────────────
+
+    #[test]
+    fn detect_from_construction_failure_returns_empty() {
+        let resource =
+            Ec2ResourceDetector::detect_from::<FakeImdsClient>(Err(ImdsError::EmptyAuthToken));
+
+        assert_eq!(resource, Resource::builder_empty().build());
+    }
+
+    // ── Identity document error → empty resource ──────────────────────────────
+
+    #[test]
+    fn detect_from_document_error_returns_empty() {
+        let fake = FakeImdsClient::new();
+        let resource = Ec2ResourceDetector::detect_from(Ok(fake));
+
+        assert_eq!(resource, Resource::builder_empty().build());
+    }
+
+    // ── Partial document: missing fields omitted ──────────────────────────────
+
+    #[test]
+    fn detect_from_partial_document_omits_missing_fields() {
+        let fake = FakeImdsClient::new()
+            .with_document(SPARSE_DOC_ARM64)
+            .with_get("hostname", "ip-10-0-0-1.ec2.internal");
+
+        let resource = Ec2ResourceDetector::detect_from(Ok(fake));
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ec2"),
+                KeyValue::new(semco::HOST_ARCH, "arm64"),
+                KeyValue::new(semco::HOST_ID, "i-0abcdef1234567890"),
+                KeyValue::new(semco::HOST_NAME, "ip-10-0-0-1.ec2.internal"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── Unknown arch omitted, hostname GET error omitted ──────────────────────
+
+    #[test]
+    fn detect_from_unknown_arch_omitted() {
+        // GET IMDS/hostname will return a 404 NotFound
+        let fake = FakeImdsClient::new().with_document(DOC_UNKNOWN_ARCH);
+
+        let resource = Ec2ResourceDetector::detect_from(Ok(fake));
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ec2"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::CLOUD_REGION, "us-west-2"),
+                KeyValue::new(semco::HOST_ID, "i-0aaa"),
+                // No HOST_NAME
+                // No HOST_ARCH
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
     }
 }

--- a/opentelemetry-aws/src/detector/ecs.rs
+++ b/opentelemetry-aws/src/detector/ecs.rs
@@ -9,7 +9,7 @@ use ureq::{Agent as HttpClient, Error as HttpClientError};
 use thiserror::Error;
 
 use super::{
-    imds::ImdsClient,
+    imds::{ImdsClient, ImdsError, ImdsProvider},
     utils::{blocking_client, opt_kv, opt_kv_array, warn_on_error},
 };
 
@@ -113,9 +113,18 @@ pub struct EcsResourceDetector;
 
 impl ResourceDetector for EcsResourceDetector {
     fn detect(&self) -> Resource {
+        Self::detect_from(EcsMetadataClient::new(), ImdsClient::new)
+    }
+}
+
+impl EcsResourceDetector {
+    fn detect_from<E: EcsMetadataProvider, I: ImdsProvider>(
+        ecs: Result<E, EcsMetadataError>,
+        imds: impl FnOnce() -> Result<I, ImdsError>,
+    ) -> Resource {
         // Platform probe: the metadata URI is injected by the ECS agent, so its
         // absence is the normal case off-platform and only worth a debug event.
-        let Some(ecs_metadata) = warn_on_error(DETECTOR, EcsMetadataClient::new()) else {
+        let Some(ecs_metadata) = warn_on_error(DETECTOR, ecs) else {
             // Not ECS, return empty resource
             return Resource::builder_empty().build();
         };
@@ -226,7 +235,7 @@ impl ResourceDetector for EcsResourceDetector {
         // IMDS is unreachable on Fargate, so it is only probed once the EC2
         // launch type is confirmed, to avoid a guaranteed 1s stall otherwise.
         let ec2_host_attributes = is_ec2_launch_type
-            .then(|| warn_on_error(DETECTOR, ImdsClient::new()))
+            .then(|| warn_on_error(DETECTOR, imds()))
             .flatten()
             .and_then(|imds| {
                 let document = warn_on_error(DETECTOR, imds.get_identity_document())?;
@@ -413,6 +422,12 @@ enum EcsMetadataError {
     JsonResponseRead(#[source] HttpClientError),
 }
 
+/// Abstraction over the ECS metadata client, used to inject fakes in tests.
+trait EcsMetadataProvider {
+    fn get_task_metadata(&self) -> Result<EcsTaskMetadata, EcsMetadataError>;
+    fn get_container_metadata(&self) -> Result<EcsContainerMetadata, EcsMetadataError>;
+}
+
 /// HTTP client and ECS metadata base URI read from the environment.
 struct EcsMetadataClient {
     client: HttpClient,
@@ -453,7 +468,9 @@ impl EcsMetadataClient {
             .read_json()
             .map_err(EcsMetadataError::JsonResponseRead)
     }
+}
 
+impl EcsMetadataProvider for EcsMetadataClient {
     /// Fetches the root endpoint (current container metadata).
     fn get_container_metadata(&self) -> Result<EcsContainerMetadata, EcsMetadataError> {
         self.get_json(None)
@@ -515,6 +532,469 @@ struct EcsTaskMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::detector::imds::{tests::FakeImdsClient, ImdsError};
+    use opentelemetry::{Array, StringValue, Value};
+
+    // ── Fake ECS metadata client ──────────────────────────────────────────────
+
+    /// Test-only fake that returns canned ECS metadata responses.
+    ///
+    /// Both the task and container payloads are stored as JSON `&str` values
+    /// and deserialized on each call, exercising the `serde` impl alongside
+    /// the detector logic.
+    struct FakeEcsMetadataClient {
+        task: &'static str,
+        container: &'static str,
+    }
+
+    impl FakeEcsMetadataClient {
+        fn new() -> Self {
+            Self {
+                task: "",
+                container: "",
+            }
+        }
+
+        fn with_task(mut self, json: &'static str) -> Self {
+            self.task = json;
+            self
+        }
+
+        fn with_container(mut self, json: &'static str) -> Self {
+            self.container = json;
+            self
+        }
+    }
+
+    impl EcsMetadataProvider for FakeEcsMetadataClient {
+        fn get_task_metadata(&self) -> Result<EcsTaskMetadata, EcsMetadataError> {
+            serde_json::from_str(self.task)
+                .map_err(HttpClientError::Json)
+                .map_err(EcsMetadataError::JsonResponseRead)
+        }
+
+        fn get_container_metadata(&self) -> Result<EcsContainerMetadata, EcsMetadataError> {
+            serde_json::from_str(self.container)
+                .map_err(HttpClientError::Json)
+                .map_err(EcsMetadataError::JsonResponseRead)
+        }
+    }
+
+    // ── JSON fixtures ─────────────────────────────────────────────────────────
+
+    /// Fargate task — cluster already given as a full ARN, AZ present.
+    const FARGATE_TASK: &str = r#"
+        {
+            "Cluster":          "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+            "TaskARN":          "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+            "Family":           "my-family",
+            "Revision":         "3",
+            "AvailabilityZone": "us-east-1b",
+            "LaunchType":       "FARGATE"
+        }
+    "#;
+
+    /// EC2 task — cluster given as a bare name (should be expanded to ARN), no AZ.
+    const EC2_TASK: &str = r#"
+        {
+            "Cluster":  "my-cluster",
+            "TaskARN":  "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+            "Family":   "my-family",
+            "Revision": "3",
+            "LaunchType": "EC2"
+        }
+    "#;
+
+    /// Task with no TaskARN — ARN-derived attrs (region, account.id, task.id,
+    /// cluster ARN expansion) should all be absent.
+    const TASK_NO_ARN: &str = r#"
+        {
+            "Cluster":          "my-cluster",
+            "Family":           "my-family",
+            "AvailabilityZone": "us-east-1b",
+            "LaunchType":       "FARGATE"
+        }
+    "#;
+
+    /// Container using the `awslogs` log driver — log group / stream attrs expected.
+    const CONTAINER_WITH_AWSLOGS: &str = r#"
+        {
+            "ContainerARN": "arn:aws:ecs:us-east-1:123456789012:container/abc",
+            "DockerId":     "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "Name":         "my-container",
+            "Image":        "nginx:1.21",
+            "ImageID":      "sha256:aabbcc",
+            "LogDriver":    "awslogs",
+            "LogOptions": {
+                "awslogs-group":  "/ecs/my-group",
+                "awslogs-stream": "my-stream"
+            }
+        }
+    "#;
+
+    /// Container using a non-awslogs driver — log attrs should be absent.
+    const CONTAINER_NO_LOGS: &str = r#"
+        {
+            "ContainerARN": "arn:aws:ecs:us-east-1:123456789012:container/abc",
+            "DockerId":     "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "Name":         "my-container",
+            "Image":        "nginx:1.21",
+            "LogDriver":    "json-file",
+            "LogOptions": {
+                "awslogs-group":  "/ecs/my-group",
+                "awslogs-stream": "my-stream"
+            }
+        }
+    "#;
+
+    /// IMDS instance identity document for an EC2-backed ECS task.
+    /// account_id / region are not consumed by the ECS detector (it derives
+    /// those from the task ARN), but they are present here to keep the fixture
+    /// realistic.
+    const EC2_IMDS_DOC: &str = r#"
+        {
+            "accountId":        "123456789012",
+            "region":           "us-east-1",
+            "availabilityZone": "us-east-1a",
+            "instanceId":       "i-0ec2instance",
+            "instanceType":     "m5.large",
+            "imageId":          "ami-0abcdef",
+            "architecture":     "x86_64"
+        }
+    "#;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    fn str_array(v: &str) -> Value {
+        Value::Array(Array::from(vec![StringValue::from(v.to_string())]))
+    }
+
+    // ── Construction failure → empty resource ─────────────────────────────────
+
+    #[test]
+    fn detect_from_ecs_construction_failure_returns_empty() {
+        let resource = EcsResourceDetector::detect_from::<FakeEcsMetadataClient, FakeImdsClient>(
+            Err(EcsMetadataError::NoMetadataUriEnvVar),
+            || panic!("IMDS closure must not be called"),
+        );
+        assert_eq!(resource, Resource::builder_empty().build());
+    }
+
+    // ── Fargate: IMDS closure not invoked ─────────────────────────────────────
+
+    #[test]
+    fn detect_from_fargate_does_not_invoke_imds() {
+        let ecs = FakeEcsMetadataClient::new()
+            .with_task(FARGATE_TASK)
+            .with_container(CONTAINER_NO_LOGS);
+
+        let imds = || -> Result<FakeImdsClient, _> {
+            panic!("IMDS closure must not be called on Fargate")
+        };
+
+        let resource = EcsResourceDetector::detect_from(Ok(ecs), imds);
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs"),
+                KeyValue::new(
+                    semco::AWS_ECS_CLUSTER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+                ),
+                KeyValue::new(
+                    semco::AWS_ECS_TASK_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+                ),
+                KeyValue::new(semco::AWS_ECS_TASK_FAMILY, "my-family"),
+                KeyValue::new(semco::AWS_ECS_TASK_REVISION, "3"),
+                KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1b"),
+                KeyValue::new(semco::AWS_ECS_LAUNCHTYPE, "fargate"),
+                KeyValue::new(
+                    semco::AWS_ECS_CONTAINER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CLOUD_RESOURCE_ID,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CONTAINER_ID,
+                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                ),
+                KeyValue::new(semco::CONTAINER_NAME, "my-container"),
+                KeyValue::new(semco::CONTAINER_IMAGE_NAME, "nginx"),
+                KeyValue::new(semco::CONTAINER_IMAGE_TAGS, str_array("1.21")),
+                KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::AWS_ECS_TASK_ID, "abc123def456"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── EC2 launch type: IMDS closure invoked → host.* attributes ─────────────
+
+    #[test]
+    fn detect_from_ec2_launch_type_queries_imds() {
+        let ecs = FakeEcsMetadataClient::new()
+            .with_task(EC2_TASK)
+            .with_container(CONTAINER_NO_LOGS);
+
+        let imds = || {
+            Ok(FakeImdsClient::new()
+                .with_document(EC2_IMDS_DOC)
+                .with_get("hostname", "ip-10-0-0-5.ec2.internal"))
+        };
+
+        let resource = EcsResourceDetector::detect_from(Ok(ecs), imds);
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs"),
+                // task attrs
+                KeyValue::new(
+                    semco::AWS_ECS_CLUSTER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+                ),
+                KeyValue::new(
+                    semco::AWS_ECS_TASK_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+                ),
+                KeyValue::new(semco::AWS_ECS_TASK_FAMILY, "my-family"),
+                KeyValue::new(semco::AWS_ECS_TASK_REVISION, "3"),
+                KeyValue::new(semco::AWS_ECS_LAUNCHTYPE, "ec2"),
+                // container attrs
+                KeyValue::new(
+                    semco::AWS_ECS_CONTAINER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CLOUD_RESOURCE_ID,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CONTAINER_ID,
+                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                ),
+                KeyValue::new(semco::CONTAINER_NAME, "my-container"),
+                KeyValue::new(semco::CONTAINER_IMAGE_NAME, "nginx"),
+                KeyValue::new(semco::CONTAINER_IMAGE_TAGS, str_array("1.21")),
+                // ARN-derived attrs
+                KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::AWS_ECS_TASK_ID, "abc123def456"),
+                // IMDS host attrs
+                KeyValue::new(semco::HOST_ARCH, "amd64"),
+                KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1a"),
+                KeyValue::new(semco::HOST_ID, "i-0ec2instance"),
+                KeyValue::new(semco::HOST_TYPE, "m5.large"),
+                KeyValue::new(semco::HOST_IMAGE_ID, "ami-0abcdef"),
+                KeyValue::new(semco::HOST_NAME, "ip-10-0-0-5.ec2.internal"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── EC2 launch type: IMDS fails → no host.* ───────────────────────────────
+
+    #[test]
+    fn detect_from_ec2_launch_type_imds_failure_omits_host_attrs() {
+        let ecs = FakeEcsMetadataClient::new()
+            .with_task(EC2_TASK)
+            .with_container(CONTAINER_NO_LOGS);
+
+        let imds = || -> Result<FakeImdsClient, _> { Err(ImdsError::EmptyAuthToken) };
+
+        let resource = EcsResourceDetector::detect_from(Ok(ecs), imds);
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs"),
+                KeyValue::new(
+                    semco::AWS_ECS_CLUSTER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+                ),
+                KeyValue::new(
+                    semco::AWS_ECS_TASK_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+                ),
+                KeyValue::new(semco::AWS_ECS_TASK_FAMILY, "my-family"),
+                KeyValue::new(semco::AWS_ECS_TASK_REVISION, "3"),
+                KeyValue::new(semco::AWS_ECS_LAUNCHTYPE, "ec2"),
+                KeyValue::new(
+                    semco::AWS_ECS_CONTAINER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CLOUD_RESOURCE_ID,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CONTAINER_ID,
+                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                ),
+                KeyValue::new(semco::CONTAINER_NAME, "my-container"),
+                KeyValue::new(semco::CONTAINER_IMAGE_NAME, "nginx"),
+                KeyValue::new(semco::CONTAINER_IMAGE_TAGS, str_array("1.21")),
+                KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::AWS_ECS_TASK_ID, "abc123def456"),
+                // No HOST_* attributes
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── awslogs driver → log attrs present ────────────────────────────────────
+
+    #[test]
+    fn detect_from_awslogs_driver_produces_log_attrs() {
+        let ecs = FakeEcsMetadataClient::new()
+            .with_task(FARGATE_TASK)
+            .with_container(CONTAINER_WITH_AWSLOGS);
+
+        let imds = || -> Result<FakeImdsClient, _> { panic!("should not be called") };
+
+        let resource = EcsResourceDetector::detect_from(Ok(ecs), imds);
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs"),
+                KeyValue::new(
+                    semco::AWS_ECS_CLUSTER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+                ),
+                KeyValue::new(
+                    semco::AWS_ECS_TASK_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+                ),
+                KeyValue::new(semco::AWS_ECS_TASK_FAMILY, "my-family"),
+                KeyValue::new(semco::AWS_ECS_TASK_REVISION, "3"),
+                KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1b"),
+                KeyValue::new(semco::AWS_ECS_LAUNCHTYPE, "fargate"),
+                KeyValue::new(
+                    semco::AWS_ECS_CONTAINER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CLOUD_RESOURCE_ID,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CONTAINER_ID,
+                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                ),
+                KeyValue::new(semco::CONTAINER_NAME, "my-container"),
+                KeyValue::new(semco::CONTAINER_IMAGE_NAME, "nginx"),
+                KeyValue::new(semco::CONTAINER_IMAGE_TAGS, str_array("1.21")),
+                KeyValue::new(semco::CONTAINER_IMAGE_ID, "sha256:aabbcc"),
+                KeyValue::new(semco::AWS_LOG_GROUP_NAMES, str_array("/ecs/my-group")),
+                KeyValue::new(
+                    semco::AWS_LOG_GROUP_ARNS,
+                    str_array(
+                        "arn:aws:logs:us-east-1:123456789012:log-group:/ecs/my-group:*",
+                    ),
+                ),
+                KeyValue::new(semco::AWS_LOG_STREAM_NAMES, str_array("my-stream")),
+                KeyValue::new(
+                    semco::AWS_LOG_STREAM_ARNS,
+                    str_array(
+                        "arn:aws:logs:us-east-1:123456789012:log-group:/ecs/my-group:log-stream:my-stream",
+                    ),
+                ),
+                KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::AWS_ECS_TASK_ID, "abc123def456"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── non-awslogs driver → log attrs absent ─────────────────────────────────
+
+    #[test]
+    fn detect_from_non_awslogs_driver_omits_log_attrs() {
+        let ecs = FakeEcsMetadataClient::new()
+            .with_task(FARGATE_TASK)
+            .with_container(CONTAINER_NO_LOGS);
+
+        let imds = || -> Result<FakeImdsClient, _> { panic!("should not be called") };
+
+        let resource = EcsResourceDetector::detect_from(Ok(ecs), imds);
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs"),
+                KeyValue::new(
+                    semco::AWS_ECS_CLUSTER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+                ),
+                KeyValue::new(
+                    semco::AWS_ECS_TASK_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456",
+                ),
+                KeyValue::new(semco::AWS_ECS_TASK_FAMILY, "my-family"),
+                KeyValue::new(semco::AWS_ECS_TASK_REVISION, "3"),
+                KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1b"),
+                KeyValue::new(semco::AWS_ECS_LAUNCHTYPE, "fargate"),
+                KeyValue::new(
+                    semco::AWS_ECS_CONTAINER_ARN,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CLOUD_RESOURCE_ID,
+                    "arn:aws:ecs:us-east-1:123456789012:container/abc",
+                ),
+                KeyValue::new(
+                    semco::CONTAINER_ID,
+                    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                ),
+                KeyValue::new(semco::CONTAINER_NAME, "my-container"),
+                KeyValue::new(semco::CONTAINER_IMAGE_NAME, "nginx"),
+                KeyValue::new(semco::CONTAINER_IMAGE_TAGS, str_array("1.21")),
+                KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                KeyValue::new(semco::AWS_ECS_TASK_ID, "abc123def456"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
+
+    // ── Absent task ARN → ARN-derived attrs omitted ───────────────────────────
+
+    #[test]
+    fn detect_from_missing_task_arn_omits_arn_derived_attrs() {
+        let ecs = FakeEcsMetadataClient::new()
+            .with_task(TASK_NO_ARN)
+            .with_container("{}");
+
+        let imds = || -> Result<FakeImdsClient, _> { panic!("should not be called") };
+
+        let resource = EcsResourceDetector::detect_from(Ok(ecs), imds);
+
+        let expected = Resource::builder_empty()
+            .with_attributes([
+                KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs"),
+                // cluster ARN not synthesised: bare name + no task ARN → omitted
+                KeyValue::new(semco::AWS_ECS_TASK_FAMILY, "my-family"),
+                KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1b"),
+                KeyValue::new(semco::AWS_ECS_LAUNCHTYPE, "fargate"),
+            ])
+            .build();
+
+        assert_eq!(resource, expected);
+    }
 
     // ── Arn::parse ────────────────────────────────────────────────────────────
 

--- a/opentelemetry-aws/src/detector/ecs.rs
+++ b/opentelemetry-aws/src/detector/ecs.rs
@@ -28,63 +28,43 @@ const AWSLOGS_DRIVER: &str = "awslogs";
 /// via the `ECS_CONTAINER_METADATA_URI_V4` environment variable and returns an
 /// OTel [`Resource`] with the following attributes:
 ///
-/// | OTel attribute            | Source                                                                      |
-/// |---------------------------|-----------------------------------------------------------------------------|
-/// | `cloud.provider`          | hardcoded `"aws"`                                                           |
-/// | `cloud.platform`          | hardcoded `"aws_ecs"`                                                       |
-/// | `cloud.region`            | task ARN region segment                                                     |
-/// | `cloud.account.id`        | task ARN account-id segment                                                 |
-/// | `cloud.availability_zone` | task metadata `AvailabilityZone` on Fargate; falls back to the identity document `availabilityZone` on the EC2 launch type, via IMDS |
-/// | `cloud.resource_id`       | container metadata `ContainerARN`                                           |
-/// | `aws.ecs.cluster.arn`     | task metadata `Cluster`, expanded to an ARN when it is a bare cluster name  |
-/// | `aws.ecs.task.arn`        | task metadata `TaskARN`                                                     |
-/// | `aws.ecs.task.id`         | last segment of the task ARN resource part                                  |
-/// | `aws.ecs.task.family`     | task metadata `Family`                                                      |
-/// | `aws.ecs.task.revision`   | task metadata `Revision`                                                    |
-/// | `aws.ecs.launchtype`      | task metadata `LaunchType`, lowercased (`ec2` or `fargate`)                 |
-/// | `aws.ecs.container.arn`   | container metadata `ContainerARN`                                           |
-/// | `container.id`            | container metadata `DockerId`                                               |
-/// | `container.name`          | container metadata `Name`                                                   |
-/// | `container.image.name`    | container metadata `Image`, without the tag and digest                      |
-/// | `container.image.tags`    | tag parsed from container metadata `Image`                                  |
-/// | `container.image.repo_digests` | container metadata `Image`, when it pins a digest                      |
-/// | `container.image.id`      | container metadata `ImageID`                                                |
-/// | `aws.log.group.names`     | `LogOptions.awslogs-group`, when `LogDriver` is `awslogs`                   |
-/// | `aws.log.group.arns`      | built from the log group, partition, account and CloudWatch region          |
-/// | `aws.log.stream.names`    | `LogOptions.awslogs-stream`, when `LogDriver` is `awslogs`                  |
-/// | `aws.log.stream.arns`     | built from the log group, log stream, partition, account and region         |
-/// | `host.id`                 | identity document `instanceId` (EC2 launch type only, via IMDS)             |
-/// | `host.type`               | identity document `instanceType` (EC2 launch type only, via IMDS)           |
-/// | `host.image.id`           | identity document `imageId` (EC2 launch type only, via IMDS)                |
-/// | `host.arch`               | identity document `architecture`, mapped to `host.arch` values (EC2 launch type only, via IMDS) |
-/// | `host.name`               | `/latest/meta-data/hostname` (EC2 launch type only, via IMDS)               |
+/// | OTel attribute                 | Source                                                                                           |
+/// |--------------------------------|--------------------------------------------------------------------------------------------------|
+/// | `cloud.provider`               | hardcoded `"aws"`                                                                                |
+/// | `cloud.platform`               | hardcoded `"aws_ecs"`                                                                            |
+/// | `cloud.region`                 | task ARN region segment                                                                          |
+/// | `cloud.account.id`             | task ARN account-id segment                                                                      |
+/// | `cloud.availability_zone`      | task metadata `AvailabilityZone` on Fargate; IMDS identity document `availabilityZone` on the EC2 launch type |
+/// | `cloud.resource_id`            | container metadata `ContainerARN`                                                                |
+/// | `aws.ecs.cluster.arn`          | task metadata `Cluster`, expanded to an ARN when it is a bare cluster name                       |
+/// | `aws.ecs.task.arn`             | task metadata `TaskARN`                                                                          |
+/// | `aws.ecs.task.id`              | last segment of the task ARN resource part                                                       |
+/// | `aws.ecs.task.family`          | task metadata `Family`                                                                           |
+/// | `aws.ecs.task.revision`        | task metadata `Revision`                                                                         |
+/// | `aws.ecs.launchtype`           | task metadata `LaunchType`, lowercased (`ec2` or `fargate`)                                      |
+/// | `aws.ecs.container.arn`        | container metadata `ContainerARN`                                                                |
+/// | `container.id`                 | container metadata `DockerId`                                                                    |
+/// | `container.name`               | container metadata `Name`                                                                        |
+/// | `container.image.name`         | container metadata `Image`, without the tag and digest                                           |
+/// | `container.image.tags`         | tag parsed from container metadata `Image`                                                       |
+/// | `container.image.repo_digests` | container metadata `Image`, when it pins a digest                                                |
+/// | `container.image.id`           | container metadata `ImageID`                                                                     |
+/// | `aws.log.group.names`          | `LogOptions.awslogs-group`, when `LogDriver` is `awslogs`                                        |
+/// | `aws.log.group.arns`           | built from the log group, partition, account and CloudWatch region                               |
+/// | `aws.log.stream.names`         | `LogOptions.awslogs-stream`, when `LogDriver` is `awslogs`                                       |
+/// | `aws.log.stream.arns`          | built from the log group, log stream, partition, account and region                              |
+/// | `host.id`                      | identity document `instanceId` (EC2 launch type only, via IMDS)                                  |
+/// | `host.type`                    | identity document `instanceType` (EC2 launch type only, via IMDS)                                |
+/// | `host.image.id`                | identity document `imageId` (EC2 launch type only, via IMDS)                                     |
+/// | `host.arch`                    | identity document `architecture`, mapped to `host.arch` values (EC2 launch type only, via IMDS)  |
+/// | `host.name`                    | `/latest/meta-data/hostname` (EC2 launch type only, via IMDS)                                    |
 ///
 /// Values that cannot be found are skipped.
 ///
-/// # Feature flag
-///
-/// This type is only available when the `detector-aws-ecs` Cargo feature is
-/// enabled.
-///
-/// # Behavior
-///
-/// Detection is best-effort. Any metadata request that fails (network error,
-/// HTTP error, or JSON parse error) is silently skipped and the corresponding
-/// attribute is omitted from the returned [`Resource`].
+/// # Probing
 ///
 /// If `ECS_CONTAINER_METADATA_URI_V4` is unset the environment is assumed not to
-/// be ECS and an empty [`Resource`] is returned, so that `cloud.provider` and
-/// `cloud.platform` are never asserted off-platform.
-///
-/// The ARN-derived attributes all come from the task ARN. When it is absent or
-/// malformed, `cloud.region`, `cloud.account.id`, `aws.ecs.task.id`, the
-/// `aws.log.*.arns` and a synthesised `aws.ecs.cluster.arn` are all omitted.
-///
-/// On the EC2 launch type, the task metadata endpoint carries neither
-/// `host.*` nor `AvailabilityZone`, so they are read from the EC2 instance's IMDSv2
-/// endpoint instead. IMDS is unreachable on Fargate, so it is only probed
-/// once the EC2 launch type is confirmed from the task metadata, and all of
-/// these attributes are omitted otherwise.
+/// be ECS and an empty [`Resource`] is returned.
 ///
 /// # Blocking
 ///
@@ -135,7 +115,7 @@ impl EcsResourceDetector {
             .as_ref()
             .and_then(|task| task.task_arn.as_deref())
             .and_then(Arn::parse);
-        
+
         // The task metadata endpoint only reports `AvailabilityZone` on the
         // Fargate launch type, so the EC2 launch type is detected here to
         // decide whether IMDS should be probed to fill the gap. Borrowed

--- a/opentelemetry-aws/src/detector/ecs.rs
+++ b/opentelemetry-aws/src/detector/ecs.rs
@@ -34,7 +34,7 @@ const AWSLOGS_DRIVER: &str = "awslogs";
 /// | `cloud.platform`          | hardcoded `"aws_ecs"`                                                       |
 /// | `cloud.region`            | task ARN region segment                                                     |
 /// | `cloud.account.id`        | task ARN account-id segment                                                 |
-/// | `cloud.availability_zone` | task metadata `AvailabilityZone`; falls back to the identity document `availabilityZone` on the EC2 launch type |
+/// | `cloud.availability_zone` | task metadata `AvailabilityZone` on Fargate; falls back to the identity document `availabilityZone` on the EC2 launch type, via IMDS |
 /// | `cloud.resource_id`       | container metadata `ContainerARN`                                           |
 /// | `aws.ecs.cluster.arn`     | task metadata `Cluster`, expanded to an ARN when it is a bare cluster name  |
 /// | `aws.ecs.task.arn`        | task metadata `TaskARN`                                                     |
@@ -81,10 +81,8 @@ const AWSLOGS_DRIVER: &str = "awslogs";
 /// `aws.log.*.arns` and a synthesised `aws.ecs.cluster.arn` are all omitted.
 ///
 /// On the EC2 launch type, the task metadata endpoint carries neither
-/// `host.*` nor `AvailabilityZone`, so `host.id`, `host.type`,
-/// `host.image.id`, `host.arch` and `host.name` are read from the EC2
-/// instance's own IMDSv2 endpoint instead, and `cloud.availability_zone`
-/// falls back to it too. IMDS is unreachable on Fargate, so it is only probed
+/// `host.*` nor `AvailabilityZone`, so they are read from the EC2 instance's IMDSv2
+/// endpoint instead. IMDS is unreachable on Fargate, so it is only probed
 /// once the EC2 launch type is confirmed from the task metadata, and all of
 /// these attributes are omitted otherwise.
 ///

--- a/opentelemetry-aws/src/detector/ecs.rs
+++ b/opentelemetry-aws/src/detector/ecs.rs
@@ -121,14 +121,13 @@ impl EcsResourceDetector {
         imds: impl FnOnce() -> Result<I, ImdsError>,
     ) -> Resource {
         // Platform probe: the metadata URI is injected by the ECS agent, so its
-        // absence is the normal case off-platform and only worth a debug event.
+        // absence is the normal case off-platform.
         let Some(ecs_metadata) = info_on_error(DETECTOR, ecs) else {
             // Not ECS, return empty resource
             return Resource::builder_empty().build();
         };
 
-        // Past this point the environment is known to be ECS, so anything that
-        // still fails is unexpected and reported as a warning.
+        // Past this point the environment is known to be ECS.
         let task = warn_on_error(DETECTOR, ecs_metadata.get_task_metadata());
         // Partition, region and account ID of the task ARN, from which every
         // other ARN is derived. Parsed before `task` is consumed below.
@@ -136,6 +135,7 @@ impl EcsResourceDetector {
             .as_ref()
             .and_then(|task| task.task_arn.as_deref())
             .and_then(Arn::parse);
+        
         // The task metadata endpoint only reports `AvailabilityZone` on the
         // Fargate launch type, so the EC2 launch type is detected here to
         // decide whether IMDS should be probed to fill the gap. Borrowed

--- a/opentelemetry-aws/src/detector/ecs.rs
+++ b/opentelemetry-aws/src/detector/ecs.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use super::{
     imds::{ImdsClient, ImdsError, ImdsProvider},
-    utils::{blocking_client, opt_kv, opt_kv_array, warn_on_error},
+    utils::{blocking_client, info_on_error, opt_kv, opt_kv_array, warn_on_error},
 };
 
 /// Name reported in internal logs emitted by this detector.
@@ -124,7 +124,7 @@ impl EcsResourceDetector {
     ) -> Resource {
         // Platform probe: the metadata URI is injected by the ECS agent, so its
         // absence is the normal case off-platform and only worth a debug event.
-        let Some(ecs_metadata) = warn_on_error(DETECTOR, ecs) else {
+        let Some(ecs_metadata) = info_on_error(DETECTOR, ecs) else {
             // Not ECS, return empty resource
             return Resource::builder_empty().build();
         };

--- a/opentelemetry-aws/src/detector/ecs.rs
+++ b/opentelemetry-aws/src/detector/ecs.rs
@@ -1,0 +1,734 @@
+use std::borrow::Cow;
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::{resource::ResourceDetector, Resource};
+use opentelemetry_semantic_conventions::attribute as semco;
+
+use ureq::{Agent as HttpClient, Error as HttpClientError};
+
+use thiserror::Error;
+
+use super::{
+    imds::ImdsClient,
+    utils::{blocking_client, opt_kv, opt_kv_array, warn_on_error},
+};
+
+/// Name reported in internal logs emitted by this detector.
+const DETECTOR: &str = "aws_ecs";
+/// Environment variable providing the base URI for the ECS metadata service.
+const ECS_CONTAINER_METADATA_URI_ENV_VAR: &str = "ECS_CONTAINER_METADATA_URI_V4";
+/// HTTP request timeout in seconds for ECS metadata calls.
+const ECS_METADATA_TIMEOUT_SECS: u64 = 1;
+/// Log driver name identifying containers that ship to CloudWatch Logs.
+const AWSLOGS_DRIVER: &str = "awslogs";
+
+/// ECS resource detector (`detector-aws-ecs` feature).
+///
+/// Queries the ECS container metadata endpoint (v4) provided by the ECS agent
+/// via the `ECS_CONTAINER_METADATA_URI_V4` environment variable and returns an
+/// OTel [`Resource`] with the following attributes:
+///
+/// | OTel attribute            | Source                                                                      |
+/// |---------------------------|-----------------------------------------------------------------------------|
+/// | `cloud.provider`          | hardcoded `"aws"`                                                           |
+/// | `cloud.platform`          | hardcoded `"aws_ecs"`                                                       |
+/// | `cloud.region`            | task ARN region segment                                                     |
+/// | `cloud.account.id`        | task ARN account-id segment                                                 |
+/// | `cloud.availability_zone` | task metadata `AvailabilityZone`; falls back to the identity document `availabilityZone` on the EC2 launch type |
+/// | `cloud.resource_id`       | container metadata `ContainerARN`                                           |
+/// | `aws.ecs.cluster.arn`     | task metadata `Cluster`, expanded to an ARN when it is a bare cluster name  |
+/// | `aws.ecs.task.arn`        | task metadata `TaskARN`                                                     |
+/// | `aws.ecs.task.id`         | last segment of the task ARN resource part                                  |
+/// | `aws.ecs.task.family`     | task metadata `Family`                                                      |
+/// | `aws.ecs.task.revision`   | task metadata `Revision`                                                    |
+/// | `aws.ecs.launchtype`      | task metadata `LaunchType`, lowercased (`ec2` or `fargate`)                 |
+/// | `aws.ecs.container.arn`   | container metadata `ContainerARN`                                           |
+/// | `container.id`            | container metadata `DockerId`                                               |
+/// | `container.name`          | container metadata `Name`                                                   |
+/// | `container.image.name`    | container metadata `Image`, without the tag and digest                      |
+/// | `container.image.tags`    | tag parsed from container metadata `Image`                                  |
+/// | `container.image.repo_digests` | container metadata `Image`, when it pins a digest                      |
+/// | `container.image.id`      | container metadata `ImageID`                                                |
+/// | `aws.log.group.names`     | `LogOptions.awslogs-group`, when `LogDriver` is `awslogs`                   |
+/// | `aws.log.group.arns`      | built from the log group, partition, account and CloudWatch region          |
+/// | `aws.log.stream.names`    | `LogOptions.awslogs-stream`, when `LogDriver` is `awslogs`                  |
+/// | `aws.log.stream.arns`     | built from the log group, log stream, partition, account and region         |
+/// | `host.id`                 | identity document `instanceId` (EC2 launch type only, via IMDS)             |
+/// | `host.type`               | identity document `instanceType` (EC2 launch type only, via IMDS)           |
+/// | `host.image.id`           | identity document `imageId` (EC2 launch type only, via IMDS)                |
+/// | `host.arch`               | identity document `architecture`, mapped to `host.arch` values (EC2 launch type only, via IMDS) |
+/// | `host.name`               | `/latest/meta-data/hostname` (EC2 launch type only, via IMDS)               |
+///
+/// Values that cannot be found are skipped.
+///
+/// # Feature flag
+///
+/// This type is only available when the `detector-aws-ecs` Cargo feature is
+/// enabled.
+///
+/// # Behavior
+///
+/// Detection is best-effort. Any metadata request that fails (network error,
+/// HTTP error, or JSON parse error) is silently skipped and the corresponding
+/// attribute is omitted from the returned [`Resource`].
+///
+/// If `ECS_CONTAINER_METADATA_URI_V4` is unset the environment is assumed not to
+/// be ECS and an empty [`Resource`] is returned, so that `cloud.provider` and
+/// `cloud.platform` are never asserted off-platform.
+///
+/// The ARN-derived attributes all come from the task ARN. When it is absent or
+/// malformed, `cloud.region`, `cloud.account.id`, `aws.ecs.task.id`, the
+/// `aws.log.*.arns` and a synthesised `aws.ecs.cluster.arn` are all omitted.
+///
+/// On the EC2 launch type, the task metadata endpoint carries neither
+/// `host.*` nor `AvailabilityZone`, so `host.id`, `host.type`,
+/// `host.image.id`, `host.arch` and `host.name` are read from the EC2
+/// instance's own IMDSv2 endpoint instead, and `cloud.availability_zone`
+/// falls back to it too. IMDS is unreachable on Fargate, so it is only probed
+/// once the EC2 launch type is confirmed from the task metadata, and all of
+/// these attributes are omitted otherwise.
+///
+/// # Blocking
+///
+/// Detection performs blocking HTTP requests, each capped by a one second
+/// timeout, and will therefore stall the calling thread.
+///
+/// # Examples
+///
+/// Register the detector with the OpenTelemetry SDK so that ECS attributes are
+/// automatically merged into the global resource:
+///
+/// ```no_run
+/// // Requires a running ECS task with ECS_CONTAINER_METADATA_URI_V4 set.
+/// use opentelemetry_aws::detector::EcsResourceDetector;
+/// use opentelemetry_sdk::Resource;
+///
+/// let resource = Resource::builder()
+///     .with_detector(Box::new(EcsResourceDetector))
+///     .build();
+/// ```
+///
+/// [`Resource`]: opentelemetry_sdk::Resource
+pub struct EcsResourceDetector;
+
+impl ResourceDetector for EcsResourceDetector {
+    fn detect(&self) -> Resource {
+        // Platform probe: the metadata URI is injected by the ECS agent, so its
+        // absence is the normal case off-platform and only worth a debug event.
+        let Some(ecs_metadata) = warn_on_error(DETECTOR, EcsMetadataClient::new()) else {
+            // Not ECS, return empty resource
+            return Resource::builder_empty().build();
+        };
+
+        // Past this point the environment is known to be ECS, so anything that
+        // still fails is unexpected and reported as a warning.
+        let task = warn_on_error(DETECTOR, ecs_metadata.get_task_metadata());
+        // Partition, region and account ID of the task ARN, from which every
+        // other ARN is derived. Parsed before `task` is consumed below.
+        let arn = task
+            .as_ref()
+            .and_then(|task| task.task_arn.as_deref())
+            .and_then(Arn::parse);
+        // The task metadata endpoint only reports `AvailabilityZone` on the
+        // Fargate launch type, so the EC2 launch type is detected here to
+        // decide whether IMDS should be probed to fill the gap. Borrowed
+        // ahead of the closure below, which consumes `task`.
+        let is_ec2_launch_type = task
+            .as_ref()
+            .and_then(|task| task.launch_type.as_deref())
+            .is_some_and(|launch_type| launch_type.eq_ignore_ascii_case("ec2"));
+
+        let task_attributes = task
+            .map(|task| {
+                [
+                    opt_kv(
+                        semco::AWS_ECS_CLUSTER_ARN,
+                        cluster_arn(task.cluster, arn.as_ref()),
+                    ),
+                    opt_kv(semco::AWS_ECS_TASK_ARN, task.task_arn),
+                    opt_kv(semco::AWS_ECS_TASK_FAMILY, task.family),
+                    opt_kv(semco::AWS_ECS_TASK_REVISION, task.revision),
+                    opt_kv(semco::CLOUD_AVAILABILITY_ZONE, task.availability_zone),
+                    // Semantic conventions spell the launch type in lower case
+                    opt_kv(
+                        semco::AWS_ECS_LAUNCHTYPE,
+                        task.launch_type.map(|v| v.to_ascii_lowercase()),
+                    ),
+                ]
+            })
+            .unwrap_or_default();
+
+        let container = warn_on_error(DETECTOR, ecs_metadata.get_container_metadata());
+        let container_attributes = container
+            .map(|container| {
+                let image = ImageReference::parse(container.image);
+                // aws.log.* only applies to the awslogs driver; the other drivers
+                // do not ship to CloudWatch Logs.
+                let uses_awslogs = container.log_driver.as_deref() == Some(AWSLOGS_DRIVER);
+                let logs = container
+                    .log_options
+                    .filter(|_| uses_awslogs)
+                    .unwrap_or_default();
+                // CloudWatch may be targeted in a region other than the task's own.
+                let logs_region = logs
+                    .region
+                    .as_deref()
+                    .or_else(|| arn.as_ref().map(|arn| arn.region.as_str()));
+
+                [
+                    opt_kv(
+                        semco::AWS_ECS_CONTAINER_ARN,
+                        container.container_arn.clone(),
+                    ),
+                    opt_kv(semco::CLOUD_RESOURCE_ID, container.container_arn),
+                    opt_kv(semco::CONTAINER_ID, container.docker_id),
+                    opt_kv(semco::CONTAINER_NAME, container.name),
+                    opt_kv(semco::CONTAINER_IMAGE_NAME, image.name),
+                    opt_kv_array(semco::CONTAINER_IMAGE_TAGS, image.tag),
+                    opt_kv_array(semco::CONTAINER_IMAGE_REPO_DIGESTS, image.repo_digest),
+                    opt_kv(semco::CONTAINER_IMAGE_ID, container.image_id),
+                    opt_kv_array(semco::AWS_LOG_GROUP_NAMES, logs.group.clone()),
+                    opt_kv_array(
+                        semco::AWS_LOG_GROUP_ARNS,
+                        log_group_arn(logs.group.as_deref(), logs_region, arn.as_ref()),
+                    ),
+                    opt_kv_array(semco::AWS_LOG_STREAM_NAMES, logs.stream.clone()),
+                    opt_kv_array(
+                        semco::AWS_LOG_STREAM_ARNS,
+                        log_stream_arn(
+                            logs.group.as_deref(),
+                            logs.stream.as_deref(),
+                            logs_region,
+                            arn.as_ref(),
+                        ),
+                    ),
+                ]
+            })
+            .unwrap_or_default();
+
+        let arn_attributes = arn
+            .map(|arn| {
+                let task_id = arn.task_id();
+                let Arn {
+                    region, account_id, ..
+                } = arn;
+                [
+                    opt_kv(semco::CLOUD_REGION, Some(region)),
+                    opt_kv(semco::CLOUD_ACCOUNT_ID, Some(account_id)),
+                    opt_kv(semco::AWS_ECS_TASK_ID, task_id),
+                ]
+            })
+            .unwrap_or_default();
+
+        // On the EC2 launch type, the ECS task metadata endpoint carries none
+        // of `host.*`, and no `AvailabilityZone` either, but the task runs on
+        // a real EC2 instance whose own metadata service can supply both.
+        // IMDS is unreachable on Fargate, so it is only probed once the EC2
+        // launch type is confirmed, to avoid a guaranteed 1s stall otherwise.
+        let ec2_host_attributes = is_ec2_launch_type
+            .then(|| warn_on_error(DETECTOR, ImdsClient::new()))
+            .flatten()
+            .and_then(|imds| {
+                let document = warn_on_error(DETECTOR, imds.get_identity_document())?;
+                Some((imds, document))
+            })
+            .map(|(imds, document)| {
+                [
+                    document
+                        .host_arch()
+                        .map(|arch| KeyValue::new(semco::HOST_ARCH, arch)),
+                    opt_kv(semco::CLOUD_AVAILABILITY_ZONE, document.availability_zone),
+                    opt_kv(semco::HOST_ID, document.instance_id),
+                    opt_kv(semco::HOST_TYPE, document.instance_type),
+                    opt_kv(semco::HOST_IMAGE_ID, document.image_id),
+                    opt_kv(
+                        semco::HOST_NAME,
+                        warn_on_error(DETECTOR, imds.get("hostname")),
+                    ),
+                ]
+            })
+            .unwrap_or_default();
+
+        let attribute_options = [
+            Some(KeyValue::new(semco::CLOUD_PROVIDER, "aws")),
+            Some(KeyValue::new(semco::CLOUD_PLATFORM, "aws_ecs")),
+        ];
+
+        Resource::builder_empty()
+            .with_attributes(attribute_options.into_iter().flatten())
+            .with_attributes(task_attributes.into_iter().flatten())
+            .with_attributes(container_attributes.into_iter().flatten())
+            .with_attributes(arn_attributes.into_iter().flatten())
+            .with_attributes(ec2_host_attributes.into_iter().flatten())
+            .build()
+    }
+}
+
+/// The partition, region, account ID and resource parts of an
+/// `arn:<partition>:<service>:<region>:<account-id>:<resource>` value.
+///
+/// Fields are accessed by name rather than by positional index so that callers
+/// cannot silently swap the region and account-id segments.
+struct Arn {
+    partition: String,
+    region: String,
+    account_id: String,
+    resource: String,
+}
+
+impl Arn {
+    /// Parses an ARN, returning `None` unless it is well formed and carries a
+    /// partition, a region and an account ID.
+    ///
+    /// The resource part is kept verbatim, including any `:` it contains.
+    fn parse(arn: &str) -> Option<Self> {
+        let mut segments = arn.splitn(6, ':');
+        if segments.next()? != "arn" {
+            return None;
+        }
+        let partition = segments.next()?;
+        let _service = segments.next()?;
+        let region = segments.next()?;
+        let account_id = segments.next()?;
+        let resource = segments.next()?;
+
+        (!partition.is_empty() && !region.is_empty() && !account_id.is_empty()).then(|| Self {
+            partition: partition.to_owned(),
+            region: region.to_owned(),
+            account_id: account_id.to_owned(),
+            resource: resource.to_owned(),
+        })
+    }
+
+    /// Extracts the task ID from the resource part, which is `task/<id>` or
+    /// `task/<cluster-name>/<id>` depending on the ARN format in use.
+    fn task_id(&self) -> Option<String> {
+        self.resource
+            .rsplit('/')
+            .next()
+            .filter(|id| !id.is_empty())
+            .map(str::to_owned)
+    }
+}
+
+/// Resolves `aws.ecs.cluster.arn` from the task metadata `Cluster` field.
+///
+/// The metadata endpoint reports `Cluster` as a full ARN on current agents but
+/// as a bare cluster name on older ones, so a bare name is expanded using the
+/// partition, region and account ID of the task ARN.
+fn cluster_arn(cluster: Option<String>, task_arn: Option<&Arn>) -> Option<String> {
+    let cluster = cluster.filter(|cluster| !cluster.is_empty())?;
+    if cluster.starts_with("arn:") {
+        return Some(cluster);
+    }
+    let task_arn = task_arn?;
+    Some(format!(
+        "arn:{}:ecs:{}:{}:cluster/{cluster}",
+        task_arn.partition, task_arn.region, task_arn.account_id
+    ))
+}
+
+/// Builds the CloudWatch Logs ARN of the log group.
+fn log_group_arn(
+    group: Option<&str>,
+    region: Option<&str>,
+    task_arn: Option<&Arn>,
+) -> Option<String> {
+    let (group, region, task_arn) = (group?, region?, task_arn?);
+    Some(format!(
+        "arn:{}:logs:{region}:{}:log-group:{group}:*",
+        task_arn.partition, task_arn.account_id
+    ))
+}
+
+/// Builds the CloudWatch Logs ARN of the log stream.
+fn log_stream_arn(
+    group: Option<&str>,
+    stream: Option<&str>,
+    region: Option<&str>,
+    task_arn: Option<&Arn>,
+) -> Option<String> {
+    let (group, stream, region, task_arn) = (group?, stream?, region?, task_arn?);
+    Some(format!(
+        "arn:{}:logs:{region}:{}:log-group:{group}:log-stream:{stream}",
+        task_arn.partition, task_arn.account_id
+    ))
+}
+
+/// The name, tag and repository digest of a container image reference.
+#[derive(Default)]
+struct ImageReference {
+    name: Option<String>,
+    tag: Option<String>,
+    /// The whole reference, kept verbatim, when it pins a digest. This is the
+    /// form `container.image.repo_digests` expects.
+    repo_digest: Option<String>,
+}
+
+impl ImageReference {
+    /// Splits an image reference into its name, optional tag and optional
+    /// repository digest.
+    ///
+    /// A task definition may pin an image by tag (`repo:tag`), by digest
+    /// (`repo@sha256:…`), or by both (`repo:tag@sha256:…`), so the digest is
+    /// stripped first — otherwise its own `:` would be mistaken for a tag
+    /// separator. In what remains, a `:` only separates a tag when it appears
+    /// after the last `/`, so that the port of a registry host such as
+    /// `registry:5000/repo` is not mistaken for one either.
+    fn parse(image: Option<String>) -> Self {
+        let Some(image) = image else {
+            return Self::default();
+        };
+        let (remainder, repo_digest) = match image.rsplit_once('@') {
+            Some((remainder, _)) => (remainder.to_owned(), Some(image.clone())),
+            None => (image, None),
+        };
+        let (name, tag) = match remainder.rsplit_once(':') {
+            Some((name, tag)) if !tag.contains('/') => (name.to_owned(), Some(tag.to_owned())),
+            _ => (remainder, None),
+        };
+        Self {
+            name: Some(name),
+            tag,
+            repo_digest,
+        }
+    }
+}
+
+/// Errors that can arise interacting with the ECS Metadata service,
+/// mostly for display purposes.
+#[derive(Debug, Error)]
+enum EcsMetadataError {
+    #[error(
+        "ECS Metadata URI environment variable {ECS_CONTAINER_METADATA_URI_ENV_VAR} not found"
+    )]
+    NoMetadataUriEnvVar,
+    #[error("Could not GET {url}: {error}")]
+    GetRequest {
+        url: String,
+        #[source]
+        error: HttpClientError,
+    },
+    #[error("Could not read JSON response: {0}")]
+    JsonResponseRead(#[source] HttpClientError),
+}
+
+/// HTTP client and ECS metadata base URI read from the environment.
+struct EcsMetadataClient {
+    client: HttpClient,
+    metadata_uri: String,
+}
+
+impl EcsMetadataClient {
+    /// Builds a blocking HTTP client and reads the metadata base URI from `ECS_CONTAINER_METADATA_URI_V4`, erroring if unset.
+    fn new() -> Result<Self, EcsMetadataError> {
+        let client = blocking_client(std::time::Duration::from_secs(ECS_METADATA_TIMEOUT_SECS));
+
+        let metadata_uri = std::env::var(ECS_CONTAINER_METADATA_URI_ENV_VAR)
+            .map_err(|_| EcsMetadataError::NoMetadataUriEnvVar)?;
+
+        Ok(Self {
+            client,
+            metadata_uri,
+        })
+    }
+
+    /// GETs `metadata_uri` optionally joined with `path` and deserializes the JSON body.
+    fn get_json<T: serde::de::DeserializeOwned>(
+        &self,
+        path: Option<&str>,
+    ) -> Result<T, EcsMetadataError> {
+        let url: Cow<str> = match path {
+            Some(p) => Cow::Owned(format!("{}/{p}", self.metadata_uri)),
+            None => Cow::Borrowed(&self.metadata_uri),
+        };
+        self.client
+            .get(url.as_ref())
+            .call()
+            .map_err(|error| EcsMetadataError::GetRequest {
+                url: url.into_owned(),
+                error,
+            })?
+            .body_mut()
+            .read_json()
+            .map_err(EcsMetadataError::JsonResponseRead)
+    }
+
+    /// Fetches the root endpoint (current container metadata).
+    fn get_container_metadata(&self) -> Result<EcsContainerMetadata, EcsMetadataError> {
+        self.get_json(None)
+    }
+    /// Fetches the `/task` endpoint (task metadata).
+    fn get_task_metadata(&self) -> Result<EcsTaskMetadata, EcsMetadataError> {
+        self.get_json(Some("task"))
+    }
+}
+
+/// Deserialization target for the ECS container metadata endpoint (root path).
+#[derive(Default, serde::Deserialize)]
+struct EcsContainerMetadata {
+    #[serde(rename = "ContainerARN")]
+    container_arn: Option<String>,
+    #[serde(rename = "DockerId")]
+    docker_id: Option<String>,
+    #[serde(rename = "Name")]
+    name: Option<String>,
+    #[serde(rename = "Image")]
+    image: Option<String>,
+    #[serde(rename = "ImageID")]
+    image_id: Option<String>,
+    #[serde(rename = "LogDriver")]
+    log_driver: Option<String>,
+    #[serde(rename = "LogOptions")]
+    log_options: Option<EcsLogOptions>,
+}
+
+/// Deserialization target for the `LogOptions` object of the container metadata,
+/// as populated by the `awslogs` driver.
+#[derive(Default, serde::Deserialize)]
+struct EcsLogOptions {
+    #[serde(rename = "awslogs-group")]
+    group: Option<String>,
+    #[serde(rename = "awslogs-stream")]
+    stream: Option<String>,
+    #[serde(rename = "awslogs-region")]
+    region: Option<String>,
+}
+
+/// Deserialization target for the ECS task metadata endpoint (`/task`).
+#[derive(Default, serde::Deserialize)]
+struct EcsTaskMetadata {
+    #[serde(rename = "Cluster")]
+    cluster: Option<String>,
+    #[serde(rename = "TaskARN")]
+    task_arn: Option<String>,
+    #[serde(rename = "Family")]
+    family: Option<String>,
+    #[serde(rename = "Revision")]
+    revision: Option<String>,
+    #[serde(rename = "AvailabilityZone")]
+    availability_zone: Option<String>,
+    #[serde(rename = "LaunchType")]
+    launch_type: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Arn::parse ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn arn_parse_valid_full() {
+        let arn = Arn::parse("arn:aws:ecs:us-east-1:123456789012:task/abc").unwrap();
+        assert_eq!(arn.partition, "aws");
+        assert_eq!(arn.region, "us-east-1");
+        assert_eq!(arn.account_id, "123456789012");
+        assert_eq!(arn.resource, "task/abc");
+    }
+
+    #[test]
+    fn arn_parse_resource_with_colons_preserved() {
+        // splitn(6, ':') keeps everything after the 5th ':' as one chunk.
+        let arn = Arn::parse("arn:aws:logs:us-east-1:123456789123:log-group:my-group:*").unwrap();
+        assert_eq!(arn.resource, "log-group:my-group:*");
+    }
+
+    #[test]
+    fn arn_parse_wrong_prefix() {
+        assert!(Arn::parse("xrn:aws:ecs:us-east-1:123456789123:task/abc").is_none());
+    }
+
+    #[test]
+    fn arn_parse_too_few_segments() {
+        // Only 5 colon-separated segments — resource is missing.
+        assert!(Arn::parse("arn:aws:ecs:us-east-1:123456789123").is_none());
+    }
+
+    #[test]
+    fn arn_parse_empty_required_fields() {
+        // Empty partition
+        assert!(Arn::parse("arn::ecs:us-east-1:123456789123:task/abc").is_none());
+        // Empty region
+        assert!(Arn::parse("arn:aws:ecs::123456789123:task/abc").is_none());
+        // Empty account_id
+        assert!(Arn::parse("arn:aws:ecs:us-east-1::task/abc").is_none());
+    }
+
+    // ── Arn::task_id ─────────────────────────────────────────────────────────
+
+    fn sample_arn(resource: impl Into<String>) -> Arn {
+        Arn {
+            partition: "aws".into(),
+            region: "us-east-1".into(),
+            account_id: "123456789123".into(),
+            resource: resource.into(),
+        }
+    }
+
+    #[test]
+    fn task_id_some() {
+        // Simple "task/<id>" format
+        let arn = sample_arn("task/abcdef");
+        assert_eq!(arn.task_id(), Some("abcdef".to_owned()));
+
+        // Long format "task/<cluster>/<id>" — last segment wins
+        let arn2 = sample_arn("task/cluster-name/abcdef");
+        assert_eq!(arn2.task_id(), Some("abcdef".to_owned()));
+    }
+
+    #[test]
+    fn task_id_none_on_trailing_slash() {
+        let arn = sample_arn("task/");
+        assert!(arn.task_id().is_none());
+    }
+
+    // ── cluster_arn ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn cluster_arn_none_or_empty_cluster() {
+        // None cluster
+        assert!(cluster_arn(None, Some(&sample_arn("task/abcdef"))).is_none());
+        // Empty string cluster
+        assert!(cluster_arn(Some(String::new()), Some(&sample_arn("task/abcdef"))).is_none());
+        // None regardless of task_arn
+        assert!(cluster_arn(None, None).is_none());
+    }
+
+    #[test]
+    fn cluster_arn_passthrough_when_already_arn() {
+        let full = "arn:aws:ecs:us-east-1:123456789123:cluster/my-cluster".to_owned();
+        // Returned as-is even when task_arn is None
+        assert_eq!(cluster_arn(Some(full.clone()), None), Some(full.clone()));
+        assert_eq!(
+            cluster_arn(Some(full.clone()), Some(&sample_arn("cluster/my-cluster"))),
+            Some(full)
+        );
+    }
+
+    #[test]
+    fn cluster_arn_expands_bare_name_with_task_arn() {
+        let result = cluster_arn(
+            Some("my-cluster".into()),
+            Some(&sample_arn("cluster/my-cluster")),
+        );
+        assert_eq!(
+            result,
+            Some("arn:aws:ecs:us-east-1:123456789123:cluster/my-cluster".to_owned())
+        );
+    }
+
+    #[test]
+    fn cluster_arn_bare_name_without_task_arn_is_none() {
+        assert!(cluster_arn(Some("my-cluster".into()), None).is_none());
+    }
+
+    // ── log_group_arn ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn log_group_arn_some() {
+        let arn = sample_arn("task/abcdef");
+        let result = log_group_arn(Some("my-group"), Some("us-west-2"), Some(&arn));
+        assert_eq!(
+            result,
+            Some("arn:aws:logs:us-west-2:123456789123:log-group:my-group:*".to_owned())
+        );
+    }
+
+    #[test]
+    fn log_group_arn_none_when_any_arg_missing() {
+        let arn = sample_arn("task/abcdef");
+        // group missing
+        assert!(log_group_arn(None, Some("us-west-2"), Some(&arn)).is_none());
+        // region missing
+        assert!(log_group_arn(Some("my-group"), None, Some(&arn)).is_none());
+        // task_arn missing
+        assert!(log_group_arn(Some("my-group"), Some("us-west-2"), None).is_none());
+    }
+
+    // ── log_stream_arn ────────────────────────────────────────────────────────
+
+    #[test]
+    fn log_stream_arn_some() {
+        let arn = sample_arn("task/abcdef");
+        let result = log_stream_arn(Some("g"), Some("s"), Some("us-west-2"), Some(&arn));
+        assert_eq!(
+            result,
+            Some("arn:aws:logs:us-west-2:123456789123:log-group:g:log-stream:s".to_owned())
+        );
+    }
+
+    #[test]
+    fn log_stream_arn_none_when_any_arg_missing() {
+        let arn = sample_arn("task/abcdef");
+        // group missing
+        assert!(log_stream_arn(None, Some("s"), Some("us-west-2"), Some(&arn)).is_none());
+        // stream missing
+        assert!(log_stream_arn(Some("g"), None, Some("us-west-2"), Some(&arn)).is_none());
+        // region missing
+        assert!(log_stream_arn(Some("g"), Some("s"), None, Some(&arn)).is_none());
+        // task_arn missing
+        assert!(log_stream_arn(Some("g"), Some("s"), Some("us-west-2"), None).is_none());
+    }
+
+    // ── ImageReference::parse ─────────────────────────────────────────────────
+
+    #[test]
+    fn image_parse_none_input() {
+        let img = ImageReference::parse(None);
+        assert!(img.name.is_none());
+        assert!(img.tag.is_none());
+        assert!(img.repo_digest.is_none());
+    }
+
+    #[test]
+    fn image_parse_plain_repo() {
+        let img = ImageReference::parse(Some("myrepo".into()));
+        assert_eq!(img.name, Some("myrepo".to_owned()));
+        assert!(img.tag.is_none());
+        assert!(img.repo_digest.is_none());
+    }
+
+    #[test]
+    fn image_parse_repo_with_tag() {
+        let img = ImageReference::parse(Some("nginx:1.21".into()));
+        assert_eq!(img.name, Some("nginx".to_owned()));
+        assert_eq!(img.tag, Some("1.21".to_owned()));
+        assert!(img.repo_digest.is_none());
+    }
+
+    #[test]
+    fn image_parse_digest_only() {
+        let img = ImageReference::parse(Some("nginx@sha256:abc123".into()));
+        assert_eq!(img.repo_digest, Some("nginx@sha256:abc123".to_owned()));
+        assert_eq!(img.name, Some("nginx".to_owned()));
+        assert!(img.tag.is_none());
+    }
+
+    #[test]
+    fn image_parse_tag_and_digest() {
+        let img = ImageReference::parse(Some("nginx:1.21@sha256:abc123".into()));
+        assert_eq!(img.repo_digest, Some("nginx:1.21@sha256:abc123".to_owned()));
+        assert_eq!(img.name, Some("nginx".to_owned()));
+        assert_eq!(img.tag, Some("1.21".to_owned()));
+    }
+
+    #[test]
+    fn image_parse_registry_host_with_port_no_tag() {
+        // The ':' before '5000' is followed by a path containing '/', so it
+        // must NOT be treated as a tag separator.
+        let img = ImageReference::parse(Some("registry:5000/repo".into()));
+        assert_eq!(img.name, Some("registry:5000/repo".to_owned()));
+        assert!(img.tag.is_none());
+        assert!(img.repo_digest.is_none());
+    }
+
+    #[test]
+    fn image_parse_registry_host_with_port_and_tag() {
+        // The last ':' separates a tag part "1.0" that contains no '/'.
+        let img = ImageReference::parse(Some("registry:5000/repo:1.0".into()));
+        assert_eq!(img.name, Some("registry:5000/repo".to_owned()));
+        assert_eq!(img.tag, Some("1.0".to_owned()));
+        assert!(img.repo_digest.is_none());
+    }
+}

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use super::{
     imds::{ImdsClient, ImdsError, ImdsProvider},
-    utils::{debug_on_error, non_empty, opt_kv, warn_on_error},
+    utils::{debug_on_error, info_on_error, non_empty, opt_kv, warn_on_error},
 };
 
 /// Name reported in internal logs emitted by this detector.
@@ -155,7 +155,7 @@ impl EksResourceDetector {
         // Kubernetes probe: without the service-account mount, this is not a
         // pod at all. An unreadable file is the normal case off-Kubernetes and
         // so is only worth a debug event.
-        let Some(namespace) = warn_on_error(DETECTOR, get_namespace(namespace_path)) else {
+        let Some(namespace) = info_on_error(DETECTOR, get_namespace(namespace_path)) else {
             // Not Kubernetes, return empty resource
             return Resource::builder_empty().build();
         };

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -786,7 +786,7 @@ mod tests {
                     .collect();
 
                 assert!(
-                    attributes.get(semco::CONTAINER_ID).is_none(),
+                    !attributes.contains_key(semco::CONTAINER_ID),
                     "container.id should be absent when cgroup and mountinfo carry none"
                 );
             },

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -153,8 +153,7 @@ impl EksResourceDetector {
         mountinfo_path: &Path,
     ) -> Resource {
         // Kubernetes probe: without the service-account mount, this is not a
-        // pod at all. An unreadable file is the normal case off-Kubernetes and
-        // so is only worth an info event.
+        // pod at all. An unreadable file is the normal case off-Kubernetes.
         let Some(namespace) = info_on_error(DETECTOR, get_namespace(namespace_path)) else {
             // Not Kubernetes, return empty resource
             return Resource::builder_empty().build();

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -23,6 +23,8 @@ const MIN_CONTAINER_ID_LEN: usize = 32;
 const MAX_CONTAINER_ID_LEN: usize = 64;
 /// IMDSv2 instance tag exposing the EKS cluster name, relative to `/latest/meta-data/`.
 const EKS_CLUSTER_NAME_TAG_PATH: &str = "tags/instance/aws:eks:cluster-name";
+/// The environment variable we expect to contain the cluster name.
+const EKS_CLUSTER_NAME_ENV_VAR: &str = "AWS_CLUSTER_NAME";
 
 /// EKS resource detector (`detector-aws-eks` feature).
 ///
@@ -177,21 +179,22 @@ impl ResourceDetector for EksResourceDetector {
             .as_ref()
             .and_then(|imds| debug_on_error(DETECTOR, imds.get(EKS_CLUSTER_NAME_TAG_PATH)))
             .and_then(non_empty)
-            .or_else(|| std::env::var("AWS_CLUSTER_NAME").ok());
+            .or_else(|| std::env::var(EKS_CLUSTER_NAME_ENV_VAR).ok())
+            .ok_or(EksError::ClusterNameNotFound);
 
         // AWS probe: a service-account mount only proves Kubernetes, which GKE,
         // AKS and self-managed clusters have too. Something has to tie the pod
         // to AWS before `cloud.platform` may claim EKS.
-        if cluster_name.is_none() && region.is_none() {
+        let Some(cluster_name) = warn_on_error(DETECTOR, cluster_name) else {
             // Kubernetes, but nothing says EKS: return empty resource
             return Resource::builder_empty().build();
-        }
+        };
 
         // The cluster ARN needs a partition, which costs an extra IMDS request,
         // so it is only fetched once the rest of the ARN is known.
         // If partition is not retrievable from IMDS, assume "aws".
-        let cluster_arn = match (&cluster_name, &region, &account_id) {
-            (Some(cluster_name), Some(region), Some(account_id)) => {
+        let cluster_arn = match (&region, &account_id) {
+            (Some(region), Some(account_id)) => {
                 let partition = imds
                     .as_ref()
                     .and_then(|imds| warn_on_error(DETECTOR, imds.get("services/partition")))
@@ -216,7 +219,7 @@ impl ResourceDetector for EksResourceDetector {
             opt_kv(semco::K8S_POD_UID, std::env::var("POD_UID").ok()),
             // Node name — requires the downward API to expose spec.nodeName as NODE_NAME
             opt_kv(semco::K8S_NODE_NAME, std::env::var("NODE_NAME").ok()),
-            opt_kv(semco::K8S_CLUSTER_NAME, cluster_name),
+            Some(KeyValue::new(semco::K8S_CLUSTER_NAME, cluster_name)),
             opt_kv(semco::AWS_EKS_CLUSTER_ARN, cluster_arn),
             // Container ID — from cgroup, then from the mount table
             opt_kv(
@@ -253,6 +256,8 @@ enum EksError {
     EmptyNamespace,
     #[error("Could not extract the container id from {CGROUP_FILE_PATH} or {MOUNTINFO_FILE_PATH}")]
     NoContainerId,
+    #[error("Could not find the cluster name, neither in the AWS EC2 tags through IMDS nor from the `{EKS_CLUSTER_NAME_ENV_VAR}` environment variable")]
+    ClusterNameNotFound,
 }
 
 /// Reads and trims the service-account namespace file, erroring if the result is empty.

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -216,12 +216,7 @@ impl EksResourceDetector {
         // If partition is not retrievable from IMDS, assume "aws".
         let cluster_arn = match (&region, &account_id, &cluster_name) {
             (Some(region), Some(account_id), Some(cluster_name)) => {
-                let partition = imds
-                    .as_ref()
-                    .and_then(|imds| warn_on_error(DETECTOR, imds.get("services/partition")))
-                    .and_then(non_empty)
-                    .unwrap_or_else(|| "aws".to_owned());
-
+                let partition = map_region_to_partition(region);
                 Some(format!(
                     "arn:{partition}:eks:{region}:{account_id}:cluster/{cluster_name}"
                 ))
@@ -374,6 +369,27 @@ fn container_id_from_mountinfo_line(line: &str) -> Option<&str> {
 fn is_valid_container_id(candidate: &str) -> bool {
     (MIN_CONTAINER_ID_LEN..=MAX_CONTAINER_ID_LEN).contains(&candidate.len())
         && candidate.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Map the AWS Region string to the corresponding partition.
+///
+/// The authoritative region→partition rules are published by AWS in
+/// `botocore/data/partitions.json`.
+/// See https://github.com/boto/botocore/blob/develop/botocore/data/partitions.json
+fn map_region_to_partition(region: &str) -> &'static str {
+    // Specific prefixes must be tested before the generic single-word prefixes
+    // they share (e.g. "us-iso-" before "us-", "us-gov-" before "us-").
+    match region {
+        r if r.starts_with("eusc-") => "aws-eusc",
+        r if r.starts_with("cn-") => "aws-cn",
+        r if r.starts_with("us-gov-") => "aws-us-gov",
+        r if r.starts_with("us-iso-") => "aws-iso",
+        r if r.starts_with("us-isob-") => "aws-iso-b",
+        r if r.starts_with("us-isof-") => "aws-iso-f",
+        r if r.starts_with("eu-isoe-") => "aws-iso-e",
+        // Avoids the need for maintenance when a "regular" new region pops.
+        _ => "aws",
+    }
 }
 
 #[cfg(test)]
@@ -565,6 +581,87 @@ mod tests {
     }
 
     // ── Not Kubernetes → empty resource ──────────────────────────────────────
+
+    // ---------------------------------------------------------------------------
+    // map_region_to_partition
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn partition_default_aws() {
+        // Standard commercial regions — several geographic prefixes.
+        for region in &[
+            "us-east-1",
+            "us-west-2",
+            "eu-west-1",
+            "eu-central-1",
+            "ap-southeast-2",
+            "ap-northeast-1",
+            "sa-east-1",
+            "ca-central-1",
+            "me-south-1",
+            "af-south-1",
+            "il-central-1",
+            "mx-central-1",
+        ] {
+            assert_eq!(
+                map_region_to_partition(region),
+                "aws",
+                "expected partition 'aws' for region '{region}'"
+            );
+        }
+    }
+
+    #[test]
+    fn partition_aws_cn() {
+        assert_eq!(map_region_to_partition("cn-north-1"), "aws-cn");
+        assert_eq!(map_region_to_partition("cn-northwest-1"), "aws-cn");
+    }
+
+    #[test]
+    fn partition_aws_us_gov() {
+        assert_eq!(map_region_to_partition("us-gov-east-1"), "aws-us-gov");
+        assert_eq!(map_region_to_partition("us-gov-west-1"), "aws-us-gov");
+    }
+
+    #[test]
+    fn partition_aws_eusc() {
+        assert_eq!(map_region_to_partition("eusc-de-east-1"), "aws-eusc");
+    }
+
+    #[test]
+    fn partition_aws_iso() {
+        assert_eq!(map_region_to_partition("us-iso-east-1"), "aws-iso");
+        assert_eq!(map_region_to_partition("us-iso-west-1"), "aws-iso");
+    }
+
+    #[test]
+    fn partition_aws_iso_b() {
+        assert_eq!(map_region_to_partition("us-isob-east-1"), "aws-iso-b");
+        assert_eq!(map_region_to_partition("us-isob-west-1"), "aws-iso-b");
+    }
+
+    #[test]
+    fn partition_aws_iso_e() {
+        assert_eq!(map_region_to_partition("eu-isoe-west-1"), "aws-iso-e");
+    }
+
+    #[test]
+    fn partition_aws_iso_f() {
+        assert_eq!(map_region_to_partition("us-isof-east-1"), "aws-iso-f");
+        assert_eq!(map_region_to_partition("us-isof-south-1"), "aws-iso-f");
+    }
+
+    #[test]
+    fn partition_fallback_for_unknown_and_empty() {
+        // Unknown strings fall back to the default partition.
+        assert_eq!(map_region_to_partition(""), "aws");
+        assert_eq!(map_region_to_partition("garbage"), "aws");
+        assert_eq!(map_region_to_partition("unknown-region-99"), "aws");
+    }
+
+    // ---------------------------------------------------------------------------
+    // detect_from
+    // ---------------------------------------------------------------------------
 
     #[sealed_test]
     fn detect_from_no_namespace_file_returns_empty() {

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::{resource::ResourceDetector, Resource};
 use opentelemetry_semantic_conventions::attribute as semco;
@@ -5,7 +7,7 @@ use opentelemetry_semantic_conventions::attribute as semco;
 use thiserror::Error;
 
 use super::{
-    imds::ImdsClient,
+    imds::{ImdsClient, ImdsError, ImdsProvider},
     utils::{debug_on_error, non_empty, opt_kv, warn_on_error},
 };
 
@@ -134,17 +136,33 @@ pub struct EksResourceDetector;
 
 impl ResourceDetector for EksResourceDetector {
     fn detect(&self) -> Resource {
+        Self::detect_from(
+            ImdsClient::new(),
+            Path::new(K8S_NAMESPACE_FILE_PATH),
+            Path::new(CGROUP_FILE_PATH),
+            Path::new(MOUNTINFO_FILE_PATH),
+        )
+    }
+}
+
+impl EksResourceDetector {
+    fn detect_from<P: ImdsProvider>(
+        imds: Result<P, ImdsError>,
+        namespace_path: &Path,
+        cgroup_path: &Path,
+        mountinfo_path: &Path,
+    ) -> Resource {
         // Kubernetes probe: without the service-account mount, this is not a
         // pod at all. An unreadable file is the normal case off-Kubernetes and
         // so is only worth a debug event.
-        let Some(namespace) = warn_on_error(DETECTOR, get_namespace()) else {
+        let Some(namespace) = warn_on_error(DETECTOR, get_namespace(namespace_path)) else {
             // Not Kubernetes, return empty resource
             return Resource::builder_empty().build();
         };
 
         // The node-level attributes come from IMDS, with environment variables as
         // a fallback for the EKS-on-Fargate case where IMDS is unreachable.
-        let imds = debug_on_error(DETECTOR, ImdsClient::new());
+        let imds = debug_on_error(DETECTOR, imds);
 
         let document = imds
             .as_ref()
@@ -224,7 +242,7 @@ impl ResourceDetector for EksResourceDetector {
             // Container ID — from cgroup, then from the mount table
             opt_kv(
                 semco::CONTAINER_ID,
-                warn_on_error(DETECTOR, get_container_id()),
+                warn_on_error(DETECTOR, get_container_id(cgroup_path, mountinfo_path)),
             ),
             opt_kv(
                 semco::HOST_NAME,
@@ -261,10 +279,10 @@ enum EksError {
 }
 
 /// Reads and trims the service-account namespace file, erroring if the result is empty.
-fn get_namespace() -> Result<String, EksError> {
-    let namespace = std::fs::read_to_string(K8S_NAMESPACE_FILE_PATH)
+fn get_namespace(path: &Path) -> Result<String, EksError> {
+    let namespace = std::fs::read_to_string(path)
         .map_err(|error| EksError::FsError {
-            path: K8S_NAMESPACE_FILE_PATH.to_owned(),
+            path: path.to_string_lossy().into_owned(),
             error,
         })?
         .trim()
@@ -281,13 +299,13 @@ fn get_namespace() -> Result<String, EksError> {
 ///
 /// The files, extraction rules and accepted ID shape mirror `ContainerResourceDetector`
 /// in `opentelemetry-resource-detectors` to ensure both detectors agree on `container.id`.
-fn get_container_id() -> Result<String, EksError> {
-    if let Ok(content) = std::fs::read_to_string(CGROUP_FILE_PATH) {
+fn get_container_id(cgroup_path: &Path, mountinfo_path: &Path) -> Result<String, EksError> {
+    if let Ok(content) = std::fs::read_to_string(cgroup_path) {
         if let Some(id) = content.lines().find_map(container_id_from_cgroup_line) {
             return Ok(id.to_owned());
         }
     }
-    if let Ok(content) = std::fs::read_to_string(MOUNTINFO_FILE_PATH) {
+    if let Ok(content) = std::fs::read_to_string(mountinfo_path) {
         if let Some(id) = content.lines().find_map(container_id_from_mountinfo_line) {
             return Ok(id.to_owned());
         }
@@ -358,11 +376,29 @@ fn is_valid_container_id(candidate: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::detector::imds::{tests::FakeImdsClient, ImdsError};
+    use sealed_test::prelude::*;
+    use std::io::Write;
 
     // A 64-char all-lowercase hex string used as the canonical container ID in tests.
     const ID64: &str = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
     // A 32-char all-lowercase hex string.
     const ID32: &str = "aabbccddeeff00112233445566778899";
+
+    // ── IMDS JSON fixture ─────────────────────────────────────────────────────
+
+    /// Relevant instance identity document for an EKS node.
+    const FULL_IMDS_DOC: &str = r#"
+        {
+            "accountId":        "123456789012",
+            "region":           "us-east-1",
+            "availabilityZone": "us-east-1c",
+            "instanceId":       "i-0node",
+            "instanceType":     "m5.large",
+            "imageId":          "ami-0nodeimage",
+            "architecture":     "x86_64"
+        }
+    "#;
 
     // ---------------------------------------------------------------------------
     // is_valid_container_id
@@ -519,5 +555,241 @@ mod tests {
         let root = "/docker/containers/not-a-valid-hex-id/hostname";
         let line = mountinfo_line(root, "/etc/hostname");
         assert_eq!(container_id_from_mountinfo_line(&line), None);
+    }
+
+    // ── detect_from helpers ───────────────────────────────────────────────────
+
+    /// Creates a temp file with the given content and returns its path.
+    fn temp_file(content: &str) -> (tempfile::NamedTempFile, std::path::PathBuf) {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        write!(f, "{content}").unwrap();
+        let path = f.path().to_path_buf();
+        (f, path)
+    }
+
+    // ── Not Kubernetes → empty resource ──────────────────────────────────────
+
+    #[sealed_test]
+    fn detect_from_no_namespace_file_returns_empty() {
+        let resource = EksResourceDetector::detect_from(
+            Ok(FakeImdsClient::new()),
+            Path::new("/nonexistent/path/to/namespace"),
+            Path::new("/nonexistent/cgroup"),
+            Path::new("/nonexistent/mountinfo"),
+        );
+        assert_eq!(resource, Resource::builder_empty().build());
+    }
+
+    // ── Kubernetes but no AWS tie → empty resource ────────────────────────────
+
+    #[sealed_test]
+    fn detect_from_no_aws_tie_returns_empty() {
+        let (_ns_file, ns_path) = temp_file("default");
+        let (_cgroup_file, cgroup_path) = temp_file("0::/\n");
+        let (_mi_file, mi_path) = temp_file("");
+
+        // IMDS fails, no AWS_CLUSTER_NAME → second probe fails
+        temp_env::with_vars(
+            [
+                ("AWS_CLUSTER_NAME", None::<&str>),
+                ("AWS_REGION", None::<&str>),
+                ("AWS_ACCOUNT_ID", None::<&str>),
+            ],
+            || {
+                let resource = EksResourceDetector::detect_from(
+                    Err::<FakeImdsClient, _>(ImdsError::EmptyAuthToken),
+                    &ns_path,
+                    &cgroup_path,
+                    &mi_path,
+                );
+                assert_eq!(resource, Resource::builder_empty().build());
+            },
+        );
+    }
+
+    // ── Happy path with IMDS: full attrs ─────────────────────────────────────
+
+    #[sealed_test]
+    fn detect_from_happy_path_with_imds() {
+        let (_ns_file, ns_path) = temp_file("kube-system");
+        // cgroup with a valid container ID
+        let (_cgroup_file, cgroup_path) =
+            temp_file(&format!("11:memory:/kubepods/besteffort/podabc/{ID64}\n"));
+        let (_mi_file, mi_path) = temp_file("");
+
+        let fake = FakeImdsClient::new()
+            .with_document(FULL_IMDS_DOC)
+            .with_get(EKS_CLUSTER_NAME_TAG_PATH, "my-eks-cluster")
+            .with_get("services/partition", "aws")
+            .with_get("hostname", "ip-10-0-1-5.ec2.internal");
+
+        temp_env::with_vars(
+            [
+                ("HOSTNAME", Some("my-pod-xyz")),
+                ("POD_UID", Some("pod-uid-123")),
+                ("NODE_NAME", Some("ip-10-0-1-5")),
+                ("AWS_CLUSTER_NAME", None::<&str>),
+                ("AWS_REGION", None::<&str>),
+                ("AWS_ACCOUNT_ID", None::<&str>),
+            ],
+            || {
+                let resource =
+                    EksResourceDetector::detect_from(Ok(fake), &ns_path, &cgroup_path, &mi_path);
+
+                let expected = Resource::builder_empty()
+                    .with_attributes([
+                        KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                        KeyValue::new(semco::CLOUD_PLATFORM, "aws_eks"),
+                        KeyValue::new(semco::HOST_ARCH, "amd64"),
+                        KeyValue::new(semco::CLOUD_AVAILABILITY_ZONE, "us-east-1c"),
+                        KeyValue::new(semco::HOST_ID, "i-0node"),
+                        KeyValue::new(semco::HOST_TYPE, "m5.large"),
+                        KeyValue::new(semco::HOST_IMAGE_ID, "ami-0nodeimage"),
+                        KeyValue::new(semco::K8S_NAMESPACE_NAME, "kube-system"),
+                        KeyValue::new(semco::K8S_POD_NAME, "my-pod-xyz"),
+                        KeyValue::new(semco::K8S_POD_UID, "pod-uid-123"),
+                        KeyValue::new(semco::K8S_NODE_NAME, "ip-10-0-1-5"),
+                        KeyValue::new(semco::K8S_CLUSTER_NAME, "my-eks-cluster"),
+                        KeyValue::new(
+                            semco::AWS_EKS_CLUSTER_ARN,
+                            "arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster",
+                        ),
+                        KeyValue::new(semco::CONTAINER_ID, ID64),
+                        KeyValue::new(semco::HOST_NAME, "ip-10-0-1-5.ec2.internal"),
+                        KeyValue::new(semco::CLOUD_REGION, "us-east-1"),
+                        KeyValue::new(semco::CLOUD_ACCOUNT_ID, "123456789012"),
+                    ])
+                    .build();
+
+                assert_eq!(resource, expected);
+            },
+        );
+    }
+
+    // ── Fargate fallback: IMDS fails, env vars supply region/account/cluster ──
+
+    #[sealed_test]
+    fn detect_from_fargate_fallback_via_env_vars() {
+        let (_ns_file, ns_path) = temp_file("default");
+        let (_cgroup_file, cgroup_path) = temp_file("0::/\n");
+        let (_mi_file, mi_path) = temp_file("");
+
+        temp_env::with_vars(
+            [
+                ("AWS_CLUSTER_NAME", Some("fargate-cluster")),
+                ("AWS_REGION", Some("eu-west-1")),
+                ("AWS_ACCOUNT_ID", Some("999888777666")),
+                ("HOSTNAME", Some("fargate-pod-abc")),
+                ("POD_UID", None::<&str>),
+                ("NODE_NAME", None::<&str>),
+            ],
+            || {
+                let resource = EksResourceDetector::detect_from(
+                    Err::<FakeImdsClient, _>(ImdsError::EmptyAuthToken),
+                    &ns_path,
+                    &cgroup_path,
+                    &mi_path,
+                );
+
+                // Partition falls back to "aws" when IMDS unavailable
+                let expected = Resource::builder_empty()
+                    .with_attributes([
+                        KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                        KeyValue::new(semco::CLOUD_PLATFORM, "aws_eks"),
+                        KeyValue::new(semco::K8S_NAMESPACE_NAME, "default"),
+                        KeyValue::new(semco::K8S_POD_NAME, "fargate-pod-abc"),
+                        KeyValue::new(semco::K8S_CLUSTER_NAME, "fargate-cluster"),
+                        KeyValue::new(
+                            semco::AWS_EKS_CLUSTER_ARN,
+                            "arn:aws:eks:eu-west-1:999888777666:cluster/fargate-cluster",
+                        ),
+                        KeyValue::new(semco::CLOUD_REGION, "eu-west-1"),
+                        KeyValue::new(semco::CLOUD_ACCOUNT_ID, "999888777666"),
+                    ])
+                    .build();
+
+                assert_eq!(resource, expected);
+            },
+        );
+    }
+
+    // ── container.id: cgroup file first, then mountinfo ───────────────────────
+
+    #[sealed_test]
+    fn detect_from_container_id_from_mountinfo_when_cgroup_empty() {
+        let (_ns_file, ns_path) = temp_file("default");
+        // cgroup v2: only "0::/" — no container ID
+        let (_cgroup_file, cgroup_path) = temp_file("0::/\n");
+        // mountinfo with a valid container ID in /etc/hostname mount
+        let root = format!("/docker/containers/{ID64}/hostname");
+        let mountinfo_line_str = format!("36 35 0:33 {root} /etc/hostname rw - ext4 /dev/sda1 rw");
+        let (_mi_file, mi_path) = temp_file(&mountinfo_line_str);
+
+        let fake = FakeImdsClient::new()
+            .with_document(FULL_IMDS_DOC)
+            .with_get(EKS_CLUSTER_NAME_TAG_PATH, "my-cluster")
+            .with_get("services/partition", "aws");
+
+        temp_env::with_vars(
+            [
+                ("HOSTNAME", None::<&str>),
+                ("POD_UID", None::<&str>),
+                ("NODE_NAME", None::<&str>),
+                ("AWS_CLUSTER_NAME", None::<&str>),
+                ("AWS_REGION", None::<&str>),
+                ("AWS_ACCOUNT_ID", None::<&str>),
+            ],
+            || {
+                let resource =
+                    EksResourceDetector::detect_from(Ok(fake), &ns_path, &cgroup_path, &mi_path);
+
+                let attributes: std::collections::HashMap<_, _> = resource
+                    .iter()
+                    .map(|(k, v)| (k.as_str().to_owned(), v.clone()))
+                    .collect();
+
+                assert_eq!(
+                    attributes.get(semco::CONTAINER_ID).map(|v| v.as_str()),
+                    Some(ID64.into())
+                );
+            },
+        );
+    }
+
+    #[sealed_test]
+    fn detect_from_container_id_absent_when_no_cgroup_or_mountinfo() {
+        let (_ns_file, ns_path) = temp_file("default");
+        let (_cgroup_file, cgroup_path) = temp_file("0::/\n");
+        let (_mi_file, mi_path) = temp_file(""); // no container ID
+
+        let fake = FakeImdsClient::new()
+            .with_document(FULL_IMDS_DOC)
+            .with_get(EKS_CLUSTER_NAME_TAG_PATH, "my-cluster")
+            .with_get("services/partition", "aws");
+
+        temp_env::with_vars(
+            [
+                ("HOSTNAME", None::<&str>),
+                ("POD_UID", None::<&str>),
+                ("NODE_NAME", None::<&str>),
+                ("AWS_CLUSTER_NAME", None::<&str>),
+                ("AWS_REGION", None::<&str>),
+                ("AWS_ACCOUNT_ID", None::<&str>),
+            ],
+            || {
+                let resource =
+                    EksResourceDetector::detect_from(Ok(fake), &ns_path, &cgroup_path, &mi_path);
+
+                let attributes: std::collections::HashMap<_, _> = resource
+                    .iter()
+                    .map(|(k, v)| (k.as_str().to_owned(), v.clone()))
+                    .collect();
+
+                assert!(
+                    attributes.get(semco::CONTAINER_ID).is_none(),
+                    "container.id should be absent when cgroup and mountinfo carry none"
+                );
+            },
+        );
     }
 }

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -1,0 +1,518 @@
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::{resource::ResourceDetector, Resource};
+use opentelemetry_semantic_conventions::attribute as semco;
+
+use thiserror::Error;
+
+use super::{
+    imds::ImdsClient,
+    utils::{debug_on_error, non_empty, opt_kv, warn_on_error},
+};
+
+/// Name reported in internal logs emitted by this detector.
+const DETECTOR: &str = "aws_eks";
+/// Filesystem path to the Kubernetes service-account namespace file.
+const K8S_NAMESPACE_FILE_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+/// Filesystem path of the cgroup membership file used to derive `container.id`.
+const CGROUP_FILE_PATH: &str = "/proc/self/cgroup";
+/// Filesystem path of the mount table, used as a fallback for `container.id`.
+const MOUNTINFO_FILE_PATH: &str = "/proc/self/mountinfo";
+/// Minimum length, in hexadecimal characters, of a container ID.
+const MIN_CONTAINER_ID_LEN: usize = 32;
+/// Maximum length, in hexadecimal characters, of a container ID.
+const MAX_CONTAINER_ID_LEN: usize = 64;
+/// IMDSv2 instance tag exposing the EKS cluster name, relative to `/latest/meta-data/`.
+const EKS_CLUSTER_NAME_TAG_PATH: &str = "tags/instance/aws:eks:cluster-name";
+
+/// EKS resource detector (`detector-aws-eks` feature).
+///
+/// Detects an EKS environment by reading the Kubernetes service-account
+/// namespace file (`/var/run/secrets/kubernetes.io/serviceaccount/namespace`),
+/// querying the EC2 Instance Metadata Service v2 (IMDSv2) at the link-local
+/// address `169.254.169.254`, and reading environment variables. It returns an
+/// OTel [`Resource`] with the following attributes:
+///
+/// | OTel attribute            | Source                                                                                        |
+/// |---------------------------|-----------------------------------------------------------------------------------------------|
+/// | `cloud.provider`          | hardcoded `"aws"`                                                                             |
+/// | `cloud.platform`          | hardcoded `"aws_eks"`                                                                         |
+/// | `k8s.namespace.name`      | service-account namespace file                                                                |
+/// | `k8s.pod.name`            | `HOSTNAME` environment variable                                                               |
+/// | `k8s.pod.uid`             | `POD_UID` environment variable (requires the downward API, see note below)                    |
+/// | `k8s.node.name`           | `NODE_NAME` environment variable (requires the downward API, see note below)                  |
+/// | `k8s.cluster.name`        | IMDSv2 instance tag `aws:eks:cluster-name`; falls back to `AWS_CLUSTER_NAME` (see note below) |
+/// | `aws.eks.cluster.arn`     | built from the partition, region, account ID and cluster name                                 |
+/// | `container.id`            | container ID parsed from `/proc/self/cgroup`, then from `/proc/self/mountinfo`                |
+/// | `cloud.region`            | instance identity document `region`; falls back to `AWS_REGION`                               |
+/// | `cloud.account.id`        | instance identity document `accountId`; falls back to `AWS_ACCOUNT_ID`                        |
+/// | `cloud.availability_zone` | instance identity document `availabilityZone`                                                 |
+/// | `host.id`                 | instance identity document `instanceId` (the node's EC2 instance)                             |
+/// | `host.type`               | instance identity document `instanceType` (the node's EC2 instance)                           |
+/// | `host.image.id`           | instance identity document `imageId` (the node's EC2 instance)                                |
+/// | `host.arch`               | instance identity document `architecture`, mapped to `host.arch` values                       |
+/// | `host.name`               | `/latest/meta-data/hostname` (the node's EC2 instance)                                        |
+///
+/// Values that cannot be found are skipped.
+///
+/// # Feature flag
+///
+/// This type is only available when the `detector-aws-eks` Cargo feature is
+/// enabled.
+///
+/// # Behavior
+///
+/// Detection is best-effort. Any operation that fails (file read error, IMDSv2
+/// network error, missing environment variable) is silently skipped and the
+/// corresponding attribute is omitted from the returned [`Resource`].
+///
+/// Detection is gated on two probes, both of which must pass before
+/// `cloud.provider` and `cloud.platform` are asserted:
+///
+/// 1. the service-account namespace file must be readable, which proves the
+///    process runs in a Kubernetes pod;
+/// 2. something must tie that pod to AWS — either a parsable instance identity
+///    document from IMDSv2, or one of the `AWS_CLUSTER_NAME` and `AWS_REGION`
+///    environment variables.
+///
+/// # `k8s.cluster.name` may require configuration
+///
+/// The cluster name is read from the node's `aws:eks:cluster-name` EC2 instance
+/// tag, which is only visible through IMDSv2 when instance tags in metadata are
+/// enabled on the node group (`InstanceMetadataTags: enabled`). EKS does not
+/// inject `AWS_CLUSTER_NAME` into pod environments, so when the tag is not
+/// exposed — including on EKS-on-Fargate, where IMDS is unreachable — you must
+/// set `AWS_CLUSTER_NAME` yourself, for instance via a `Deployment` manifest.
+/// Setting `OTEL_RESOURCE_ATTRIBUTES=k8s.cluster.name=…` is a portable
+/// alternative that does not depend on this detector.
+///
+/// `aws.eks.cluster.arn` is built from the cluster name, so it inherits the
+/// same requirement, and additionally needs the region, the account ID and the
+/// partition. The partition is only available from IMDSv2, so the ARN is never
+/// reported when IMDS is unreachable, even if the cluster name is configured.
+///
+/// # `k8s.pod.uid` and `k8s.node.name` require the downward API
+///
+/// Kubernetes does not expose these to containers by default. Add them to the
+/// pod spec to have them detected:
+///
+/// ```yaml
+/// env:
+///   - name: POD_UID
+///     valueFrom:
+///       fieldRef:
+///         fieldPath: metadata.uid
+///   - name: NODE_NAME
+///     valueFrom:
+///       fieldRef:
+///         fieldPath: spec.nodeName
+/// ```
+///
+/// # Blocking
+///
+/// Detection performs blocking HTTP requests, each capped by a one second
+/// timeout, and will therefore stall the calling thread.
+///
+/// # Examples
+///
+/// Register the detector with the OpenTelemetry SDK so that EKS attributes are
+/// automatically merged into the global resource:
+///
+/// ```no_run
+/// // Requires a running EKS pod with the service-account token mount present.
+/// use opentelemetry_aws::detector::EksResourceDetector;
+/// use opentelemetry_sdk::Resource;
+///
+/// let resource = Resource::builder()
+///     .with_detector(Box::new(EksResourceDetector))
+///     .build();
+/// ```
+///
+/// [`Resource`]: opentelemetry_sdk::Resource
+pub struct EksResourceDetector;
+
+impl ResourceDetector for EksResourceDetector {
+    fn detect(&self) -> Resource {
+        // Kubernetes probe: without the service-account mount, this is not a
+        // pod at all. An unreadable file is the normal case off-Kubernetes and
+        // so is only worth a debug event.
+        let Some(namespace) = warn_on_error(DETECTOR, get_namespace()) else {
+            // Not Kubernetes, return empty resource
+            return Resource::builder_empty().build();
+        };
+
+        // The node-level attributes come from IMDS, with environment variables as
+        // a fallback for the EKS-on-Fargate case where IMDS is unreachable.
+        let imds = debug_on_error(DETECTOR, ImdsClient::new());
+
+        let document = imds
+            .as_ref()
+            .and_then(|imds| warn_on_error(DETECTOR, imds.get_identity_document()));
+        let (region, account_id, ec2_document_attributes) = document
+            .map(|document| {
+                let host_arch = document
+                    .host_arch()
+                    .map(|arch| KeyValue::new(semco::HOST_ARCH, arch));
+                (
+                    document.region,
+                    document.account_id,
+                    [
+                        host_arch,
+                        opt_kv(semco::CLOUD_AVAILABILITY_ZONE, document.availability_zone),
+                        opt_kv(semco::HOST_ID, document.instance_id),
+                        opt_kv(semco::HOST_TYPE, document.instance_type),
+                        opt_kv(semco::HOST_IMAGE_ID, document.image_id),
+                    ],
+                )
+            })
+            .unwrap_or_default();
+
+        // Region and account ID — identity document first, then env var
+        let region = region.or_else(|| std::env::var("AWS_REGION").ok());
+        let account_id = account_id.or_else(|| std::env::var("AWS_ACCOUNT_ID").ok());
+
+        // Cluster name — from the node's EKS instance tag if exposed through IMDS, then from an env var.
+        // The tag is absent unless instance tags in metadata are enabled, which
+        // is not the default, so its absence is not worth a warning.
+        let cluster_name = imds
+            .as_ref()
+            .and_then(|imds| debug_on_error(DETECTOR, imds.get(EKS_CLUSTER_NAME_TAG_PATH)))
+            .and_then(non_empty)
+            .or_else(|| std::env::var("AWS_CLUSTER_NAME").ok());
+
+        // AWS probe: a service-account mount only proves Kubernetes, which GKE,
+        // AKS and self-managed clusters have too. Something has to tie the pod
+        // to AWS before `cloud.platform` may claim EKS.
+        if cluster_name.is_none() && region.is_none() {
+            // Kubernetes, but nothing says EKS: return empty resource
+            return Resource::builder_empty().build();
+        }
+
+        // The cluster ARN needs a partition, which costs an extra IMDS request,
+        // so it is only fetched once the rest of the ARN is known.
+        // If partition is not retrievable from IMDS, assume "aws".
+        let cluster_arn = match (&cluster_name, &region, &account_id) {
+            (Some(cluster_name), Some(region), Some(account_id)) => {
+                let partition = imds
+                    .as_ref()
+                    .and_then(|imds| warn_on_error(DETECTOR, imds.get("services/partition")))
+                    .and_then(non_empty)
+                    .unwrap_or_else(|| "aws".to_owned());
+
+                Some(format!(
+                    "arn:{partition}:eks:{region}:{account_id}:cluster/{cluster_name}"
+                ))
+            }
+            _ => None,
+        };
+
+        let attribute_options = [
+            Some(KeyValue::new(semco::CLOUD_PROVIDER, "aws")),
+            Some(KeyValue::new(semco::CLOUD_PLATFORM, "aws_eks")),
+            // Namespace — from the Kubernetes service-account token mount
+            Some(KeyValue::new(semco::K8S_NAMESPACE_NAME, namespace)),
+            // Pod name — HOSTNAME is set to the pod name in standard k8s pods
+            opt_kv(semco::K8S_POD_NAME, std::env::var("HOSTNAME").ok()),
+            // Pod UID — requires the downward API to expose metadata.uid as POD_UID
+            opt_kv(semco::K8S_POD_UID, std::env::var("POD_UID").ok()),
+            // Node name — requires the downward API to expose spec.nodeName as NODE_NAME
+            opt_kv(semco::K8S_NODE_NAME, std::env::var("NODE_NAME").ok()),
+            opt_kv(semco::K8S_CLUSTER_NAME, cluster_name),
+            opt_kv(semco::AWS_EKS_CLUSTER_ARN, cluster_arn),
+            // Container ID — from cgroup, then from the mount table
+            opt_kv(
+                semco::CONTAINER_ID,
+                warn_on_error(DETECTOR, get_container_id()),
+            ),
+            opt_kv(
+                semco::HOST_NAME,
+                imds.as_ref()
+                    .and_then(|imds| warn_on_error(DETECTOR, imds.get("hostname"))),
+            ),
+            opt_kv(semco::CLOUD_REGION, region),
+            opt_kv(semco::CLOUD_ACCOUNT_ID, account_id),
+        ];
+
+        Resource::builder_empty()
+            .with_attributes(ec2_document_attributes.into_iter().flatten())
+            .with_attributes(attribute_options.into_iter().flatten())
+            .build()
+    }
+}
+
+/// Errors that can arise during EKS detection: filesystem reads, an empty
+/// namespace file, or no container ID anywhere in the cgroup or mount files.
+#[derive(Debug, Error)]
+enum EksError {
+    #[error("Cannot read file {path}: {error}")]
+    FsError {
+        path: String,
+        #[source]
+        error: std::io::Error,
+    },
+    #[error("Empty file at {K8S_NAMESPACE_FILE_PATH}")]
+    EmptyNamespace,
+    #[error("Could not extract the container id from {CGROUP_FILE_PATH} or {MOUNTINFO_FILE_PATH}")]
+    NoContainerId,
+}
+
+/// Reads and trims the service-account namespace file, erroring if the result is empty.
+fn get_namespace() -> Result<String, EksError> {
+    let namespace = std::fs::read_to_string(K8S_NAMESPACE_FILE_PATH)
+        .map_err(|error| EksError::FsError {
+            path: K8S_NAMESPACE_FILE_PATH.to_owned(),
+            error,
+        })?
+        .trim()
+        .to_owned();
+    if namespace.is_empty() {
+        Err(EksError::EmptyNamespace)
+    } else {
+        Ok(namespace)
+    }
+}
+
+/// Reads the container ID from the cgroup file, falling back to the mount table
+/// when the cgroup file carries none (cgroup v2 namespace, where the pod only sees `0::/`).
+///
+/// The files, extraction rules and accepted ID shape mirror `ContainerResourceDetector`
+/// in `opentelemetry-resource-detectors` to ensure both detectors agree on `container.id`.
+fn get_container_id() -> Result<String, EksError> {
+    if let Ok(content) = std::fs::read_to_string(CGROUP_FILE_PATH) {
+        if let Some(id) = content.lines().find_map(container_id_from_cgroup_line) {
+            return Ok(id.to_owned());
+        }
+    }
+    if let Ok(content) = std::fs::read_to_string(MOUNTINFO_FILE_PATH) {
+        if let Some(id) = content.lines().find_map(container_id_from_mountinfo_line) {
+            return Ok(id.to_owned());
+        }
+    }
+    Err(EksError::NoContainerId)
+}
+
+/// Extracts a container ID from a single cgroup line, or `None` if the line carries none.
+///
+/// Handles the known path layouts:
+/// - `.../docker/<id>` — plain Docker, cgroup v1
+/// - `.../kubepods/besteffort/pod<uid>/<id>` — Kubernetes, cgroupfs driver
+/// - `.../docker-<id>.scope` — Docker, systemd driver
+/// - `.../cri-containerd-<id>.scope` — containerd, systemd driver
+/// - `.../crio-<id>.scope` — CRI-O, systemd driver
+///
+/// The runtime prefix is stripped at the last `:` or `-`, the suffix at the first `.`,
+/// and the result is accepted only if it passes [`is_valid_container_id`].
+fn container_id_from_cgroup_line(line: &str) -> Option<&str> {
+    let last_segment = line[line.rfind('/')? + 1..].trim();
+
+    let candidate = match last_segment.rfind([':', '-']) {
+        Some(index) => &last_segment[index + 1..],
+        None => last_segment,
+    };
+
+    let candidate = candidate
+        .split_once('.')
+        .map_or(candidate, |(before, _)| before);
+
+    is_valid_container_id(candidate).then_some(candidate)
+}
+
+/// Extracts a container ID from a single mount table line, or `None` if the line
+/// carries no container ID.
+///
+/// The ID is the segment following `containers` or `overlay-containers` in the
+/// root of the `/etc/hostname` mount, which every container runtime bind-mounts
+/// from its own per-container directory.
+fn container_id_from_mountinfo_line(line: &str) -> Option<&str> {
+    // Root and mount point precede the " - " separator and are indexed 3 and 4 when split by whitespace.
+    let mut fields = line.split_once(" - ")?.0.split_whitespace();
+    let root = fields.nth(3)?;
+    let mount_point = fields.next()?;
+    if mount_point != "/etc/hostname" {
+        return None;
+    }
+
+    let mut previous = "";
+    for segment in root.split('/') {
+        if matches!(previous, "containers" | "overlay-containers") && is_valid_container_id(segment)
+        {
+            return Some(segment);
+        }
+        previous = segment;
+    }
+
+    None
+}
+
+/// Checks that a candidate is a hexadecimal string of a plausible length for a
+/// container ID.
+fn is_valid_container_id(candidate: &str) -> bool {
+    (MIN_CONTAINER_ID_LEN..=MAX_CONTAINER_ID_LEN).contains(&candidate.len())
+        && candidate.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A 64-char all-lowercase hex string used as the canonical container ID in tests.
+    const ID64: &str = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+    // A 32-char all-lowercase hex string.
+    const ID32: &str = "aabbccddeeff00112233445566778899";
+
+    // ---------------------------------------------------------------------------
+    // is_valid_container_id
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn is_valid_container_id_valid() {
+        // 32-char all-hex string (minimum valid length)
+        assert!(is_valid_container_id(ID32));
+
+        // 64-char all-hex string (maximum valid length)
+        assert!(is_valid_container_id(ID64));
+
+        // Mixed-case hex string of valid length (48 chars)
+        let mixed = "aAbBcCdDeEfF001122334455aAbBcCdDeEfF0011223344";
+        assert_eq!(mixed.len(), 46); // verify length is in range
+        assert!(is_valid_container_id(mixed));
+
+        // Another mixed-case at exactly 64 chars
+        let mixed64 = "aAbBcCdDeEfF0011223344556677889900112233445566778899aAbBcCdDeEfF";
+        assert_eq!(mixed64.len(), 64);
+        assert!(is_valid_container_id(mixed64));
+    }
+
+    #[test]
+    fn is_valid_container_id_invalid() {
+        // Too short: 31 hex chars (one below the 32-char minimum)
+        let short31 = "aabbccddeeff0011223344556677889";
+        assert_eq!(short31.len(), 31);
+        assert!(!is_valid_container_id(short31));
+
+        // Too long: 65 hex chars
+        let long65 = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899a";
+        assert_eq!(long65.len(), 65);
+        assert!(!is_valid_container_id(long65));
+
+        // Correct length (64) but contains a non-hex char 'g'
+        let with_g = "aabbccddeeff00112233445566778899aabbccddeeff0011223344556677889g";
+        assert_eq!(with_g.len(), 64);
+        assert!(!is_valid_container_id(with_g));
+
+        // Correct length (64) but contains a dash '-'
+        let with_dash = "aabbccddeeff00112233445566778899aabbccddeeff001122334455667788-9";
+        assert_eq!(with_dash.len(), 64);
+        assert!(!is_valid_container_id(with_dash));
+
+        // Empty string
+        assert!(!is_valid_container_id(""));
+    }
+
+    // ---------------------------------------------------------------------------
+    // container_id_from_cgroup_line
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn cgroup_line_plain_docker_v1() {
+        // Plain Docker cgroup v1: `12:cpuset:/docker/<ID>`
+        let line = format!("12:cpuset:/docker/{ID64}");
+        assert_eq!(container_id_from_cgroup_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn cgroup_line_kubernetes_cgroupfs() {
+        // Kubernetes cgroupfs driver: `.../kubepods/besteffort/pod<uid>/<ID>`
+        let line = format!(
+            "11:memory:/kubepods/besteffort/podabcd1234-ef56-7890-abcd-ef1234567890/{ID64}"
+        );
+        assert_eq!(container_id_from_cgroup_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn cgroup_line_docker_systemd() {
+        // Docker systemd driver: `.../docker-<ID>.scope`
+        let line = format!("10:cpu:/system.slice/docker-{ID64}.scope");
+        assert_eq!(container_id_from_cgroup_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn cgroup_line_containerd_systemd() {
+        // containerd systemd driver: `.../cri-containerd-<ID>.scope`
+        let line = format!("9:cpuset:/system.slice/cri-containerd-{ID64}.scope");
+        assert_eq!(container_id_from_cgroup_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn cgroup_line_crio_systemd() {
+        // CRI-O systemd driver: `.../crio-<ID>.scope`
+        let line = format!("8:memory:/system.slice/crio-{ID64}.scope");
+        assert_eq!(container_id_from_cgroup_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn cgroup_line_rejected() {
+        // cgroup v2 root entry with no container ID
+        assert_eq!(container_id_from_cgroup_line("0::/"), None);
+
+        // Last segment is non-hex (contains letters outside a-f)
+        assert_eq!(
+            container_id_from_cgroup_line("1:name=systemd:/user.slice/user-1000.slice"),
+            None
+        );
+
+        // Last segment is a valid-looking path but the ID contains non-hex chars
+        let bad_id = "aabbccddeeff00112233445566778899aabbccddeeff001122334455667788zz";
+        let line = format!("12:cpuset:/docker/{bad_id}");
+        assert_eq!(container_id_from_cgroup_line(&line), None);
+    }
+
+    // ---------------------------------------------------------------------------
+    // container_id_from_mountinfo_line
+    // ---------------------------------------------------------------------------
+
+    // Helper: build a mountinfo line with the given root and mount_point.
+    // Format: `mountID parentID major:minor root mountPoint options - fstype source superOpts`
+    // Fields before " - ": [0]=mountID [1]=parentID [2]=major:minor [3]=root [4]=mountPoint [5]=options
+    fn mountinfo_line(root: &str, mount_point: &str) -> String {
+        format!("36 35 0:33 {root} {mount_point} rw - ext4 /dev/sda1 rw")
+    }
+
+    #[test]
+    fn mountinfo_line_containers_valid() {
+        // root contains `.../containers/<ID>/...`, mount_point is /etc/hostname
+        let root = format!("/docker/containers/{ID64}/hostname");
+        let line = mountinfo_line(&root, "/etc/hostname");
+        assert_eq!(container_id_from_mountinfo_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn mountinfo_line_overlay_containers_valid() {
+        // root uses `overlay-containers/<ID>/...`
+        let root = format!("/var/lib/overlay-containers/{ID64}/userdata/hostname");
+        let line = mountinfo_line(&root, "/etc/hostname");
+        assert_eq!(container_id_from_mountinfo_line(&line), Some(ID64));
+    }
+
+    #[test]
+    fn mountinfo_line_wrong_mount_point() {
+        // mount_point is not /etc/hostname -> None
+        let root = format!("/docker/containers/{ID64}/hostname");
+        let line = mountinfo_line(&root, "/etc/hosts");
+        assert_eq!(container_id_from_mountinfo_line(&line), None);
+    }
+
+    #[test]
+    fn mountinfo_line_no_separator() {
+        // No " - " separator in the line -> None
+        let line = format!("36 35 0:33 /docker/containers/{ID64}/hostname /etc/hostname rw");
+        assert_eq!(container_id_from_mountinfo_line(&line), None);
+    }
+
+    #[test]
+    fn mountinfo_line_invalid_id_after_containers() {
+        // "containers" is present but the following segment is not a valid container ID
+        let root = "/docker/containers/not-a-valid-hex-id/hostname";
+        let line = mountinfo_line(root, "/etc/hostname");
+        assert_eq!(container_id_from_mountinfo_line(&line), None);
+    }
+}

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -75,8 +75,7 @@ const EKS_CLUSTER_NAME_ENV_VAR: &str = "AWS_CLUSTER_NAME";
 /// 1. the service-account namespace file must be readable, which proves the
 ///    process runs in a Kubernetes pod;
 /// 2. something must tie that pod to AWS — either a parsable instance identity
-///    document from IMDSv2, or one of the `AWS_CLUSTER_NAME` and `AWS_REGION`
-///    environment variables.
+///    document from IMDSv2, or the `AWS_CLUSTER_NAME` environment variables.
 ///
 /// # `k8s.cluster.name` may require configuration
 ///
@@ -166,6 +165,10 @@ impl EksResourceDetector {
         let document = imds
             .as_ref()
             .and_then(|imds| warn_on_error(DETECTOR, imds.get_identity_document()));
+
+        // We are on an AWS EC2 instance if we were able to retrieve the Instance Identity doc
+        let on_aws_ec2_node = document.is_some();
+
         let (region, account_id, ec2_document_attributes) = document
             .map(|document| {
                 let host_arch = document
@@ -185,33 +188,34 @@ impl EksResourceDetector {
             })
             .unwrap_or_default();
 
-        // Region and account ID — identity document first, then env var
-        let region = region.or_else(|| std::env::var("AWS_REGION").ok());
-        let account_id = account_id.or_else(|| std::env::var("AWS_ACCOUNT_ID").ok());
-
-        // Cluster name — from the node's EKS instance tag if exposed through IMDS, then from an env var.
-        // The tag is absent unless instance tags in metadata are enabled, which
-        // is not the default, so its absence is not worth a warning.
-        let cluster_name = imds
-            .as_ref()
-            .and_then(|imds| debug_on_error(DETECTOR, imds.get(EKS_CLUSTER_NAME_TAG_PATH)))
-            .and_then(non_empty)
-            .or_else(|| std::env::var(EKS_CLUSTER_NAME_ENV_VAR).ok())
-            .ok_or(EksError::ClusterNameNotFound);
+        // Cluster name — from the node's EKS instance tag if exposed through IMDS (which is not the case by default),
+        // then from an env var.
+        let cluster_name = warn_on_error(
+            DETECTOR,
+            imds.as_ref()
+                .and_then(|imds| debug_on_error(DETECTOR, imds.get(EKS_CLUSTER_NAME_TAG_PATH)))
+                .and_then(non_empty)
+                .or_else(|| std::env::var(EKS_CLUSTER_NAME_ENV_VAR).ok())
+                .ok_or(EksError::ClusterNameNotFound),
+        );
 
         // AWS probe: a service-account mount only proves Kubernetes, which GKE,
         // AKS and self-managed clusters have too. Something has to tie the pod
-        // to AWS before `cloud.platform` may claim EKS.
-        let Some(cluster_name) = warn_on_error(DETECTOR, cluster_name) else {
+        // to AWS, or we return an empty response.
+        if !on_aws_ec2_node && cluster_name.is_none() {
             // Kubernetes, but nothing says EKS: return empty resource
             return Resource::builder_empty().build();
         };
 
+        // Region and account ID — identity document first, then env var
+        let region = region.or_else(|| std::env::var("AWS_REGION").ok());
+        let account_id = account_id.or_else(|| std::env::var("AWS_ACCOUNT_ID").ok());
+
         // The cluster ARN needs a partition, which costs an extra IMDS request,
         // so it is only fetched once the rest of the ARN is known.
         // If partition is not retrievable from IMDS, assume "aws".
-        let cluster_arn = match (&region, &account_id) {
-            (Some(region), Some(account_id)) => {
+        let cluster_arn = match (&region, &account_id, &cluster_name) {
+            (Some(region), Some(account_id), Some(cluster_name)) => {
                 let partition = imds
                     .as_ref()
                     .and_then(|imds| warn_on_error(DETECTOR, imds.get("services/partition")))
@@ -236,7 +240,7 @@ impl EksResourceDetector {
             opt_kv(semco::K8S_POD_UID, std::env::var("POD_UID").ok()),
             // Node name — requires the downward API to expose spec.nodeName as NODE_NAME
             opt_kv(semco::K8S_NODE_NAME, std::env::var("NODE_NAME").ok()),
-            Some(KeyValue::new(semco::K8S_CLUSTER_NAME, cluster_name)),
+            opt_kv(semco::K8S_CLUSTER_NAME, cluster_name),
             opt_kv(semco::AWS_EKS_CLUSTER_ARN, cluster_arn),
             // Container ID — from cgroup, then from the mount table
             opt_kv(

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -154,7 +154,7 @@ impl EksResourceDetector {
     ) -> Resource {
         // Kubernetes probe: without the service-account mount, this is not a
         // pod at all. An unreadable file is the normal case off-Kubernetes and
-        // so is only worth a debug event.
+        // so is only worth an info event.
         let Some(namespace) = info_on_error(DETECTOR, get_namespace(namespace_path)) else {
             // Not Kubernetes, return empty resource
             return Resource::builder_empty().build();
@@ -412,15 +412,9 @@ mod tests {
         // 64-char all-hex string (maximum valid length)
         assert!(is_valid_container_id(ID64));
 
-        // Mixed-case hex string of valid length (48 chars)
+        // Mixed-case hex string of valid length (46 chars)
         let mixed = "aAbBcCdDeEfF001122334455aAbBcCdDeEfF0011223344";
-        assert_eq!(mixed.len(), 46); // verify length is in range
         assert!(is_valid_container_id(mixed));
-
-        // Another mixed-case at exactly 64 chars
-        let mixed64 = "aAbBcCdDeEfF0011223344556677889900112233445566778899aAbBcCdDeEfF";
-        assert_eq!(mixed64.len(), 64);
-        assert!(is_valid_container_id(mixed64));
     }
 
     #[test]

--- a/opentelemetry-aws/src/detector/eks.rs
+++ b/opentelemetry-aws/src/detector/eks.rs
@@ -58,24 +58,15 @@ const EKS_CLUSTER_NAME_ENV_VAR: &str = "AWS_CLUSTER_NAME";
 ///
 /// Values that cannot be found are skipped.
 ///
-/// # Feature flag
+/// # Probing
 ///
-/// This type is only available when the `detector-aws-eks` Cargo feature is
-/// enabled.
-///
-/// # Behavior
-///
-/// Detection is best-effort. Any operation that fails (file read error, IMDSv2
-/// network error, missing environment variable) is silently skipped and the
-/// corresponding attribute is omitted from the returned [`Resource`].
-///
-/// Detection is gated on two probes, both of which must pass before
-/// `cloud.provider` and `cloud.platform` are asserted:
+/// Detection of EKS is gated on two probes:
 ///
 /// 1. the service-account namespace file must be readable, which proves the
 ///    process runs in a Kubernetes pod;
 /// 2. something must tie that pod to AWS — either a parsable instance identity
-///    document from IMDSv2, or the `AWS_CLUSTER_NAME` environment variables.
+///    document from IMDSv2, or a cluster name (from the EC2 instance tag via
+///    IMDSv2 or the `AWS_CLUSTER_NAME` environment variable).
 ///
 /// # `k8s.cluster.name` may require configuration
 ///
@@ -89,9 +80,7 @@ const EKS_CLUSTER_NAME_ENV_VAR: &str = "AWS_CLUSTER_NAME";
 /// alternative that does not depend on this detector.
 ///
 /// `aws.eks.cluster.arn` is built from the cluster name, so it inherits the
-/// same requirement, and additionally needs the region, the account ID and the
-/// partition. The partition is only available from IMDSv2, so the ARN is never
-/// reported when IMDS is unreachable, even if the cluster name is configured.
+/// same requirement, and additionally needs the region and the account ID.
 ///
 /// # `k8s.pod.uid` and `k8s.node.name` require the downward API
 ///
@@ -259,7 +248,8 @@ impl EksResourceDetector {
 }
 
 /// Errors that can arise during EKS detection: filesystem reads, an empty
-/// namespace file, or no container ID anywhere in the cgroup or mount files.
+/// namespace file, no container ID anywhere in the cgroup or mount files, or a
+/// cluster name that could not be found.
 #[derive(Debug, Error)]
 enum EksError {
     #[error("Cannot read file {path}: {error}")]

--- a/opentelemetry-aws/src/detector/imds.rs
+++ b/opentelemetry-aws/src/detector/imds.rs
@@ -52,6 +52,12 @@ pub(super) enum ImdsError {
     JsonResponseRead(#[source] HttpClientError),
 }
 
+/// Abstraction over the IMDSv2 client, used to inject fakes in tests.
+pub(super) trait ImdsProvider {
+    fn get(&self, path: &str) -> Result<String, ImdsError>;
+    fn get_identity_document(&self) -> Result<InstanceIdentityDocument, ImdsError>;
+}
+
 /// IMDSv2 session holding an HTTP client and an acquired session token.
 pub(super) struct ImdsClient {
     client: HttpClient,
@@ -88,14 +94,6 @@ impl ImdsClient {
             .map_err(|error| ImdsError::GetRequest { url, error })
     }
 
-    /// GETs a metadata path under `/latest/meta-data/` and returns the response body as a `String`.
-    pub(super) fn get(&self, path: &str) -> Result<String, ImdsError> {
-        self.get_response(&format!("meta-data/{path}"))?
-            .body_mut()
-            .read_to_string()
-            .map_err(ImdsError::TextResponseRead)
-    }
-
     /// GETs a path under `/latest/` and deserializes the JSON response body.
     fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, ImdsError> {
         self.get_response(path)?
@@ -103,9 +101,19 @@ impl ImdsClient {
             .read_json()
             .map_err(ImdsError::JsonResponseRead)
     }
+}
+
+impl ImdsProvider for ImdsClient {
+    /// GETs a metadata path under `/latest/meta-data/` and returns the response body as a `String`.
+    fn get(&self, path: &str) -> Result<String, ImdsError> {
+        self.get_response(&format!("meta-data/{path}"))?
+            .body_mut()
+            .read_to_string()
+            .map_err(ImdsError::TextResponseRead)
+    }
 
     /// GETs `/latest/dynamic/instance-identity/document` and deserializes it.
-    pub(super) fn get_identity_document(&self) -> Result<InstanceIdentityDocument, ImdsError> {
+    fn get_identity_document(&self) -> Result<InstanceIdentityDocument, ImdsError> {
         self.get_json(IMDS_IDENTITY_DOCUMENT_PATH)
     }
 }
@@ -145,48 +153,91 @@ impl InstanceIdentityDocument {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+
+    // ── Fake IMDS client ──────────────────────────────────────────────────────
+
+    /// Test-only fake that returns canned responses.
+    ///
+    /// Data is stored as JSON `&str` and deserialized on
+    /// each call to exercises the `serde` impl alongside the detectors
+    /// logic.
+    pub struct FakeImdsClient {
+        document: &'static str,
+        gets: HashMap<&'static str, &'static str>,
+    }
+
+    impl FakeImdsClient {
+        pub fn new() -> Self {
+            Self {
+                document: "",
+                gets: HashMap::new(),
+            }
+        }
+
+        pub fn with_document(mut self, json: &'static str) -> Self {
+            self.document = json;
+            self
+        }
+
+        /// Add/Overrides the value returned for a specific GET path.
+        pub fn with_get(mut self, path: &'static str, value: &'static str) -> Self {
+            self.gets.insert(path, value);
+            self
+        }
+    }
+
+    impl ImdsProvider for FakeImdsClient {
+        fn get(&self, path: &str) -> Result<String, ImdsError> {
+            self.gets
+                .get(&path)
+                .map(|&s| s.to_owned())
+                .ok_or(ImdsError::GetRequest {
+                    url: path.to_owned(),
+                    error: HttpClientError::StatusCode(404),
+                })
+        }
+
+        fn get_identity_document(&self) -> Result<InstanceIdentityDocument, ImdsError> {
+            serde_json::from_str(self.document)
+                .map_err(HttpClientError::Json)
+                .map_err(ImdsError::TextResponseRead)
+        }
+    }
+
+    // ── host_arch mapping ─────────────────────────────────────────────────────
+
+    const DOC_X86_64: &str = r#"{ "architecture": "x86_64" }"#;
+    const DOC_ARM64: &str = r#"{ "architecture": "arm64"  }"#;
+    const DOC_I386: &str = r#"{ "architecture": "i386"   }"#;
+    const DOC_MIPS: &str = r#"{ "architecture": "mips"   }"#;
+    const DOC_EMPTY_ARCH: &str = r#"{ "architecture": ""    }"#;
+    const DOC_NO_ARCH: &str = r#"{}"#;
 
     #[test]
     fn host_arch_known_mappings() {
-        let x86_64 = InstanceIdentityDocument {
-            architecture: Some("x86_64".to_owned()),
-            ..Default::default()
-        };
-        assert_eq!(x86_64.host_arch(), Some("amd64"));
+        let doc: InstanceIdentityDocument = serde_json::from_str(DOC_X86_64).unwrap();
+        assert_eq!(doc.host_arch(), Some("amd64"));
 
-        let arm64 = InstanceIdentityDocument {
-            architecture: Some("arm64".to_owned()),
-            ..Default::default()
-        };
-        assert_eq!(arm64.host_arch(), Some("arm64"));
+        let doc: InstanceIdentityDocument = serde_json::from_str(DOC_ARM64).unwrap();
+        assert_eq!(doc.host_arch(), Some("arm64"));
 
-        let i386 = InstanceIdentityDocument {
-            architecture: Some("i386".to_owned()),
-            ..Default::default()
-        };
-        assert_eq!(i386.host_arch(), Some("x86"));
+        let doc: InstanceIdentityDocument = serde_json::from_str(DOC_I386).unwrap();
+        assert_eq!(doc.host_arch(), Some("x86"));
     }
 
     #[test]
     fn host_arch_unknown_or_absent() {
-        let none = InstanceIdentityDocument {
-            architecture: None,
-            ..Default::default()
-        };
-        assert_eq!(none.host_arch(), None);
+        let doc: InstanceIdentityDocument = serde_json::from_str(DOC_NO_ARCH).unwrap();
+        assert_eq!(doc.host_arch(), None);
 
-        let mips = InstanceIdentityDocument {
-            architecture: Some("mips".to_owned()),
-            ..Default::default()
-        };
-        assert_eq!(mips.host_arch(), None);
+        let doc: InstanceIdentityDocument = serde_json::from_str(DOC_MIPS).unwrap();
+        assert_eq!(doc.host_arch(), None);
 
-        let empty = InstanceIdentityDocument {
-            architecture: Some("".to_owned()),
-            ..Default::default()
-        };
-        assert_eq!(empty.host_arch(), None);
+        let doc: InstanceIdentityDocument = serde_json::from_str(DOC_EMPTY_ARCH).unwrap();
+        assert_eq!(doc.host_arch(), None);
     }
 }

--- a/opentelemetry-aws/src/detector/imds.rs
+++ b/opentelemetry-aws/src/detector/imds.rs
@@ -163,7 +163,7 @@ pub(super) mod tests {
     /// Test-only fake that returns canned responses.
     ///
     /// Data is stored as JSON `&str` and deserialized on
-    /// each call to exercises the `serde` impl alongside the detectors
+    /// each call to exercise the `serde` impl alongside the detector
     /// logic.
     pub struct FakeImdsClient {
         document: &'static str,
@@ -204,7 +204,7 @@ pub(super) mod tests {
         fn get_identity_document(&self) -> Result<InstanceIdentityDocument, ImdsError> {
             serde_json::from_str(self.document)
                 .map_err(HttpClientError::Json)
-                .map_err(ImdsError::TextResponseRead)
+                .map_err(ImdsError::JsonResponseRead)
         }
     }
 

--- a/opentelemetry-aws/src/detector/imds.rs
+++ b/opentelemetry-aws/src/detector/imds.rs
@@ -1,0 +1,192 @@
+//! Shared IMDSv2 client for the EC2 instance metadata service.
+//!
+//! IMDSv2 requires a two-step flow:
+//!   1. PUT /latest/api/token with X-aws-ec2-metadata-token-ttl-seconds header
+//!      to obtain a session token.
+//!   2. GET /latest/{path} with X-aws-ec2-metadata-token header set
+//!      to the token obtained in step 1.
+//!
+//! This module provides a thin wrapper that handles both steps.
+
+// `http` is re-exported by `ureq`, so that the detector features do not have to
+// depend on the `http` crate, which only the `trace` feature pulls in.
+use ureq::http::Response;
+use ureq::{Agent as HttpClient, Body, Error as HttpClientError};
+
+use thiserror::Error;
+
+use super::utils::{blocking_client, non_empty};
+
+/// Base URL for the EC2 instance metadata service.
+const IMDS_BASE: &str = "http://169.254.169.254";
+/// IMDSv2 token endpoint path.
+const IMDS_TOKEN_PATH: &str = "latest/api/token";
+/// Path of the instance identity document, relative to `/latest/`.
+const IMDS_IDENTITY_DOCUMENT_PATH: &str = "dynamic/instance-identity/document";
+/// Request header used to specify the token TTL when acquiring an IMDSv2 token.
+const IMDS_TTL_HEADER: &str = "X-aws-ec2-metadata-token-ttl-seconds";
+/// Request header used to pass the IMDSv2 session token on metadata requests.
+const IMDS_TOKEN_HEADER: &str = "X-aws-ec2-metadata-token";
+/// Token TTL in seconds (60s).
+const IMDS_TOKEN_TTL: &str = "60";
+/// HTTP request timeout in seconds for IMDS calls.
+const IMDS_TIMEOUT_SECS: u64 = 1;
+
+/// Errors that can arise interacting with the IMDSv2 service,
+/// mostly for display purposes.
+#[derive(Debug, Error)]
+pub(super) enum ImdsError {
+    #[error("Could not retrieve an IMDSv2 auth token: {0}")]
+    AuthToken(#[source] HttpClientError),
+    #[error("The IMDSv2 auth token endpoint answered with an empty body")]
+    EmptyAuthToken,
+    #[error("Could not GET {url}: {error}")]
+    GetRequest {
+        url: String,
+        #[source]
+        error: HttpClientError,
+    },
+    #[error("Could not read text response: {0}")]
+    TextResponseRead(#[source] HttpClientError),
+    #[error("Could not read JSON response: {0}")]
+    JsonResponseRead(#[source] HttpClientError),
+}
+
+/// IMDSv2 session holding an HTTP client and an acquired session token.
+pub(super) struct ImdsClient {
+    client: HttpClient,
+    token: String,
+}
+
+impl ImdsClient {
+    /// Builds a blocking HTTP client with a 1s timeout and acquires an IMDSv2 session token.
+    pub(super) fn new() -> Result<Self, ImdsError> {
+        let client = blocking_client(std::time::Duration::from_secs(IMDS_TIMEOUT_SECS));
+
+        // A non-2xx status is an error by default in `ureq`, which is what keeps
+        // the other metadata services reachable at this link-local address —
+        // Google Compute Engine and Azure both use it — from being mistaken for
+        // IMDSv2. Rejecting an empty body closes the remaining gap.
+        let token = client
+            .put(format!("{IMDS_BASE}/{IMDS_TOKEN_PATH}"))
+            .header(IMDS_TTL_HEADER, IMDS_TOKEN_TTL)
+            .send_empty()
+            .and_then(|mut r| r.body_mut().read_to_string())
+            .map_err(ImdsError::AuthToken)?;
+        let token = non_empty(token).ok_or(ImdsError::EmptyAuthToken)?;
+
+        Ok(Self { client, token })
+    }
+
+    /// GETs a path under `/latest/` with the session token and returns the error-checked raw `Response`.
+    fn get_response(&self, path: &str) -> Result<Response<Body>, ImdsError> {
+        let url = format!("{IMDS_BASE}/latest/{path}");
+        self.client
+            .get(&url)
+            .header(IMDS_TOKEN_HEADER, &self.token)
+            .call()
+            .map_err(|error| ImdsError::GetRequest { url, error })
+    }
+
+    /// GETs a metadata path under `/latest/meta-data/` and returns the response body as a `String`.
+    pub(super) fn get(&self, path: &str) -> Result<String, ImdsError> {
+        self.get_response(&format!("meta-data/{path}"))?
+            .body_mut()
+            .read_to_string()
+            .map_err(ImdsError::TextResponseRead)
+    }
+
+    /// GETs a path under `/latest/` and deserializes the JSON response body.
+    fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, ImdsError> {
+        self.get_response(path)?
+            .body_mut()
+            .read_json()
+            .map_err(ImdsError::JsonResponseRead)
+    }
+
+    /// GETs `/latest/dynamic/instance-identity/document` and deserializes it.
+    pub(super) fn get_identity_document(&self) -> Result<InstanceIdentityDocument, ImdsError> {
+        self.get_json(IMDS_IDENTITY_DOCUMENT_PATH)
+    }
+}
+
+/// Deserialization target for the IMDSv2 instance identity document.
+///
+/// Only the fields consumed by the resource detectors are modelled; every field
+/// is optional so that a partial document still yields the attributes it does
+/// contain.
+#[derive(Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct InstanceIdentityDocument {
+    #[cfg(any(feature = "detector-aws-ec2", feature = "detector-aws-eks"))]
+    pub account_id: Option<String>,
+    #[cfg(any(feature = "detector-aws-ec2", feature = "detector-aws-eks"))]
+    pub region: Option<String>,
+    pub availability_zone: Option<String>,
+    pub instance_id: Option<String>,
+    pub instance_type: Option<String>,
+    pub image_id: Option<String>,
+    /// EC2 architecture name (`x86_64`, `arm64`, `i386`), which is *not* a
+    /// `host.arch` semantic convention value. See [`Self::host_arch`].
+    architecture: Option<String>,
+}
+
+impl InstanceIdentityDocument {
+    /// Maps the EC2 `architecture` field onto the corresponding `host.arch`
+    /// semantic convention value, returning `None` for unknown architectures.
+    pub(super) fn host_arch(&self) -> Option<&'static str> {
+        match self.architecture.as_deref() {
+            Some("x86_64") => Some("amd64"),
+            Some("arm64") => Some("arm64"),
+            Some("i386") => Some("x86"),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_arch_known_mappings() {
+        let x86_64 = InstanceIdentityDocument {
+            architecture: Some("x86_64".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(x86_64.host_arch(), Some("amd64"));
+
+        let arm64 = InstanceIdentityDocument {
+            architecture: Some("arm64".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(arm64.host_arch(), Some("arm64"));
+
+        let i386 = InstanceIdentityDocument {
+            architecture: Some("i386".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(i386.host_arch(), Some("x86"));
+    }
+
+    #[test]
+    fn host_arch_unknown_or_absent() {
+        let none = InstanceIdentityDocument {
+            architecture: None,
+            ..Default::default()
+        };
+        assert_eq!(none.host_arch(), None);
+
+        let mips = InstanceIdentityDocument {
+            architecture: Some("mips".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(mips.host_arch(), None);
+
+        let empty = InstanceIdentityDocument {
+            architecture: Some("".to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(empty.host_arch(), None);
+    }
+}

--- a/opentelemetry-aws/src/detector/mod.rs
+++ b/opentelemetry-aws/src/detector/mod.rs
@@ -2,3 +2,32 @@
 mod lambda;
 #[cfg(feature = "detector-aws-lambda")]
 pub use lambda::LambdaResourceDetector;
+
+#[cfg(feature = "detector-aws-ec2")]
+mod ec2;
+#[cfg(feature = "detector-aws-ec2")]
+pub use ec2::Ec2ResourceDetector;
+
+#[cfg(feature = "detector-aws-ecs")]
+mod ecs;
+#[cfg(feature = "detector-aws-ecs")]
+pub use ecs::EcsResourceDetector;
+
+#[cfg(feature = "detector-aws-eks")]
+mod eks;
+#[cfg(feature = "detector-aws-eks")]
+pub use eks::EksResourceDetector;
+
+#[cfg(any(
+    feature = "detector-aws-ec2",
+    feature = "detector-aws-ecs",
+    feature = "detector-aws-eks"
+))]
+mod imds;
+
+#[cfg(any(
+    feature = "detector-aws-ec2",
+    feature = "detector-aws-ecs",
+    feature = "detector-aws-eks"
+))]
+mod utils;

--- a/opentelemetry-aws/src/detector/utils.rs
+++ b/opentelemetry-aws/src/detector/utils.rs
@@ -14,15 +14,9 @@ pub(super) fn blocking_client(timeout: std::time::Duration) -> ureq::Agent {
         .into()
 }
 
-#[cfg(feature = "detector-aws-eks")]
-#[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
-pub(super) fn log_debug(detector: &'static str, error: &dyn std::error::Error) {
-    #[cfg(feature = "internal-logs")]
-    tracing::debug!(%detector, %error, "Detector error");
-}
-
 /// Converts a `Result` into an `Option`, reporting the error via [`log_debug`].
 #[cfg(feature = "detector-aws-eks")]
+#[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
 pub(super) fn debug_on_error<T, E: std::error::Error>(
     detector: &'static str,
     result: Result<T, E>,
@@ -30,13 +24,15 @@ pub(super) fn debug_on_error<T, E: std::error::Error>(
     match result {
         Ok(value) => Some(value),
         Err(error) => {
-            log_debug(detector, &error);
+            #[cfg(feature = "internal-logs")]
+            tracing::debug!(%detector, %error, "Detector error");
             None
         }
     }
 }
 
 /// Converts a `Result` into an `Option`, reporting the error via [`log_warn`].
+#[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
 pub(super) fn warn_on_error<T, E: std::error::Error>(
     detector: &'static str,
     result: Result<T, E>,

--- a/opentelemetry-aws/src/detector/utils.rs
+++ b/opentelemetry-aws/src/detector/utils.rs
@@ -14,7 +14,7 @@ pub(super) fn blocking_client(timeout: std::time::Duration) -> ureq::Agent {
         .into()
 }
 
-/// Converts a `Result` into an `Option`, reporting the error via [`log_debug`].
+/// Converts a `Result` into an `Option`, reporting the error via [`tracing::debug`].
 #[cfg(feature = "detector-aws-eks")]
 #[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
 pub(super) fn debug_on_error<T, E: std::error::Error>(
@@ -31,7 +31,23 @@ pub(super) fn debug_on_error<T, E: std::error::Error>(
     }
 }
 
-/// Converts a `Result` into an `Option`, reporting the error via [`log_warn`].
+/// Converts a `Result` into an `Option`, reporting the error via [`tracing::info`].
+#[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
+pub(super) fn info_on_error<T, E: std::error::Error>(
+    detector: &'static str,
+    result: Result<T, E>,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            #[cfg(feature = "internal-logs")]
+            tracing::info!(%detector, %error, "Detector error");
+            None
+        }
+    }
+}
+
+/// Converts a `Result` into an `Option`, reporting the error via [`tracing::warn`].
 #[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
 pub(super) fn warn_on_error<T, E: std::error::Error>(
     detector: &'static str,
@@ -136,7 +152,7 @@ mod tests {
     }
 
     // Tests for opt_kv_array
-
+    #[cfg(feature = "detector-aws-ecs")]
     #[test]
     fn opt_kv_array_some() {
         let kv = opt_kv_array("array.key", Some("v".to_owned()));
@@ -146,7 +162,7 @@ mod tests {
         let expected = Value::Array(Array::from(vec![StringValue::from("v")]));
         assert_eq!(kv.value, expected);
     }
-
+    #[cfg(feature = "detector-aws-ecs")]
     #[test]
     fn opt_kv_array_none() {
         // None input

--- a/opentelemetry-aws/src/detector/utils.rs
+++ b/opentelemetry-aws/src/detector/utils.rs
@@ -1,0 +1,165 @@
+//! Helpers shared by the AWS resource detectors.
+
+use opentelemetry::KeyValue;
+#[cfg(feature = "detector-aws-ecs")]
+use opentelemetry::{Array, StringValue, Value};
+
+/// Builds a blocking HTTP client with proxying disabled and a global timeout.
+#[cfg(feature = "_detector-http")]
+pub(super) fn blocking_client(timeout: std::time::Duration) -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .proxy(None)
+        .timeout_global(Some(timeout))
+        .build()
+        .into()
+}
+
+#[cfg(feature = "detector-aws-eks")]
+#[cfg_attr(not(feature = "internal-logs"), allow(unused_variables))]
+pub(super) fn log_debug(detector: &'static str, error: &dyn std::error::Error) {
+    #[cfg(feature = "internal-logs")]
+    tracing::debug!(%detector, %error, "Detector error");
+}
+
+/// Converts a `Result` into an `Option`, reporting the error via [`log_debug`].
+#[cfg(feature = "detector-aws-eks")]
+pub(super) fn debug_on_error<T, E: std::error::Error>(
+    detector: &'static str,
+    result: Result<T, E>,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            log_debug(detector, &error);
+            None
+        }
+    }
+}
+
+/// Converts a `Result` into an `Option`, reporting the error via [`log_warn`].
+pub(super) fn warn_on_error<T, E: std::error::Error>(
+    detector: &'static str,
+    result: Result<T, E>,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            #[cfg(feature = "internal-logs")]
+            tracing::warn!(%detector, %error, "Detector error");
+            None
+        }
+    }
+}
+
+/// Builds an attribute from an optional value, dropping it when absent or blank.
+pub(super) fn opt_kv(key: &'static str, value: Option<String>) -> Option<KeyValue> {
+    value.and_then(non_empty).map(|v| KeyValue::new(key, v))
+}
+
+/// [`opt_kv`] for the attributes that semantic conventions type as `string[]`,
+/// wrapping the single value the metadata endpoints expose in a one-element array.
+#[cfg(feature = "detector-aws-ecs")]
+pub(super) fn opt_kv_array(key: &'static str, value: Option<String>) -> Option<KeyValue> {
+    value
+        .and_then(non_empty)
+        .map(|v| KeyValue::new(key, Value::Array(Array::from(vec![StringValue::from(v)]))))
+}
+
+/// Trims a string and returns `None` if the result is empty.
+pub(super) fn non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else if trimmed.len() == value.len() {
+        Some(value)
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for non_empty
+
+    #[test]
+    fn non_empty_some() {
+        // Branch (b): no whitespace, returns original unchanged
+        let result = non_empty("hello".to_owned());
+        assert_eq!(result, Some("hello".to_owned()));
+
+        // Branch (c): surrounding whitespace trimmed, returns trimmed owned string
+        let result = non_empty("  hello world  ".to_owned());
+        assert_eq!(result, Some("hello world".to_owned()));
+
+        // Branch (c): tabs and newlines trimmed
+        let result = non_empty("\t  content\n".to_owned());
+        assert_eq!(result, Some("content".to_owned()));
+    }
+
+    #[test]
+    fn non_empty_none() {
+        // Empty string
+        assert_eq!(non_empty("".to_owned()), None);
+
+        // Whitespace-only string
+        assert_eq!(non_empty("   ".to_owned()), None);
+
+        // Tabs and newlines only
+        assert_eq!(non_empty("\t\n\r".to_owned()), None);
+    }
+
+    // Tests for opt_kv
+
+    #[test]
+    fn opt_kv_some() {
+        // Some value with no whitespace
+        let kv = opt_kv("my.key", Some("my-value".to_owned()));
+        let kv = kv.expect("expected Some(KeyValue)");
+        assert_eq!(kv.key.as_str(), "my.key");
+        assert_eq!(kv.value, opentelemetry::Value::String("my-value".into()));
+
+        // Some value with surrounding whitespace — trimmed
+        let kv = opt_kv("trimmed.key", Some("  trimmed  ".to_owned()));
+        let kv = kv.expect("expected Some(KeyValue) after trimming");
+        assert_eq!(kv.key.as_str(), "trimmed.key");
+        assert_eq!(kv.value, opentelemetry::Value::String("trimmed".into()));
+    }
+
+    #[test]
+    fn opt_kv_none() {
+        // None input
+        assert!(opt_kv("k", None).is_none());
+
+        // Some empty string
+        assert!(opt_kv("k", Some("".to_owned())).is_none());
+
+        // Some whitespace-only string
+        assert!(opt_kv("k", Some("   ".to_owned())).is_none());
+    }
+
+    // Tests for opt_kv_array
+
+    #[test]
+    fn opt_kv_array_some() {
+        let kv = opt_kv_array("array.key", Some("v".to_owned()));
+        let kv = kv.expect("expected Some(KeyValue)");
+        assert_eq!(kv.key.as_str(), "array.key");
+
+        let expected = Value::Array(Array::from(vec![StringValue::from("v")]));
+        assert_eq!(kv.value, expected);
+    }
+
+    #[test]
+    fn opt_kv_array_none() {
+        // None input
+        assert!(opt_kv_array("k", None).is_none());
+
+        // Some empty string
+        assert!(opt_kv_array("k", Some("".to_owned())).is_none());
+
+        // Some whitespace-only string
+        assert!(opt_kv_array("k", Some("  ".to_owned())).is_none());
+    }
+}


### PR DESCRIPTION
Fixes #705
Fixes #706
Part of #707
Part of #94

## Changes

Adds three AWS resource detectors to the `opentelemetry-aws` crate, each behind its own feature flag:

- `Ec2ResourceDetector` (`detector-aws-ec2`) — queries IMDSv2 for `cloud.*` and `host.*` attributes.
- `EcsResourceDetector` (`detector-aws-ecs`) — reads the ECS container metadata   endpoint v4 (`ECS_CONTAINER_METADATA_URI_V4`) and IMDSv2 on EC2 workers for `cloud.*`, `aws.ecs.*`,
  `container.*` and `aws.log.*` attributes.
- `EksResourceDetector` (`detector-aws-eks`) — detects a pod via the
  service-account namespace file and ties it to AWS via IMDSv2, reporting
  `cloud.*`, `k8s.*`, `aws.eks.cluster.arn`, `container.id` and node `host.*`.

Supporting changes:

- New internal feature groups `_detector` / `_detector-http` to share deps.
- New optional dependency `ureq` (blocking HTTP client — `ResourceDetector::detect`
  is synchronous). Empty attribute values are filtered out; errors are best-effort
  logged (gated by `internal-logs`) and the attribute is skipped.
- The existing `LambdaResourceDetector` is intentionally untouched.

### Usage

```rust
use opentelemetry_aws::detector::Ec2ResourceDetector;
use opentelemetry_sdk::Resource;

let resource = Resource::builder()
    .with_detector(Box::new(Ec2ResourceDetector))
    .build();
```

# Discussion / open questions
I'd like maintainer input on the following before finalizing:
1. Warning on wrong platform. A detector run on the wrong platform emits a
single warning log line (disableable by dropping the internal-logs
feature). Pro: surfaces likely misconfiguration cheaply. Con: an app that
legitimately runs on multiple platforms (e.g. EC2 and ECS) and enables
several detectors will always warn for the ones that don't match. Keep,
downgrade to debug, or drop?
2. IMDS use in ECS/EKS vs. Fargate. Both ECS and EKS detectors contact
IMDSv2 to enrich with node info, which does not work on Fargate. Should these
detectors instead focus only on ECS/EKS-specific sources and leave node
detection to the EC2 detector (user opts in by also enabling it)? If so, how
should cloud.platform be resolved when several detectors are chained —
relying on detector order is poor API design; is there a better contract?
3. IMDSv2 only. I only implement IMDSv2 (no v1 fallback). Is v1 support
wanted? Relatedly, endpoints use /latest/; should a pinned, dated IMDS
version be used instead?
4. Empty-value filtering. Every detector filters out empty/blank values to
avoid populating keys with empty strings. Is the added code worth it, or is
it acceptable to emit empty values?
5. EKS approach differs from #707 which proposes the k8s-API route
(read aws-auth / cluster-info configmaps, container.id from cgroup).
This PR instead uses the service-account namespace file + IMDSv2
aws:eks:cluster-name instance tag + downward-API env vars, which avoids a
Kubernetes client dependency but requires instance-tags-in-metadata to be
enabled (or AWS_CLUSTER_NAME to be set) for k8s.cluster.name. Is this
trade-off acceptable, or should it follow #707's configmap approach?
6. Refactor the Lambda detector? The existing lambda.rs populates
attributes with unwrap_or_default(), producing empty values on error —
inconsistent with the empty-filtering the new detectors do. Should a small
refactor be included in this PR, or kept separate?
 # Testing

Unit tests cover the pure logic (arch mapping, value filtering, ARN parsing, etc.).

End-to-end behavior was verified by running a probe program on real AWS (EC2, ECS, EKS). See: https://github.com/RustyServerless/opentelemetry-rust-contrib/tree/wip/aws-resource-detectors/otel-aws-probe-deploy

# Merge requirement checklist

* [x] CONTRIBUTING (https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate CHANGELOG.md files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
