### PR TITLE
chore(deps): update otap pdata dependencies

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e", optional = true }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -72,7 +72,7 @@ default = ["tls-native"]
 
 [dev-dependencies]
 geneva-test-server = { path = "../geneva-test-server", features = ["testing"] }
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["l
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 futures = "0.3"
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
+otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
 
 [features]
 # TLS backend selection is forwarded to geneva-uploader. `tls-native` (default)

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -3,7 +3,7 @@ name = "stress"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 publish = false
 
 [[bin]]
@@ -37,7 +37,7 @@ opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "4f522d2e" }
+otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
 prost = "0.14"
 
 [features]


### PR DESCRIPTION
## Changes

Updates `otap-df-pdata-views` to the latest otel-arrow revision.

Also updates the dev-only `otap-df-pdata` dependency to the same revision so uploader tests and examples use the same view-trait identity.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (not applicable; existing tests cover compatibility)
* [x] Appropriate `CHANGELOG.md` files updated (not applicable; dependency alignment only)
* [x] Changes in public API reviewed (no API changes)
