### PR TITLE
ci: align codeql autobuild to v4.37.3 to fix version mismatch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
         languages: rust
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
Fixes the repo-wide CodeQL Analysis failure that has affected every `main` commit and PR since 2026-08-01.

### Root cause
The `Autobuild` step was still pinned to `v4.36.2` while `Initialize CodeQL` and `Perform CodeQL Analysis` were bumped to `v4.37.3` (in the dependabot bump of `codeql-action/analyze` on 2026-08-01). `init` loads the config for 4.37.3, then autobuild runs 4.36.2, producing:

```
##[error]We were unable to automatically build your code. ... Loaded a configuration file for version '4.37.3', but running version '4.36.2'
```

### Fix
Bump the `autobuild` step to the same `v4.37.3` SHA (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`) so all three `github/codeql-action` steps are on a consistent version.
