### PR TITLE
feat(geneva): support multi-moniker routing

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/log_records_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/log_records_example.c
@@ -10,6 +10,7 @@
  *   GENEVA_ENVIRONMENT           e.g. Test
  *   GENEVA_ACCOUNT               e.g. myaccount
  *   GENEVA_NAMESPACE             e.g. mynamespace
+ *   GENEVA_ACCOUNT_GROUP         e.g. mynamespacediag (optional for a single-group response)
  *   GENEVA_REGION                e.g. eastus
  *   GENEVA_CONFIG_MAJOR_VERSION  e.g. 2
  *
@@ -57,6 +58,7 @@ int main(void) {
     const char* environment   = getenv("GENEVA_ENVIRONMENT");
     const char* account       = getenv("GENEVA_ACCOUNT");
     const char* namespaceName = getenv("GENEVA_NAMESPACE");
+    const char* accountGroup  = getenv("GENEVA_ACCOUNT_GROUP");
     const char* region        = getenv("GENEVA_REGION");
     const char* cfg_ver_str   = getenv("GENEVA_CONFIG_MAJOR_VERSION");
 
@@ -103,6 +105,7 @@ int main(void) {
         .environment          = environment,
         .account              = account,
         .namespace_name       = namespaceName,
+        .account_group        = accountGroup,
         .region               = region,
         .config_major_version = (uint32_t)cfg_ver,
         .auth_method          = auth_method,

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/log_records_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/log_records_example.c
@@ -10,7 +10,7 @@
  *   GENEVA_ENVIRONMENT           e.g. Test
  *   GENEVA_ACCOUNT               e.g. myaccount
  *   GENEVA_NAMESPACE             e.g. mynamespace
- *   GENEVA_ACCOUNT_GROUP         e.g. mynamespacediag (optional for a single-group response)
+ *   GENEVA_ACCOUNT_GROUP         e.g. mynamespacediag (default logical account group)
  *   GENEVA_REGION                e.g. eastus
  *   GENEVA_CONFIG_MAJOR_VERSION  e.g. 2
  *
@@ -62,12 +62,13 @@ int main(void) {
     const char* region        = getenv("GENEVA_REGION");
     const char* cfg_ver_str   = getenv("GENEVA_CONFIG_MAJOR_VERSION");
 
-    if (!endpoint || !environment || !account || !namespaceName || !region || !cfg_ver_str) {
+    if (!endpoint || !environment || !account || !namespaceName || !accountGroup || !region || !cfg_ver_str) {
         fprintf(stderr, "Missing required environment variables:\n"
                         "  GENEVA_ENDPOINT\n"
                         "  GENEVA_ENVIRONMENT\n"
                         "  GENEVA_ACCOUNT\n"
                         "  GENEVA_NAMESPACE\n"
+                        "  GENEVA_ACCOUNT_GROUP\n"
                         "  GENEVA_REGION\n"
                         "  GENEVA_CONFIG_MAJOR_VERSION\n");
         return 1;

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/logs_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/logs_example.c
@@ -41,6 +41,7 @@ int main(void) {
     const char* environment   = getenv("GENEVA_ENVIRONMENT");
     const char* account       = getenv("GENEVA_ACCOUNT");
     const char* namespaceName = getenv("GENEVA_NAMESPACE");
+    const char* accountGroup  = getenv("GENEVA_ACCOUNT_GROUP");
     const char* region        = getenv("GENEVA_REGION");
     const char* cfg_ver_str   = getenv("GENEVA_CONFIG_MAJOR_VERSION");
 
@@ -93,6 +94,7 @@ int main(void) {
         .environment = environment,
         .account = account,
         .namespace_name = namespaceName,
+        .account_group = accountGroup,
         .region = region,
         .config_major_version = (uint32_t)cfg_ver,
         .auth_method = auth_method,

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/spans_example.c
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/examples/spans_example.c
@@ -41,6 +41,7 @@ int main(void) {
     const char* environment   = getenv("GENEVA_ENVIRONMENT");
     const char* account       = getenv("GENEVA_ACCOUNT");
     const char* namespaceName = getenv("GENEVA_NAMESPACE");
+    const char* accountGroup  = getenv("GENEVA_ACCOUNT_GROUP");
     const char* region        = getenv("GENEVA_REGION");
     const char* cfg_ver_str   = getenv("GENEVA_CONFIG_MAJOR_VERSION");
 
@@ -93,6 +94,7 @@ int main(void) {
         .environment = environment,
         .account = account,
         .namespace_name = namespaceName,
+        .account_group = accountGroup,
         .region = region,
         .config_major_version = (uint32_t)cfg_ver,
         .auth_method = auth_method,

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/include/geneva_ffi.h
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/include/geneva_ffi.h
@@ -21,6 +21,17 @@ typedef struct EncodedBatchesHandle EncodedBatchesHandle;
 #define GENEVA_AUTH_USER_MANAGED_IDENTITY_BY_OBJECT_ID 4
 #define GENEVA_AUTH_USER_MANAGED_IDENTITY_BY_RESOURCE_ID 5
 
+/* Maps a final event name to a logical account group. */
+typedef struct {
+    const char* event_name;
+    const char* account_group;
+} GenevaAccountGroupMapEntry;
+
+typedef struct {
+    const GenevaAccountGroupMapEntry* entries;
+    size_t count;
+} GenevaAccountGroupMapping;
+
 /* Configuration for certificate auth (valid only when auth_method == GENEVA_AUTH_CERTIFICATE) */
 typedef struct {
     const char* cert_path;      /* Path to certificate file */
@@ -147,6 +158,8 @@ typedef struct {
     const char* environment;
     const char* account;
     const char* namespace_name;
+    const char* account_group; /* Required default logical GCS account group. */
+    const GenevaAccountGroupMapping* account_group_mapping; /* Optional final event-name to logical account-group overrides. */
     const char* region;
     uint32_t config_major_version;
     uint32_t auth_method; /* 0 = System MSI, 1 = Certificate, 2 = Workload Identity, 3 = User MSI by client ID, 4 = User MSI by object ID, 5 = User MSI by resource ID */

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -12,8 +12,8 @@ use tokio::runtime::Runtime;
 
 use geneva_uploader::client::{EncodedBatch, GenevaClient, GenevaClientConfig, UploadError};
 use geneva_uploader::{
-    AuthMethod, LogsConfig, LogsEventNameMapping, LogsEventNameRoutingKey, SpanEventNameMapping,
-    SpanEventNameRoutingKey, TracesConfig,
+    AccountRouting, AuthMethod, LogsConfig, LogsEventNameMapping, LogsEventNameRoutingKey,
+    SpanEventNameMapping, SpanEventNameRoutingKey, TracesConfig,
 };
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
@@ -180,6 +180,8 @@ pub struct GenevaConfig {
     pub environment: *const c_char,
     pub account: *const c_char,
     pub namespace_name: *const c_char,
+    pub account_group: *const c_char, // Required default logical GCS account group.
+    pub account_group_mapping: *const FfiAccountGroupMapping, // Optional final event-name to account-group overrides.
     pub region: *const c_char,
     pub config_major_version: c_uint,
     pub auth_method: c_uint,
@@ -193,6 +195,19 @@ pub struct GenevaConfig {
     pub logs_event_name_mapping: *const FfiLogsEventNameMapping, // Optional logs routing map. Nullable.
     pub spans_default_event_name: *const c_char, // Optional default destination table for spans. Nullable.
     pub spans_event_name_mapping: *const FfiSpansEventNameMapping, // Optional spans routing map. Nullable.
+}
+
+/// Maps one final Geneva event name to one logical GCS account group.
+#[repr(C)]
+pub struct FfiAccountGroupMapEntry {
+    pub event_name: *const c_char,
+    pub account_group: *const c_char,
+}
+
+#[repr(C)]
+pub struct FfiAccountGroupMapping {
+    pub entries: *const FfiAccountGroupMapEntry,
+    pub count: usize,
 }
 
 /// FFI-safe logs event-name mapping routing kinds.
@@ -420,6 +435,44 @@ unsafe fn convert_obo_event_map(
     } else {
         Ok(Some(obo_map))
     }
+}
+
+unsafe fn convert_account_group_mapping(
+    ffi_map: *const FfiAccountGroupMapping,
+) -> Result<std::collections::HashMap<String, String>, String> {
+    if ffi_map.is_null() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let map_ref = unsafe { &*ffi_map };
+    if map_ref.count == 0 {
+        return Ok(std::collections::HashMap::new());
+    }
+    if map_ref.entries.is_null() {
+        return Err("account_group_mapping.entries must not be null when count is non-zero".into());
+    }
+
+    let entries = unsafe { std::slice::from_raw_parts(map_ref.entries, map_ref.count) };
+    let mut result = std::collections::HashMap::with_capacity(entries.len());
+    for (index, entry) in entries.iter().enumerate() {
+        let event_name = unsafe {
+            c_str_to_string(
+                entry.event_name,
+                &format!("account_group_mapping.entries[{index}].event_name"),
+            )
+        }?;
+        let account_group = unsafe {
+            c_str_to_string(
+                entry.account_group,
+                &format!("account_group_mapping.entries[{index}].account_group"),
+            )
+        }?;
+        if result.insert(event_name.clone(), account_group).is_some() {
+            return Err(format!(
+                "duplicate event name '{event_name}' in account_group_mapping"
+            ));
+        }
+    }
+    Ok(result)
 }
 
 /// Shared accessor over the identically-shaped logs/spans mapping entry structs
@@ -716,6 +769,21 @@ pub unsafe extern "C" fn geneva_client_new(
             return GenevaError::InvalidConfig;
         }
     };
+    let account_group = match unsafe { c_str_to_string(config.account_group, "account_group") } {
+        Ok(s) => s,
+        Err(e) => {
+            unsafe { write_error_if_provided(err_msg_out, err_msg_len, &e) };
+            return GenevaError::InvalidConfig;
+        }
+    };
+    let account_group_mapping =
+        match unsafe { convert_account_group_mapping(config.account_group_mapping) } {
+            Ok(mapping) => mapping,
+            Err(e) => {
+                unsafe { write_error_if_provided(err_msg_out, err_msg_len, &e) };
+                return GenevaError::InvalidConfig;
+            }
+        };
     let region = match unsafe { c_str_to_string(config.region, "region") } {
         Ok(s) => s,
         Err(e) => {
@@ -927,6 +995,10 @@ pub unsafe extern "C" fn geneva_client_new(
         environment,
         account,
         namespace,
+        account_routing: AccountRouting {
+            default_group: account_group,
+            groups_by_event: account_group_mapping,
+        },
         region,
         config_major_version: config.config_major_version,
         auth_method,
@@ -1986,6 +2058,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -2014,6 +2087,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -2168,6 +2242,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2178,6 +2253,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 0, // SystemManagedIdentity - union not used
@@ -2210,6 +2287,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2220,6 +2298,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 99, // Invalid auth method - union not used
@@ -2249,6 +2329,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2259,6 +2340,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 1, // Certificate auth
@@ -2293,6 +2376,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2303,6 +2387,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 2, // Workload Identity
@@ -2336,6 +2422,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2346,6 +2433,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 3, // User Managed Identity by client ID
@@ -2379,6 +2468,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2389,6 +2479,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 4, // User Managed Identity by object ID
@@ -2425,6 +2517,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2435,6 +2528,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 5, // User Managed Identity by resource ID
@@ -2471,6 +2566,7 @@ mod tests {
             let environment = CString::new("test").unwrap();
             let account = CString::new("testaccount").unwrap();
             let namespace = CString::new("testns").unwrap();
+            let account_group = CString::new("testgroup").unwrap();
             let region = CString::new("testregion").unwrap();
             let tenant = CString::new("testtenant").unwrap();
             let role_name = CString::new("testrole").unwrap();
@@ -2482,6 +2578,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: account_group.as_ptr(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 1, // Certificate auth
@@ -2522,6 +2620,52 @@ mod tests {
         unsafe {
             geneva_batches_free(ptr::null_mut());
         }
+    }
+
+    #[test]
+    fn test_convert_account_group_mapping_success() {
+        let event = CString::new("SecurityEvent").unwrap();
+        let group = CString::new("security").unwrap();
+        let entries = [FfiAccountGroupMapEntry {
+            event_name: event.as_ptr(),
+            account_group: group.as_ptr(),
+        }];
+        let mapping = FfiAccountGroupMapping {
+            entries: entries.as_ptr(),
+            count: entries.len(),
+        };
+
+        let converted =
+            unsafe { convert_account_group_mapping(&mapping) }.expect("conversion should succeed");
+        assert_eq!(
+            converted.get("SecurityEvent").map(String::as_str),
+            Some("security")
+        );
+    }
+
+    #[test]
+    fn test_convert_account_group_mapping_rejects_duplicate_event() {
+        let event = CString::new("SecurityEvent").unwrap();
+        let security = CString::new("security").unwrap();
+        let audit = CString::new("audit").unwrap();
+        let entries = [
+            FfiAccountGroupMapEntry {
+                event_name: event.as_ptr(),
+                account_group: security.as_ptr(),
+            },
+            FfiAccountGroupMapEntry {
+                event_name: event.as_ptr(),
+                account_group: audit.as_ptr(),
+            },
+        ];
+        let mapping = FfiAccountGroupMapping {
+            entries: entries.as_ptr(),
+            count: entries.len(),
+        };
+
+        let error = unsafe { convert_account_group_mapping(&mapping) }
+            .expect_err("duplicate events must be rejected");
+        assert!(error.contains("duplicate event name"));
     }
 
     #[test]
@@ -3097,7 +3241,7 @@ mod tests {
                         }},
                         "StorageAccountKeys": [{{
                             "AccountMonikerName": "testdiagaccount",
-                            "AccountGroupName": "testgroup",
+                            "AccountGroupName": "test-group",
                             "IsPrimaryMoniker": true
                         }}],
                         "TagId": "test"
@@ -3121,6 +3265,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("testgroup"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -3229,7 +3374,7 @@ mod tests {
                         }},
                         "StorageAccountKeys": [{{
                             "AccountMonikerName": "testdiagaccount",
-                            "AccountGroupName": "testgroup",
+                            "AccountGroupName": "test-group",
                             "IsPrimaryMoniker": true
                         }}],
                         "TagId": "test"
@@ -3252,6 +3397,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -3325,17 +3471,26 @@ mod tests {
 
         // Upload all batches
         for i in 0..len {
-            let _ = unsafe {
+            let mut error = [0_i8; 512];
+            let result = unsafe {
                 geneva_upload_batch_sync(
                     handle_ptr,
                     batches_ptr as *const _,
                     i,
-                    ptr::null_mut(),
-                    0,
+                    error.as_mut_ptr(),
+                    error.len(),
                     ptr::null_mut(),
                     ptr::null_mut(),
                 )
             };
+            let message = unsafe { CStr::from_ptr(error.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            assert_eq!(
+                result as u32,
+                GenevaError::Success as u32,
+                "batch upload failed: {message}"
+            );
         }
 
         // Verify requests use the fixed Log table name in their URLs.
@@ -3421,6 +3576,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -3550,6 +3706,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -3725,6 +3882,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -4040,6 +4198,8 @@ mod tests {
                 environment: environment.as_ptr(),
                 account: account.as_ptr(),
                 namespace_name: namespace.as_ptr(),
+                account_group: ptr::null(),
+                account_group_mapping: ptr::null(),
                 region: region.as_ptr(),
                 config_major_version: 1,
                 auth_method: 0, // SystemManagedIdentity - union not used

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -3471,7 +3471,7 @@ mod tests {
 
         // Upload all batches
         for i in 0..len {
-            let mut error = [0_i8; 512];
+            let mut error = [0 as c_char; 512];
             let result = unsafe {
                 geneva_upload_batch_sync(
                     handle_ptr,

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -3218,7 +3218,7 @@ mod tests {
     #[cfg(all(feature = "mock_auth", feature = "otlp_bytes"))]
     fn test_encode_and_upload_with_mock_server() {
         use otlp_builder::builder::build_otlp_logs_minimal;
-        use wiremock::matchers::method;
+        use wiremock::matchers::{method, query_param};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         // Start mock server on the shared runtime used by the FFI code
@@ -3252,9 +3252,11 @@ mod tests {
 
             // Mock ingestion service (POST)
             Mock::given(method("POST"))
+                .and(query_param("moniker", "testdiagaccount"))
                 .respond_with(
                     ResponseTemplate::new(202).set_body_string(r#"{"ticket":"accepted"}"#),
                 )
+                .expect(1)
                 .mount(&mock_server)
                 .await;
         });
@@ -3265,7 +3267,7 @@ mod tests {
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "testns".to_string(),
-            account_routing: AccountRouting::new("testgroup"),
+            account_routing: AccountRouting::new("test-group"),
             region: "testregion".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -3319,8 +3321,7 @@ mod tests {
         let len = unsafe { geneva_batches_len(batches_ptr) };
         assert!(len >= 1, "expected at least one encoded batch");
 
-        // Attempt upload (ignore return code; we will assert via recorded requests)
-        let _ = unsafe {
+        let upload_result = unsafe {
             geneva_upload_batch_sync(
                 handle_ptr,
                 batches_ptr as *const _,
@@ -3331,6 +3332,12 @@ mod tests {
                 ptr::null_mut(),
             )
         };
+        assert_eq!(
+            upload_result as u32,
+            GenevaError::Success as u32,
+            "upload failed"
+        );
+        runtime().block_on(mock_server.verify());
 
         // Cleanup: free batches and client
         unsafe {

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/src/lib.rs
@@ -995,10 +995,8 @@ pub unsafe extern "C" fn geneva_client_new(
         environment,
         account,
         namespace,
-        account_routing: AccountRouting {
-            default_group: account_group,
-            groups_by_event: account_group_mapping,
-        },
+        account_routing: AccountRouting::new(account_group)
+            .with_event_groups(account_group_mapping),
         region,
         config_major_version: config.config_major_version,
         auth_method,

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -6,15 +6,15 @@
 - New `tls-rustls` feature flag enables a pure-Rust TLS backend as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. No built-in crypto provider (e.g. ring) is compiled in; consumers **must** install a `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start. The uploader returns a clear error if no provider is found.
 - New opt-in `certificate-auth` feature enables PKCS#12 client certificate authentication. With `tls-rustls`, legacy PBES1, RC2, and DES-encrypted keystores are not supported.
 - Attribute-based event/table-name routing for logs and spans. `LogsConfig` and `TracesConfig` gained an optional `event_name_mapping` field (`LogsEventNameMapping` / `SpanEventNameMapping`) that routes each record to a destination event/table based on a `routing_key` (logs: event name, resource/scope/log-record attribute; spans: resource/scope/span attribute; plus the reserved `scope.name` / `scope.version` keys) and a source→destination `events` map. Unmapped source values fall back to the configured default event name; entries with an empty destination pass the source value through unchanged. Records/spans are split into one encoded batch per resolved destination. Invalid mappings (empty `events`, blank source keys, or a blank attribute routing-key name) are rejected by `GenevaClient::new`.
-- Agent-fed credential source: `GenevaClient::with_agent_fed_source` builds an uploader that pulls a host-provisioned GIG token and routing (endpoint, moniker) from an `AgentFedCredentialSource` on each upload, skipping the GCS config-service handshake. New public API: `AgentFedCredentialSource`, `AgentFedCredential`, `AgentFedCredentialFuture`.
+- Agent-fed credential source: `GenevaClient::with_agent_fed_source` builds an uploader that pulls a host-provisioned GIG token and routing snapshot (endpoint and account-group-to-moniker map) from an `AgentFedCredentialSource` on each upload, skipping the GCS config-service handshake. New public API: `AgentFedCredentialSource`, `AgentFedCredential`, `AgentFedCredentialFuture`.
+- Native multi-moniker routing. `AccountRouting` defines one required default logical account group and optional exact final-event-name overrides. Encoded batches carry their resolved logical group, and uploads resolve that group through the current GCS snapshot to the corresponding primary physical moniker.
 
 ### Fixed
 - Corrected a misleading startup log message: when `logs.default_event_name` is set without an `event_name_mapping`, `GenevaClient::new` now logs `Configured logs event name routing [default_event_name=...]` instead of `Logs config not initialized; using default values for log events`. The default was always applied correctly; only the log line was wrong. This makes the logs message symmetric with the equivalent spans message.
-
-### Fixed
-- Resolve the GCS ingestion moniker from the primary entry for the exact
-  `<namespace>diag` account group instead of selecting the first physical
-  moniker whose name contains `diag`.
+- Resolve every GCS logical account group to exactly one primary physical
+  moniker instead of inspecting physical moniker names for `diag` or depending
+  on response ordering. Empty group sets and zero or multiple primaries fail
+  explicitly.
 
 ### Changed
 - Certificate authentication is disabled by default. Enable `certificate-auth` explicitly, or use managed identity, workload identity, or agent-fed authentication.
@@ -22,6 +22,10 @@
   credentials in zeroizing secret containers and backing sensitive
   `Authorization` headers with application-owned memory that is zeroized when
   released.
+- **Breaking:** `GenevaClientConfig.account_group` was replaced by required
+  `account_routing: AccountRouting`. The C `GenevaConfig.account_group` is now
+  required and `account_group_mapping` supplies optional final-event-name
+  overrides.
 - Bump opentelemetry-proto version to 0.32.
 - Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
   to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -11,6 +11,11 @@
 ### Fixed
 - Corrected a misleading startup log message: when `logs.default_event_name` is set without an `event_name_mapping`, `GenevaClient::new` now logs `Configured logs event name routing [default_event_name=...]` instead of `Logs config not initialized; using default values for log events`. The default was always applied correctly; only the log line was wrong. This makes the logs message symmetric with the equivalent spans message.
 
+### Fixed
+- Resolve the GCS ingestion moniker from the primary entry for the exact
+  `<namespace>diag` account group instead of selecting the first physical
+  moniker whose name contains `diag`.
+
 ### Changed
 - Certificate authentication is disabled by default. Enable `certificate-auth` explicitly, or use managed identity, workload identity, or agent-fed authentication.
 - Minimize GIG ingestion bearer-token memory remanence by storing resolved

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_advanced.rs
@@ -37,7 +37,7 @@
 //! records will appear in Geneva under the event name `"Log"`.
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
+use geneva_uploader::{AccountRouting, AuthMethod, LogsConfig, TracesConfig};
 use otap_df_pdata_views::views::{
     common::{AnyValueView, AttributeView, InstrumentationScopeView, ValueType},
     logs::{LogRecordView, LogsDataView, ResourceLogsView, ScopeLogsView},
@@ -316,6 +316,7 @@ async fn main() {
     let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT required");
     let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT required");
     let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE required");
+    let account_group = env::var("GENEVA_ACCOUNT_GROUP").ok();
     let region = env::var("GENEVA_REGION").expect("GENEVA_REGION required");
     let cert_path = PathBuf::from(env::var("GENEVA_CERT_PATH").expect("GENEVA_CERT_PATH required"));
     let cert_password = env::var("GENEVA_CERT_PASSWORD").expect("GENEVA_CERT_PASSWORD required");
@@ -334,6 +335,9 @@ async fn main() {
         environment,
         account,
         namespace,
+        account_routing: AccountRouting::new(
+            account_group.expect("GENEVA_ACCOUNT_GROUP must be set"),
+        ),
         region,
         config_major_version,
         auth_method: AuthMethod::Certificate {

--- a/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/examples/view_basic.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
+use geneva_uploader::{AccountRouting, AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, InstrumentationScope, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
@@ -114,6 +114,7 @@ async fn main() {
     let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT required");
     let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT required");
     let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE required");
+    let account_group = env::var("GENEVA_ACCOUNT_GROUP").ok();
     let region = env::var("GENEVA_REGION").expect("GENEVA_REGION required");
     let cert_path = PathBuf::from(env::var("GENEVA_CERT_PATH").expect("GENEVA_CERT_PATH required"));
     let cert_password = env::var("GENEVA_CERT_PASSWORD").expect("GENEVA_CERT_PASSWORD required");
@@ -132,6 +133,9 @@ async fn main() {
         environment,
         account,
         namespace,
+        account_routing: AccountRouting::new(
+            account_group.expect("GENEVA_ACCOUNT_GROUP must be set"),
+        ),
         region,
         config_major_version,
         auth_method: AuthMethod::Certificate {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -26,6 +26,7 @@ use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, Span};
 use otap_df_pdata_views::views::logs::LogsDataView;
 use secrecy::{ExposeSecret, SecretString};
+use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -38,6 +39,7 @@ use tracing::{debug, info};
 #[derive(Debug, Clone, PartialEq)]
 pub struct EncodedBatch {
     pub event_name: String,
+    pub account_group: String,
     pub(crate) data: Vec<u8>,
     pub(crate) metadata: crate::payload_encoder::central_blob::BatchMetadata,
     pub row_count: usize,
@@ -58,6 +60,7 @@ pub struct GenevaClientConfig {
     pub environment: String,
     pub account: String,
     pub namespace: String,
+    pub account_routing: AccountRouting,
     pub region: String,
     pub config_major_version: u32,
     pub auth_method: AuthMethod,
@@ -68,6 +71,50 @@ pub struct GenevaClientConfig {
     pub logs: Option<LogsConfig>,
     pub spans: Option<TracesConfig>,
     pub obo_event_map: Option<OboEventMap>, // Per-event OBO config (None = no OBO)
+}
+
+/// Maps each final Geneva event name to one logical GCS account group.
+#[derive(Clone, Debug)]
+pub struct AccountRouting {
+    pub default_group: String,
+    pub groups_by_event: HashMap<String, String>,
+}
+
+impl AccountRouting {
+    pub fn new(default_group: impl Into<String>) -> Self {
+        Self {
+            default_group: default_group.into(),
+            groups_by_event: HashMap::new(),
+        }
+    }
+
+    pub fn with_event_group(
+        mut self,
+        event_name: impl Into<String>,
+        account_group: impl Into<String>,
+    ) -> Self {
+        self.groups_by_event
+            .insert(event_name.into(), account_group.into());
+        self
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.default_group.trim().is_empty() {
+            return Err("account_routing.default_group must not be empty".to_string());
+        }
+        for (event, group) in &self.groups_by_event {
+            if event.trim().is_empty() || group.trim().is_empty() {
+                return Err("account_routing event and group names must not be empty".to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn group_for_event(&self, event_name: &str) -> &str {
+        self.groups_by_event
+            .get(event_name)
+            .map_or(self.default_group.as_str(), String::as_str)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -109,8 +156,8 @@ pub struct AgentFedCredential {
     token: SecretString,
     /// GIG ingestion endpoint (base URL the upload POSTs to).
     pub endpoint: String,
-    /// Account moniker for the upload.
-    pub moniker: String,
+    /// Primary physical moniker for every logical account group.
+    pub primary_monikers: HashMap<String, String>,
 }
 
 impl AgentFedCredential {
@@ -119,12 +166,12 @@ impl AgentFedCredential {
     pub fn new(
         token: impl Into<SecretString>,
         endpoint: impl Into<String>,
-        moniker: impl Into<String>,
+        primary_monikers: HashMap<String, String>,
     ) -> Self {
         Self {
             token: token.into(),
             endpoint: endpoint.into(),
-            moniker: moniker.into(),
+            primary_monikers,
         }
     }
 
@@ -134,8 +181,8 @@ impl AgentFedCredential {
         self.token.expose_secret()
     }
 
-    pub(crate) fn into_parts(self) -> (SecretString, String, String) {
-        (self.token, self.endpoint, self.moniker)
+    pub(crate) fn into_parts(self) -> (SecretString, String, HashMap<String, String>) {
+        (self.token, self.endpoint, self.primary_monikers)
     }
 }
 
@@ -145,7 +192,7 @@ impl std::fmt::Debug for AgentFedCredential {
         f.debug_struct("AgentFedCredential")
             .field("token", &"<redacted>")
             .field("endpoint", &self.endpoint)
-            .field("moniker", &self.moniker)
+            .field("account_groups", &self.primary_monikers.keys())
             .finish()
     }
 }
@@ -200,6 +247,7 @@ pub struct GenevaClient {
     span_table_name: Arc<str>,
     span_event_name_mapping: Option<SpanEventNameMapping>,
     obo_event_map: Option<OboEventMap>,
+    account_routing: AccountRouting,
 }
 
 /// Stored client pieces shared by every constructor (all of `Self` except the
@@ -211,11 +259,13 @@ struct ClientParts {
     span_event_name_mapping: Option<SpanEventNameMapping>,
     metadata_fields: MetadataFields,
     obo_event_map: Option<OboEventMap>,
+    account_routing: AccountRouting,
 }
 
 impl GenevaClient {
     /// Validate any configured event-name mappings before building the client.
     fn validate_event_name_mappings(cfg: &GenevaClientConfig) -> Result<(), String> {
+        cfg.account_routing.validate()?;
         if let Some(mapping) = cfg
             .logs
             .as_ref()
@@ -246,6 +296,7 @@ impl GenevaClient {
             logs,
             spans,
             obo_event_map,
+            account_routing,
             ..
         } = cfg;
 
@@ -375,6 +426,7 @@ impl GenevaClient {
                 span_event_name_mapping,
                 metadata_fields,
                 obo_event_map,
+                account_routing,
             },
         )
     }
@@ -390,6 +442,7 @@ impl GenevaClient {
             span_table_name: parts.span_table_name,
             span_event_name_mapping: parts.span_event_name_mapping,
             obo_event_map: parts.obo_event_map,
+            account_routing: parts.account_routing,
         }
     }
 
@@ -549,7 +602,8 @@ impl GenevaClient {
             "Encoding and compressing logs"
         );
 
-        self.encoder
+        let mut batches = self
+            .encoder
             .encode_logs_from_view(
                 view,
                 &self.metadata_fields,
@@ -565,7 +619,9 @@ impl GenevaClient {
                     "Logs compression failed"
                 );
                 format!("Compression failed: {e}")
-            })
+            })?;
+        self.assign_account_groups(&mut batches);
+        Ok(batches)
     }
 
     /// Encode OTLP spans into LZ4 chunked compressed batches.
@@ -588,7 +644,7 @@ impl GenevaClient {
                 .iter()
                 .flat_map(|resource_span| &resource_span.scope_spans)
                 .flat_map(|scope_span| &scope_span.spans);
-            return self
+            let mut batches = self
                 .encoder
                 .encode_span_batch(
                     all_spans,
@@ -605,7 +661,9 @@ impl GenevaClient {
                         "Span compression failed"
                     );
                     format!("Compression failed: {e}")
-                });
+                })?;
+            self.assign_account_groups(&mut batches);
+            return Ok(batches);
         };
 
         let mut routed_groups: Vec<(String, Vec<&Span>)> = Vec::new();
@@ -664,7 +722,17 @@ impl GenevaClient {
             batches.extend(encoded);
         }
 
+        self.assign_account_groups(&mut batches);
         Ok(batches)
+    }
+
+    fn assign_account_groups(&self, batches: &mut [EncodedBatch]) {
+        for batch in batches {
+            batch.account_group = self
+                .account_routing
+                .group_for_event(&batch.event_name)
+                .to_string();
+        }
     }
 
     /// Upload a single compressed batch.
@@ -686,6 +754,7 @@ impl GenevaClient {
             .upload(
                 batch.data.clone(),
                 &batch.event_name,
+                &batch.account_group,
                 &batch.metadata,
                 batch.row_count,
                 obo_config,
@@ -740,6 +809,7 @@ mod tests {
             environment: "Test".to_string(),
             account: "acct".to_string(),
             namespace: "ns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "eastus".to_string(),
             config_major_version: 2,
             auth_method: AuthMethod::WorkloadIdentity {
@@ -898,6 +968,53 @@ mod tests {
             Err(err) => err,
         };
         assert!(err.contains("events must be non-empty"));
+    }
+
+    #[test]
+    fn new_rejects_invalid_account_routing() {
+        let mut cfg = build_config(None, None);
+        cfg.account_routing = AccountRouting::new("   ");
+
+        let err = match GenevaClient::new(cfg) {
+            Ok(_) => panic!("blank default account group must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.contains("default_group must not be empty"));
+
+        let mut cfg = build_config(None, None);
+        cfg.account_routing = AccountRouting::new("default").with_event_group("Log", "  ");
+
+        let err = match GenevaClient::new(cfg) {
+            Ok(_) => panic!("blank mapped account group must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.contains("event and group names must not be empty"));
+    }
+
+    #[test]
+    fn encoded_batches_route_final_event_name_to_account_group() {
+        let mut cfg = build_config(Some("SecurityEvent"), None);
+        cfg.account_routing =
+            AccountRouting::new("diagnostics").with_event_group("SecurityEvent", "security");
+        let client = GenevaClient::new(cfg).expect("client should initialize");
+
+        let request = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord::default()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        let bytes = request.encode_to_vec();
+        let batches = client
+            .encode_and_compress_logs(&RawLogsData::new(&bytes))
+            .expect("log encoding should succeed");
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].event_name, "SecurityEvent");
+        assert_eq!(batches[0].account_group, "security");
     }
 
     #[test]
@@ -1475,6 +1592,7 @@ mod tests {
             environment: "Test".to_string(),
             account: "acct".to_string(),
             namespace: "ns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "eastus".to_string(),
             config_major_version: 2,
             auth_method: AuthMethod::WorkloadIdentity {
@@ -1516,6 +1634,7 @@ mod tests {
             environment: "Test".to_string(),
             account: "acct".to_string(),
             namespace: "ns".to_string(),
+            account_routing: AccountRouting::new("test-group"),
             region: "eastus".to_string(),
             config_major_version: 2,
             auth_method: AuthMethod::WorkloadIdentity {
@@ -1562,7 +1681,7 @@ mod tests {
                     Some(AgentFedCredential::new(
                         "secret-token",
                         "https://ingest.example",
-                        "moniker",
+                        HashMap::from([("test-group".to_string(), "moniker".to_string())]),
                     ))
                 })
             }
@@ -1598,7 +1717,11 @@ mod tests {
     /// Guarantees: The bearer token is redacted while routing remains inspectable.
     #[test]
     fn agent_fed_credential_debug_redacts_token() {
-        let cred = AgentFedCredential::new("top-secret", "https://ingest.example", "moniker");
+        let cred = AgentFedCredential::new(
+            "top-secret",
+            "https://ingest.example",
+            HashMap::from([("test-group".to_string(), "moniker".to_string())]),
+        );
         assert_eq!(cred.expose_token(), "top-secret");
         let rendered = format!("{cred:?}");
         assert!(
@@ -1606,6 +1729,6 @@ mod tests {
             "token must be redacted: {rendered}"
         );
         assert!(rendered.contains("<redacted>"));
-        assert!(rendered.contains("moniker"));
+        assert!(rendered.contains("test-group"));
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -74,10 +74,16 @@ pub struct GenevaClientConfig {
 }
 
 /// Maps each final Geneva event name to one logical GCS account group.
+///
+/// Overrides are matched after event-name mapping, so `groups_by_event` keys
+/// must be destination event names rather than source names. Events without an
+/// exact override silently use `default_group`. Give streams that require
+/// different routing distinct destination event names so they cannot fall
+/// through to the default group unintentionally.
 #[derive(Clone, Debug)]
 pub struct AccountRouting {
-    pub default_group: String,
-    pub groups_by_event: HashMap<String, String>,
+    default_group: String,
+    groups_by_event: HashMap<String, String>,
 }
 
 impl AccountRouting {
@@ -95,6 +101,11 @@ impl AccountRouting {
     ) -> Self {
         self.groups_by_event
             .insert(event_name.into(), account_group.into());
+        self
+    }
+
+    pub fn with_event_groups(mut self, map: HashMap<String, String>) -> Self {
+        self.groups_by_event.extend(map);
         self
     }
 
@@ -205,6 +216,8 @@ impl std::fmt::Debug for AgentFedCredential {
 ///   server errors (429, 5xx) from permanent client errors (4xx).
 /// - [`Transport`](UploadError::Transport) indicates a network-level failure
 ///   (timeout, connection refused, DNS) that is typically retriable.
+/// - [`AccountGroupNotResolved`](UploadError::AccountGroupNotResolved) indicates
+///   a permanent routing configuration error.
 /// - [`Other`](UploadError::Other) covers config-service or internal errors.
 #[derive(Debug)]
 pub enum UploadError {
@@ -216,6 +229,13 @@ pub enum UploadError {
     },
     /// Network/transport failure (timeout, connection refused, DNS, etc.)
     Transport(String),
+    /// The configured logical account group was not present in the resolved
+    /// primary-moniker map. This is not retriable without a configuration or
+    /// credential update.
+    AccountGroupNotResolved {
+        requested: String,
+        available: Vec<String>,
+    },
     /// Config service or other internal error.
     Other(String),
 }
@@ -229,6 +249,13 @@ impl fmt::Display for UploadError {
                 write!(f, "upload failed with status {status}: {message}")
             }
             Self::Transport(msg) => write!(f, "transport error: {msg}"),
+            Self::AccountGroupNotResolved {
+                requested,
+                available,
+            } => write!(
+                f,
+                "account group '{requested}' was not resolved; available groups: {available:?}"
+            ),
             Self::Other(msg) => write!(f, "{msg}"),
         }
     }
@@ -726,6 +753,8 @@ impl GenevaClient {
         Ok(batches)
     }
 
+    /// Assigns logical account groups from final, post-mapping event names.
+    /// Events without an exact override silently fall back to the default group.
     fn assign_account_groups(&self, batches: &mut [EncodedBatch]) {
         for batch in batches {
             batch.account_group = self
@@ -787,6 +816,13 @@ impl GenevaClient {
                         message,
                     },
                     GenevaUploaderError::Http(msg) => UploadError::Transport(msg),
+                    GenevaUploaderError::AccountGroupNotResolved {
+                        requested,
+                        available,
+                    } => UploadError::AccountGroupNotResolved {
+                        requested,
+                        available,
+                    },
                     other => UploadError::Other(other.to_string()),
                 }
             })
@@ -989,6 +1025,18 @@ mod tests {
             Err(err) => err,
         };
         assert!(err.contains("event and group names must not be empty"));
+    }
+
+    #[test]
+    fn account_routing_bulk_builder_extends_event_groups() {
+        let routing = AccountRouting::new("default").with_event_groups(HashMap::from([
+            ("SecurityEvent".to_string(), "security".to_string()),
+            ("AuditEvent".to_string(), "audit".to_string()),
+        ]));
+
+        assert_eq!(routing.group_for_event("SecurityEvent"), "security");
+        assert_eq!(routing.group_for_event("AuditEvent"), "audit");
+        assert_eq!(routing.group_for_event("UnmappedEvent"), "default");
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
@@ -1,6 +1,6 @@
 ### GenevaConfigClient Flow (Certificate-Based Authentication)
 
-The diagram below illustrates how the `GenevaConfigClient` is initialized with a client certificate (in PKCS#12 format) and then used to fetch ingestion information from the Geneva Config Service using mutual TLS (mTLS). It includes the flow for loading the certificate, handling cached tokens, making authenticated requests, and parsing the response. The client resolves the ingestion moniker from the primary `StorageAccountKeys` entry whose `AccountGroupName` exactly matches `<namespace>diag` (case-insensitively); physical moniker names are not used to infer the account group.
+The diagram below illustrates how the `GenevaConfigClient` is initialized with a client certificate (in PKCS#12 format) and then used to fetch ingestion information from the Geneva Config Service using mutual TLS (mTLS). It includes the flow for loading the certificate, handling cached tokens, making authenticated requests, and parsing the response. The client resolves the ingestion moniker from the primary `StorageAccountKeys` entry whose `AccountGroupName` exactly and case-sensitively matches the configured logical account group. When no group is configured, selection succeeds only if GCS returns one distinct group. Physical moniker names are never used to infer the account group.
 
 ```mermaid
 sequenceDiagram
@@ -17,16 +17,16 @@ sequenceDiagram
     App->>Client: get_ingestion_info()
 
     alt Token in cache and not expired
-        Client->>App: Return cached (IngestionGatewayInfo, MonikerInfo)
+        Client->>App: Return cached gateway and primary-moniker map
     else Cache miss or token expired
         Client->>Client: Build HTTP GET URL
         Client->>GCS: Send HTTPS request with mTLS\n+ Query Params & Headers
         GCS-->>Client: JSON response (200 OK or error)
 
         alt Response contains valid moniker
-            Client->>Client: Parse IngestionGatewayInfo and MonikerInfo
+            Client->>Client: Parse gateway and validate one primary per account group
             Client->>Client: Cache new token + expiry
-            Client->>App: Return new (IngestionGatewayInfo, MonikerInfo)
+            Client->>App: Return new gateway and primary-moniker map
         else No valid moniker
             Client->>App: Error (MonikerNotFound)
         end

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
@@ -1,6 +1,6 @@
 ### GenevaConfigClient Flow (Certificate-Based Authentication)
 
-The diagram below illustrates how the `GenevaConfigClient` is initialized with a client certificate (in PKCS#12 format) and then used to fetch ingestion information from the Geneva Config Service using mutual TLS (mTLS). It includes the flow for loading the certificate, handling cached tokens, making authenticated requests, and parsing the response (including primary diagnostic monikers).
+The diagram below illustrates how the `GenevaConfigClient` is initialized with a client certificate (in PKCS#12 format) and then used to fetch ingestion information from the Geneva Config Service using mutual TLS (mTLS). It includes the flow for loading the certificate, handling cached tokens, making authenticated requests, and parsing the response. The client resolves the ingestion moniker from the primary `StorageAccountKeys` entry whose `AccountGroupName` exactly matches `<namespace>diag` (case-insensitively); physical moniker names are not used to infer the account group.
 
 ```mermaid
 sequenceDiagram

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/README.md
@@ -1,6 +1,6 @@
 ### GenevaConfigClient Flow (Certificate-Based Authentication)
 
-The diagram below illustrates how the `GenevaConfigClient` is initialized with a client certificate (in PKCS#12 format) and then used to fetch ingestion information from the Geneva Config Service using mutual TLS (mTLS). It includes the flow for loading the certificate, handling cached tokens, making authenticated requests, and parsing the response. The client resolves the ingestion moniker from the primary `StorageAccountKeys` entry whose `AccountGroupName` exactly and case-sensitively matches the configured logical account group. When no group is configured, selection succeeds only if GCS returns one distinct group. Physical moniker names are never used to infer the account group.
+The diagram below illustrates how the `GenevaConfigClient` is initialized with a client certificate (in PKCS#12 format) and then used to fetch ingestion information from the Geneva Config Service using mutual TLS (mTLS). It includes the flow for loading the certificate, handling cached tokens, making authenticated requests, and parsing the response. The client validates that every distinct `StorageAccountKeys[].AccountGroupName` has exactly one primary entry and returns a map of `AccountGroupName` to primary `AccountMonikerName`. Physical moniker names are never used to infer the account group.
 
 ```mermaid
 sequenceDiagram
@@ -23,11 +23,11 @@ sequenceDiagram
         Client->>GCS: Send HTTPS request with mTLS\n+ Query Params & Headers
         GCS-->>Client: JSON response (200 OK or error)
 
-        alt Response contains valid moniker
+        alt Response contains valid account-group monikers
             Client->>Client: Parse gateway and validate one primary per account group
             Client->>Client: Cache new token + expiry
             Client->>App: Return new gateway and primary-moniker map
-        else No valid moniker
+        else Any account group has no primary or multiple primaries
             Client->>App: Error (MonikerNotFound)
         end
     end

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -222,6 +222,32 @@ struct GenevaResponse {
     tag_id: String,
 }
 
+fn select_primary_account(
+    accounts: Vec<StorageAccountKey>,
+    account_group: &str,
+) -> Result<StorageAccountKey> {
+    let mut matches = accounts.into_iter().filter(|account| {
+        account.is_primary_moniker
+            && account
+                .account_group_name
+                .eq_ignore_ascii_case(account_group)
+    });
+
+    let Some(account) = matches.next() else {
+        return Err(GenevaConfigClientError::MonikerNotFound(format!(
+            "No primary moniker found for diagnostics account group '{account_group}'"
+        )));
+    };
+
+    if matches.next().is_some() {
+        return Err(GenevaConfigClientError::MonikerNotFound(format!(
+            "Multiple primary monikers found for diagnostics account group '{account_group}'"
+        )));
+    }
+
+    Ok(account)
+}
+
 #[derive(Debug, Deserialize)]
 struct MsiTokenResponse {
     access_token: String,
@@ -244,6 +270,7 @@ pub(crate) struct GenevaConfigClient {
     // TODO: revisit if the lock can be removed
     cached_data: RwLock<Option<CachedAuthData>>,
     precomputed_url_prefix: String,
+    diagnostics_account_group: String,
     agent_identity: String,
     agent_version: String,
 }
@@ -253,6 +280,7 @@ impl fmt::Debug for GenevaConfigClient {
         f.debug_struct("GenevaConfigClient")
             .field("config", &self.config)
             .field("precomputed_url_prefix", &self.precomputed_url_prefix)
+            .field("diagnostics_account_group", &self.diagnostics_account_group)
             .field("agent_identity", &self.agent_identity)
             .field("agent_version", &self.agent_version)
             .finish()
@@ -449,12 +477,14 @@ impl GenevaConfigClient {
         ).map_err(|e| GenevaConfigClientError::InternalError(format!("Failed to write URL: {e}")))?;
 
         let http_client = client_builder.build()?;
+        let diagnostics_account_group = format!("{}diag", config.namespace);
 
         Ok(Self {
             config,
             http_client,
             cached_data: RwLock::new(None),
             precomputed_url_prefix: pre_url,
+            diagnostics_account_group,
             agent_identity: agent_identity.to_string(), // TODO make this configurable
             agent_version: "1.0".to_string(),           // TODO make this configurable
         })
@@ -994,33 +1024,33 @@ impl GenevaConfigClient {
                 }
             };
 
-            for account in parsed.storage_account_keys {
-                if account.is_primary_moniker && account.account_moniker_name.contains("diag") {
-                    // Move (not clone) the strings out of the StorageAccountKey; no extra allocation
-                    let account_moniker_name = account.account_moniker_name;
-                    let account_group_name = account.account_group_name;
-                    let moniker_info = MonikerInfo {
-                        name: account_moniker_name,
-                        account_group: account_group_name,
-                    };
-                    info!(
-                        name: "config_client.fetch_ingestion_info.success",
-                        target: "geneva-uploader",
-                        moniker = %moniker_info.name,
-                        "Successfully retrieved ingestion info"
-                    );
-                    return Ok((parsed.ingestion_gateway_info, moniker_info));
-                }
-            }
+            let account = select_primary_account(
+                parsed.storage_account_keys,
+                &self.diagnostics_account_group,
+            )
+            .map_err(|error| {
+                debug!(
+                    name: "config_client.fetch_ingestion_info.account_group_error",
+                    target: "geneva-uploader",
+                    account_group = %self.diagnostics_account_group,
+                    error = %error,
+                    "Failed to resolve diagnostics account group"
+                );
+                error
+            })?;
 
-            debug!(
-                name: "config_client.fetch_ingestion_info.no_diag_moniker",
+            let moniker_info = MonikerInfo {
+                name: account.account_moniker_name,
+                account_group: account.account_group_name,
+            };
+            info!(
+                name: "config_client.fetch_ingestion_info.success",
                 target: "geneva-uploader",
-                "No primary diag moniker found in storage accounts"
+                moniker = %moniker_info.name,
+                account_group = %moniker_info.account_group,
+                "Successfully retrieved ingestion info"
             );
-            Err(GenevaConfigClientError::MonikerNotFound(
-                "No primary diag moniker found in storage accounts".to_string(),
-            ))
+            Ok((parsed.ingestion_gateway_info, moniker_info))
         } else {
             debug!(
                 name: "config_client.fetch_ingestion_info.error_status",
@@ -1230,4 +1260,63 @@ fn build_rustls_client_config(
         .map_err(|e| GenevaConfigClientError::Certificate(e.to_string()))?;
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod account_selection_tests {
+    use super::*;
+
+    fn account(group: &str, moniker: &str, is_primary: bool) -> StorageAccountKey {
+        StorageAccountKey {
+            account_moniker_name: moniker.to_string(),
+            account_group_name: group.to_string(),
+            is_primary_moniker: is_primary,
+        }
+    }
+
+    #[test]
+    fn selects_primary_from_exact_account_group() {
+        let selected = select_primary_account(
+            vec![
+                account("other", "contains-diag", true),
+                account("nsdiag", "secondary", false),
+                account("NsDiag", "primary", true),
+            ],
+            "nsdiag",
+        )
+        .expect("matching primary should be selected");
+
+        assert_eq!(selected.account_group_name, "NsDiag");
+        assert_eq!(selected.account_moniker_name, "primary");
+    }
+
+    #[test]
+    fn rejects_missing_primary_for_account_group() {
+        let error = select_primary_account(
+            vec![
+                account("nsdiag", "secondary", false),
+                account("other", "contains-diag", true),
+            ],
+            "nsdiag",
+        )
+        .expect_err("a secondary or unrelated moniker must not be selected");
+
+        assert!(error.to_string().contains("No primary moniker found"));
+    }
+
+    #[test]
+    fn rejects_ambiguous_primary_for_account_group() {
+        let error = select_primary_account(
+            vec![
+                account("nsdiag", "primary-a", true),
+                account("NSDIAG", "primary-b", true),
+            ],
+            "nsdiag",
+        )
+        .expect_err("multiple primaries must not be response-order-dependent");
+
+        assert!(error
+            .to_string()
+            .contains("Multiple primary monikers found"));
+    }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -20,6 +20,7 @@ use chrono::{DateTime, Utc};
     not(feature = "tls-rustls")
 ))]
 use native_tls::{Identity, Protocol};
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Write;
 #[cfg(feature = "certificate-auth")]
@@ -192,13 +193,6 @@ pub(crate) struct IngestionGatewayInfo {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub(crate) struct MonikerInfo {
-    pub name: String,
-    pub account_group: String,
-}
-
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct StorageAccountKey {
     #[serde(rename = "AccountMonikerName")]
@@ -222,30 +216,41 @@ struct GenevaResponse {
     tag_id: String,
 }
 
-fn select_primary_account(
-    accounts: Vec<StorageAccountKey>,
-    account_group: &str,
-) -> Result<StorageAccountKey> {
-    let mut matches = accounts.into_iter().filter(|account| {
-        account.is_primary_moniker
-            && account
-                .account_group_name
-                .eq_ignore_ascii_case(account_group)
-    });
-
-    let Some(account) = matches.next() else {
-        return Err(GenevaConfigClientError::MonikerNotFound(format!(
-            "No primary moniker found for diagnostics account group '{account_group}'"
-        )));
-    };
-
-    if matches.next().is_some() {
-        return Err(GenevaConfigClientError::MonikerNotFound(format!(
-            "Multiple primary monikers found for diagnostics account group '{account_group}'"
-        )));
+fn select_primary_monikers(accounts: Vec<StorageAccountKey>) -> Result<HashMap<String, String>> {
+    let mut groups: HashMap<String, Vec<StorageAccountKey>> = HashMap::new();
+    for account in accounts {
+        groups
+            .entry(account.account_group_name.clone())
+            .or_default()
+            .push(account);
+    }
+    if groups.is_empty() {
+        return Err(GenevaConfigClientError::MonikerNotFound(
+            "GCS returned no account groups".to_string(),
+        ));
     }
 
-    Ok(account)
+    let mut primary_monikers = HashMap::with_capacity(groups.len());
+    for (group, entries) in groups {
+        let mut primaries = entries.into_iter().filter(|entry| entry.is_primary_moniker);
+        let primary = primaries.next().ok_or_else(|| {
+            GenevaConfigClientError::MonikerNotFound(format!(
+                "No primary moniker found for account group '{group}'"
+            ))
+        })?;
+        if primaries.next().is_some() {
+            return Err(GenevaConfigClientError::MonikerNotFound(format!(
+                "Multiple primary monikers found for account group '{group}'"
+            )));
+        }
+        if primary.account_moniker_name.trim().is_empty() {
+            return Err(GenevaConfigClientError::MonikerNotFound(format!(
+                "Primary moniker for account group '{group}' is empty"
+            )));
+        }
+        primary_monikers.insert(group, primary.account_moniker_name);
+    }
+    Ok(primary_monikers)
 }
 
 #[derive(Debug, Deserialize)]
@@ -256,7 +261,7 @@ struct MsiTokenResponse {
 #[allow(dead_code)]
 struct CachedAuthData {
     // Store the complete token and moniker info
-    auth_info: (IngestionGatewayInfo, MonikerInfo),
+    auth_info: (IngestionGatewayInfo, HashMap<String, String>),
     // Store the endpoint from token for quick access
     token_endpoint: String,
     // Store expiry separately for quick access
@@ -270,7 +275,6 @@ pub(crate) struct GenevaConfigClient {
     // TODO: revisit if the lock can be removed
     cached_data: RwLock<Option<CachedAuthData>>,
     precomputed_url_prefix: String,
-    diagnostics_account_group: String,
     agent_identity: String,
     agent_version: String,
 }
@@ -280,7 +284,6 @@ impl fmt::Debug for GenevaConfigClient {
         f.debug_struct("GenevaConfigClient")
             .field("config", &self.config)
             .field("precomputed_url_prefix", &self.precomputed_url_prefix)
-            .field("diagnostics_account_group", &self.diagnostics_account_group)
             .field("agent_identity", &self.agent_identity)
             .field("agent_version", &self.agent_version)
             .finish()
@@ -477,14 +480,11 @@ impl GenevaConfigClient {
         ).map_err(|e| GenevaConfigClientError::InternalError(format!("Failed to write URL: {e}")))?;
 
         let http_client = client_builder.build()?;
-        let diagnostics_account_group = format!("{}diag", config.namespace);
-
         Ok(Self {
             config,
             http_client,
             cached_data: RwLock::new(None),
             precomputed_url_prefix: pre_url,
-            diagnostics_account_group,
             agent_identity: agent_identity.to_string(), // TODO make this configurable
             agent_version: "1.0".to_string(),           // TODO make this configurable
         })
@@ -841,7 +841,7 @@ impl GenevaConfigClient {
     #[allow(dead_code)]
     pub(crate) async fn get_ingestion_info(
         &self,
-    ) -> Result<(IngestionGatewayInfo, MonikerInfo, String)> {
+    ) -> Result<(IngestionGatewayInfo, HashMap<String, String>, String)> {
         debug!(
             name: "config_client.get_ingestion_info",
             target: "geneva-uploader",
@@ -875,7 +875,7 @@ impl GenevaConfigClient {
         }
         // Cache miss or expired token, fetch fresh data
         // Perform actual fetch before acquiring write lock to minimize lock contention
-        let (fresh_ingestion_gateway_info, fresh_moniker_info) =
+        let (fresh_ingestion_gateway_info, fresh_primary_monikers) =
             self.fetch_ingestion_info().await?;
 
         let token_expiry =
@@ -920,7 +920,7 @@ impl GenevaConfigClient {
         *guard = Some(CachedAuthData {
             auth_info: (
                 fresh_ingestion_gateway_info.clone(),
-                fresh_moniker_info.clone(),
+                fresh_primary_monikers.clone(),
             ),
             token_endpoint: token_endpoint.clone(),
             token_expiry,
@@ -928,13 +928,15 @@ impl GenevaConfigClient {
 
         Ok((
             fresh_ingestion_gateway_info,
-            fresh_moniker_info,
+            fresh_primary_monikers,
             token_endpoint,
         ))
     }
 
     /// Internal method that actually fetches data from Geneva Config Service
-    async fn fetch_ingestion_info(&self) -> Result<(IngestionGatewayInfo, MonikerInfo)> {
+    async fn fetch_ingestion_info(
+        &self,
+    ) -> Result<(IngestionGatewayInfo, HashMap<String, String>)> {
         info!(
             name: "config_client.fetch_ingestion_info",
             target: "geneva-uploader",
@@ -1024,33 +1026,14 @@ impl GenevaConfigClient {
                 }
             };
 
-            let account = select_primary_account(
-                parsed.storage_account_keys,
-                &self.diagnostics_account_group,
-            )
-            .map_err(|error| {
-                debug!(
-                    name: "config_client.fetch_ingestion_info.account_group_error",
-                    target: "geneva-uploader",
-                    account_group = %self.diagnostics_account_group,
-                    error = %error,
-                    "Failed to resolve diagnostics account group"
-                );
-                error
-            })?;
-
-            let moniker_info = MonikerInfo {
-                name: account.account_moniker_name,
-                account_group: account.account_group_name,
-            };
+            let primary_monikers = select_primary_monikers(parsed.storage_account_keys)?;
             info!(
                 name: "config_client.fetch_ingestion_info.success",
                 target: "geneva-uploader",
-                moniker = %moniker_info.name,
-                account_group = %moniker_info.account_group,
+                account_group_count = primary_monikers.len(),
                 "Successfully retrieved ingestion info"
             );
-            Ok((parsed.ingestion_gateway_info, moniker_info))
+            Ok((parsed.ingestion_gateway_info, primary_monikers))
         } else {
             debug!(
                 name: "config_client.fetch_ingestion_info.error_status",
@@ -1275,30 +1258,27 @@ mod account_selection_tests {
     }
 
     #[test]
-    fn selects_primary_from_exact_account_group() {
-        let selected = select_primary_account(
-            vec![
-                account("other", "contains-diag", true),
-                account("nsdiag", "secondary", false),
-                account("NsDiag", "primary", true),
-            ],
-            "nsdiag",
-        )
-        .expect("matching primary should be selected");
+    fn selects_one_primary_for_every_exact_account_group() {
+        let selected = select_primary_monikers(vec![
+            account("other", "contains-diag", true),
+            account("NsDiag", "secondary", false),
+            account("NsDiag", "primary", true),
+        ])
+        .expect("all groups should be resolved");
 
-        assert_eq!(selected.account_group_name, "NsDiag");
-        assert_eq!(selected.account_moniker_name, "primary");
+        assert_eq!(selected.get("NsDiag").map(String::as_str), Some("primary"));
+        assert_eq!(
+            selected.get("other").map(String::as_str),
+            Some("contains-diag")
+        );
     }
 
     #[test]
     fn rejects_missing_primary_for_account_group() {
-        let error = select_primary_account(
-            vec![
-                account("nsdiag", "secondary", false),
-                account("other", "contains-diag", true),
-            ],
-            "nsdiag",
-        )
+        let error = select_primary_monikers(vec![
+            account("nsdiag", "secondary", false),
+            account("other", "contains-diag", true),
+        ])
         .expect_err("a secondary or unrelated moniker must not be selected");
 
         assert!(error.to_string().contains("No primary moniker found"));
@@ -1306,17 +1286,26 @@ mod account_selection_tests {
 
     #[test]
     fn rejects_ambiguous_primary_for_account_group() {
-        let error = select_primary_account(
-            vec![
-                account("nsdiag", "primary-a", true),
-                account("NSDIAG", "primary-b", true),
-            ],
-            "nsdiag",
-        )
+        let error = select_primary_monikers(vec![
+            account("nsdiag", "primary-a", true),
+            account("nsdiag", "primary-b", true),
+        ])
         .expect_err("multiple primaries must not be response-order-dependent");
 
         assert!(error
             .to_string()
             .contains("Multiple primary monikers found"));
+    }
+
+    #[test]
+    fn preserves_case_distinct_account_groups() {
+        let selected = select_primary_monikers(vec![
+            account("NsDiag", "upper", true),
+            account("nsdiag", "lower", true),
+        ])
+        .expect("case-distinct groups must remain distinct");
+
+        assert_eq!(selected.get("NsDiag").map(String::as_str), Some("upper"));
+        assert_eq!(selected.get("nsdiag").map(String::as_str), Some("lower"));
     }
 }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/client.rs
@@ -831,7 +831,9 @@ impl GenevaConfigClient {
     /// Uses mutual TLS (mTLS) with client certificate authentication
     ///
     /// # Returns
-    /// * `Result<IngestionGatewayInfo, MonikerInfo>` - Ingestion gateway information, with storage monikers or an error
+    /// * `Result<(IngestionGatewayInfo, HashMap<String, String>, String)>` - Ingestion
+    ///   gateway information, the logical-account-group to primary-moniker map, and
+    ///   the endpoint query parameter, or an error
     ///
     /// # Errors
     /// * `GenevaConfigClientError::Http` - If the HTTP request fails

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -427,7 +427,7 @@ mod tests {
                 },
                 {
                     "AccountMonikerName": "mock-diag-secondary",
-                    "AccountGroupName": "mocknsdiag",
+                    "AccountGroupName": "MockNsDiag",
                     "IsPrimaryMoniker": false
                 },
                 {
@@ -491,8 +491,10 @@ mod tests {
         );
 
         // Check moniker info
-        assert_eq!(moniker_info.name, "mock-diag-moniker");
-        assert_eq!(moniker_info.account_group, "MockNsDiag");
+        assert_eq!(
+            moniker_info.get("MockNsDiag").map(String::as_str),
+            Some("mock-diag-moniker")
+        );
         assert_eq!(token_endpoint, jwt_endpoint);
     }
 
@@ -562,7 +564,10 @@ mod tests {
 
         assert_eq!(ingestion_info.endpoint, "https://mock.ingestion.endpoint");
         assert_eq!(ingestion_info.auth_token.expose_secret(), valid_token);
-        assert_eq!(moniker_info.name, "mock-diag-moniker");
+        assert_eq!(
+            moniker_info.get("MockNsDiag").map(String::as_str),
+            Some("mock-diag-moniker")
+        );
         assert_eq!(token_endpoint, jwt_endpoint);
     }
 
@@ -712,8 +717,10 @@ mod tests {
             ingestion_info.auth_token_expiry_time,
             "2030-01-01T00:00:00Z"
         );
-        assert_eq!(moniker_info.name, "mock-diag-moniker");
-        assert_eq!(moniker_info.account_group, "MockNsDiag");
+        assert_eq!(
+            moniker_info.get("MockNsDiag").map(String::as_str),
+            Some("mock-diag-moniker")
+        );
         assert_eq!(token_endpoint, jwt_endpoint);
         tls_server.handle.join().unwrap();
     }
@@ -926,17 +933,16 @@ mod tests {
             !ingestion_info.auth_token.expose_secret().is_empty(),
             "Auth token should not be empty"
         );
-        assert!(!moniker.name.is_empty(), "Moniker name should not be empty");
         assert!(
-            !moniker.account_group.is_empty(),
-            "Moniker account group should not be empty"
+            !moniker.is_empty(),
+            "Primary moniker map should not be empty"
         );
 
         println!("Successfully connected to real server");
         println!("Endpoint: {}", ingestion_info.endpoint);
         let token_len = ingestion_info.auth_token.expose_secret().len();
         println!("Auth token length: {token_len}");
-        println!("Moniker name: {}", moniker.name);
+        println!("Primary account groups: {:?}", moniker.keys());
     }
 
     mod extract_endpoint_from_token_tests {

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/config_service/mod.rs
@@ -421,8 +421,18 @@ mod tests {
             },
             "StorageAccountKeys": [
                 {
+                    "AccountMonikerName": "wrong-diag-moniker",
+                    "AccountGroupName": "unrelated-group",
+                    "IsPrimaryMoniker": true
+                },
+                {
+                    "AccountMonikerName": "mock-diag-secondary",
+                    "AccountGroupName": "mocknsdiag",
+                    "IsPrimaryMoniker": false
+                },
+                {
                     "AccountMonikerName": "mock-diag-moniker",
-                    "AccountGroupName": "mock-diag-group",
+                    "AccountGroupName": "MockNsDiag",
                     "IsPrimaryMoniker": true
                 }
             ],
@@ -482,7 +492,7 @@ mod tests {
 
         // Check moniker info
         assert_eq!(moniker_info.name, "mock-diag-moniker");
-        assert_eq!(moniker_info.account_group, "mock-diag-group");
+        assert_eq!(moniker_info.account_group, "MockNsDiag");
         assert_eq!(token_endpoint, jwt_endpoint);
     }
 
@@ -703,7 +713,7 @@ mod tests {
             "2030-01-01T00:00:00Z"
         );
         assert_eq!(moniker_info.name, "mock-diag-moniker");
-        assert_eq!(moniker_info.account_group, "mock-diag-group");
+        assert_eq!(moniker_info.account_group, "MockNsDiag");
         assert_eq!(token_endpoint, jwt_endpoint);
         tls_server.handle.join().unwrap();
     }

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/mod.rs
@@ -17,6 +17,7 @@ mod tests {
             pub data: Vec<u8>,
             pub uploader: GenevaUploader,
             pub event_name: String,
+            pub account_group: String,
         }
 
         pub async fn build_test_upload_context() -> TestUploadContext {
@@ -31,6 +32,8 @@ mod tests {
                 env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT is required");
             let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT is required");
             let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE is required");
+            let account_group =
+                env::var("GENEVA_ACCOUNT_GROUP").expect("GENEVA_ACCOUNT_GROUP is required");
             let region = env::var("GENEVA_REGION").expect("GENEVA_REGION is required");
             let cert_path = std::path::PathBuf::from(
                 std::env::var("GENEVA_CERT_PATH").expect("GENEVA_CERT_PATH is required"),
@@ -83,6 +86,7 @@ mod tests {
                 data,
                 uploader,
                 event_name,
+                account_group,
             }
         }
     }
@@ -129,7 +133,14 @@ mod tests {
 
         let response = ctx
             .uploader
-            .upload(ctx.data, &ctx.event_name, &metadata, 1, None)
+            .upload(
+                ctx.data,
+                &ctx.event_name,
+                &ctx.account_group,
+                &metadata,
+                1,
+                None,
+            )
             .await
             .expect("Upload failed");
 
@@ -196,7 +207,14 @@ mod tests {
 
         let _ = ctx
             .uploader
-            .upload(ctx.data.clone(), &ctx.event_name, &warmup_metadata, 1, None)
+            .upload(
+                ctx.data.clone(),
+                &ctx.event_name,
+                &ctx.account_group,
+                &warmup_metadata,
+                1,
+                None,
+            )
             .await
             .expect("Warm-up upload failed");
         let warmup_elapsed = start_warmup.elapsed();
@@ -211,6 +229,7 @@ mod tests {
             let uploader = ctx.uploader.clone();
             let data = ctx.data.clone();
             let event_name = ctx.event_name.to_string();
+            let account_group = ctx.account_group.clone();
             let handle = tokio::spawn(async move {
                 let start = Instant::now();
 
@@ -222,7 +241,7 @@ mod tests {
                 };
 
                 let resp = uploader
-                    .upload(data, &event_name, &metadata, 1, None)
+                    .upload(data, &event_name, &account_group, &metadata, 1, None)
                     .await
                     .unwrap_or_else(|_| panic!("Upload {i} failed"));
                 let elapsed = start.elapsed();

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -29,6 +29,11 @@ pub(crate) enum GenevaUploaderError {
     ConfigClient(String),
     #[error("Agent-fed credential not provisioned: {0}")]
     CredentialNotProvisioned(String),
+    #[error("Account group '{requested}' was not resolved; available groups: {available:?}")]
+    AccountGroupNotResolved {
+        requested: String,
+        available: Vec<String>,
+    },
     #[allow(dead_code)]
     #[error("Upload failed with status {status}: {message}")]
     UploadFailed {
@@ -377,9 +382,12 @@ impl GenevaUploader {
             endpoint_query_param,
         } = self.source.resolve().await?;
         let moniker = primary_monikers.get(account_group).ok_or_else(|| {
-            GenevaUploaderError::InternalError(format!(
-                "No primary moniker is available for account group '{account_group}'"
-            ))
+            let mut available: Vec<_> = primary_monikers.keys().cloned().collect();
+            available.sort();
+            GenevaUploaderError::AccountGroupNotResolved {
+                requested: account_group.to_string(),
+                available,
+            }
         })?;
         let data_size = data.len();
         let upload_uri = self.create_upload_uri(
@@ -782,6 +790,33 @@ mod tests {
             matches!(err, GenevaUploaderError::CredentialNotProvisioned(_)),
             "expected CredentialNotProvisioned, got: {err:?}"
         );
+    }
+
+    /// Scenario: A batch targets a logical group absent from the current credential.
+    /// Guarantees: The permanent routing error names the requested group and reports
+    /// available groups in deterministic order without attempting an upload.
+    #[tokio::test]
+    async fn agent_fed_upload_reports_unresolved_account_group() {
+        let source = Arc::new(TestAgentFedSource::new(
+            "token",
+            "https://unused.example",
+            "moniker",
+        ));
+        let uploader = agent_fed_uploader(source);
+        let metadata = make_test_metadata();
+
+        let error = uploader
+            .upload(vec![1], "Log", "missing-group", &metadata, 1, None)
+            .await
+            .expect_err("an unknown logical account group must fail");
+
+        assert!(matches!(
+            error,
+            GenevaUploaderError::AccountGroupNotResolved {
+                requested,
+                available,
+            } if requested == "missing-group" && available == ["test-group"]
+        ));
     }
 
     /// Scenario: The agent-fed token carries an Endpoint claim.

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/ingestion_service/uploader.rs
@@ -133,7 +133,7 @@ pub(crate) enum IngestionSource {
 struct ResolvedIngestion {
     token: SecretString,
     gig_endpoint: String,
-    moniker: String,
+    primary_monikers: HashMap<String, String>,
     endpoint_query_param: String,
 }
 
@@ -169,12 +169,12 @@ impl IngestionSource {
     async fn resolve(&self) -> Result<ResolvedIngestion> {
         match self {
             IngestionSource::ConfigClient(config_client) => {
-                let (auth_info, moniker_info, endpoint_query_param) =
+                let (auth_info, primary_monikers, endpoint_query_param) =
                     config_client.get_ingestion_info().await?;
                 Ok(ResolvedIngestion {
                     token: auth_info.auth_token,
                     gig_endpoint: auth_info.endpoint,
-                    moniker: moniker_info.name,
+                    primary_monikers,
                     endpoint_query_param,
                 })
             }
@@ -195,11 +195,11 @@ impl IngestionSource {
                 // credential's own endpoint rather than rejecting the upload.
                 let endpoint_query_param = extract_endpoint_from_token(cred.expose_token())
                     .unwrap_or_else(|_| cred.endpoint.clone());
-                let (token, gig_endpoint, moniker) = cred.into_parts();
+                let (token, gig_endpoint, primary_monikers) = cred.into_parts();
                 Ok(ResolvedIngestion {
                     token,
                     gig_endpoint,
-                    moniker,
+                    primary_monikers,
                     endpoint_query_param,
                 })
             }
@@ -354,6 +354,7 @@ impl GenevaUploader {
         &self,
         data: Vec<u8>,
         event_name: &str,
+        account_group: &str,
         metadata: &BatchMetadata,
         row_count: usize,
         obo_config: Option<&crate::payload_encoder::otlp_encoder::OboEventConfig>,
@@ -372,13 +373,18 @@ impl GenevaUploader {
         let ResolvedIngestion {
             token: auth_token,
             gig_endpoint,
-            moniker,
+            primary_monikers,
             endpoint_query_param,
         } = self.source.resolve().await?;
+        let moniker = primary_monikers.get(account_group).ok_or_else(|| {
+            GenevaUploaderError::InternalError(format!(
+                "No primary moniker is available for account group '{account_group}'"
+            ))
+        })?;
         let data_size = data.len();
         let upload_uri = self.create_upload_uri(
             &endpoint_query_param,
-            &moniker,
+            moniker,
             data_size,
             event_name,
             metadata,
@@ -392,6 +398,7 @@ impl GenevaUploader {
             target: "geneva-uploader",
             event_name = %event_name,
             moniker = %moniker,
+            account_group = %account_group,
             "Posting to ingestion gateway"
         );
 
@@ -630,7 +637,7 @@ mod tests {
             let cred = crate::client::AgentFedCredential::new(
                 self.token.lock().unwrap().clone(),
                 self.endpoint.clone(),
-                self.moniker.clone(),
+                HashMap::from([("test-group".to_string(), self.moniker.clone())]),
             );
             Box::pin(async move { Some(cred) })
         }
@@ -713,7 +720,7 @@ mod tests {
         let metadata = make_test_metadata();
 
         let resp = uploader
-            .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
+            .upload(vec![1, 2, 3], "Log", "test-group", &metadata, 1, None)
             .await;
         assert!(resp.is_ok(), "agent-fed upload should succeed: {resp:?}");
         // mock_server drop verifies exactly one POST carrying the host token.
@@ -749,13 +756,13 @@ mod tests {
         let metadata = make_test_metadata();
 
         uploader
-            .upload(vec![1], "Log", &metadata, 1, None)
+            .upload(vec![1], "Log", "test-group", &metadata, 1, None)
             .await
             .expect("upload A");
         // Host rotates the credential; the next upload must use the new token.
         source.set_token(token_b);
         uploader
-            .upload(vec![2], "Log", &metadata, 1, None)
+            .upload(vec![2], "Log", "test-group", &metadata, 1, None)
             .await
             .expect("upload B");
         // Both `.expect(1)` mocks verify each token was used exactly once.
@@ -767,7 +774,9 @@ mod tests {
     async fn agent_fed_upload_errors_when_not_provisioned() {
         let uploader = agent_fed_uploader(Arc::new(EmptyAgentFedSource));
         let metadata = make_test_metadata();
-        let resp = uploader.upload(vec![1], "Log", &metadata, 1, None).await;
+        let resp = uploader
+            .upload(vec![1], "Log", "test-group", &metadata, 1, None)
+            .await;
         let err = resp.expect_err("upload must error when no credential is provisioned");
         assert!(
             matches!(err, GenevaUploaderError::CredentialNotProvisioned(_)),
@@ -801,7 +810,7 @@ mod tests {
         let uploader = agent_fed_uploader(source);
         let metadata = make_test_metadata();
         let resp = uploader
-            .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
+            .upload(vec![1, 2, 3], "Log", "test-group", &metadata, 1, None)
             .await;
         assert!(
             resp.is_ok(),
@@ -833,7 +842,7 @@ mod tests {
         let uploader = agent_fed_uploader(source);
         let metadata = make_test_metadata();
         let resp = uploader
-            .upload(vec![1, 2, 3], "Log", &metadata, 1, None)
+            .upload(vec![1, 2, 3], "Log", "test-group", &metadata, 1, None)
             .await;
         assert!(
             resp.is_ok(),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/lib.rs
@@ -18,7 +18,9 @@ pub(crate) use ingestion_service::uploader::{
 };
 
 pub use client::EncodedBatch;
-pub use client::{AgentFedCredential, AgentFedCredentialFuture, AgentFedCredentialSource};
+pub use client::{
+    AccountRouting, AgentFedCredential, AgentFedCredentialFuture, AgentFedCredentialSource,
+};
 pub use client::{
     GenevaClient, GenevaClientConfig, LogsConfig, LogsEventNameMapping, LogsEventNameRoutingKey,
     SpanEventNameMapping, SpanEventNameRoutingKey, TracesConfig, UploadError,

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -971,6 +971,7 @@ impl LogBatchAccumulator {
 
             blobs.push(EncodedBatch {
                 event_name: batch_event_name.to_string(),
+                account_group: String::new(),
                 data: compressed,
                 metadata: BatchMetadata {
                     start_time: if batch_data.metadata.start_time == u64::MAX {
@@ -1193,6 +1194,7 @@ impl OtlpEncoder {
 
         Ok(vec![EncodedBatch {
             event_name: table_name.to_string(),
+            account_group: String::new(),
             data: compressed,
             metadata: batch_metadata,
             row_count: events_count,

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -1,5 +1,7 @@
 use geneva_test_server::testing::TestServer;
-use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig};
+use geneva_uploader::{
+    AccountRouting, AuthMethod, GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig,
+};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value::Value, AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
@@ -16,6 +18,7 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
         environment: "testenv".to_string(),
         account: "testaccount".to_string(),
         namespace: "TestNamespace".to_string(),
+        account_routing: AccountRouting::new("diag-test-account-group"),
         region: "testregion".to_string(),
         config_major_version: 1,
         auth_method: AuthMethod::MockAuth,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/README.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/README.md
@@ -237,7 +237,7 @@ Expected log output should show:
 | `GENEVA_ENVIRONMENT` | Environment name in Geneva | `Test` |
 | `GENEVA_ACCOUNT` | Geneva monitoring account | `PipelineAgent2Demo` |
 | `GENEVA_NAMESPACE` | Geneva namespace | `PAdemo2` |
-| `GENEVA_ACCOUNT_GROUP` | Logical GCS account group; may be omitted only when GCS returns one group | `pademo2diag` |
+| `GENEVA_ACCOUNT_GROUP` | Logical GCS account group (required) | `pademo2diag` |
 | `GENEVA_REGION` | Azure region | `eastus` |
 | `GENEVA_CONFIG_MAJOR_VERSION` | Config schema version | `2` |
 | `MONITORING_GCS_AUTH_ID_TYPE` | Authentication type | `AuthWorkloadIdentity` |

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/README.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/README.md
@@ -149,6 +149,7 @@ data:
   GENEVA_ENVIRONMENT: "Test"  # Your environment name
   GENEVA_ACCOUNT: "PipelineAgent2Demo"  # Your Geneva account
   GENEVA_NAMESPACE: "PAdemo2"  # Your Geneva namespace
+  GENEVA_ACCOUNT_GROUP: "pademo2diag"  # Logical GCS account group
   GENEVA_REGION: "eastus"  # Your Azure region
   GENEVA_CONFIG_MAJOR_VERSION: "2"
   MONITORING_GCS_AUTH_ID_TYPE: "AuthWorkloadIdentity"
@@ -236,6 +237,7 @@ Expected log output should show:
 | `GENEVA_ENVIRONMENT` | Environment name in Geneva | `Test` |
 | `GENEVA_ACCOUNT` | Geneva monitoring account | `PipelineAgent2Demo` |
 | `GENEVA_NAMESPACE` | Geneva namespace | `PAdemo2` |
+| `GENEVA_ACCOUNT_GROUP` | Logical GCS account group; may be omitted only when GCS returns one group | `pademo2diag` |
 | `GENEVA_REGION` | Azure region | `eastus` |
 | `GENEVA_CONFIG_MAJOR_VERSION` | Config schema version | `2` |
 | `MONITORING_GCS_AUTH_ID_TYPE` | Authentication type | `AuthWorkloadIdentity` |
@@ -357,4 +359,3 @@ az identity delete \
 
 - [Azure Workload Identity Documentation](https://azure.github.io/azure-workload-identity/)
 - [AKS Workload Identity Overview](https://learn.microsoft.com/azure/aks/workload-identity-overview)
-

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic.rs
@@ -27,7 +27,7 @@
 //! ```
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
+use geneva_uploader::{AccountRouting, AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -60,6 +60,7 @@ async fn main() {
     let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT is required");
     let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT is required");
     let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE is required");
+    let account_group = env::var("GENEVA_ACCOUNT_GROUP").ok();
     let region = env::var("GENEVA_REGION").expect("GENEVA_REGION is required");
     let cert_path =
         PathBuf::from(env::var("GENEVA_CERT_PATH").expect("GENEVA_CERT_PATH is required"));
@@ -79,6 +80,9 @@ async fn main() {
         environment,
         account,
         namespace,
+        account_routing: AccountRouting::new(
+            account_group.expect("GENEVA_ACCOUNT_GROUP must be set"),
+        ),
         region,
         config_major_version,
         auth_method: AuthMethod::Certificate {

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_msi_test.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic_msi_test`
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
+use geneva_uploader::{AccountRouting, AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -41,6 +41,7 @@ async fn main() {
     let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT is required");
     let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT is required");
     let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE is required");
+    let account_group = env::var("GENEVA_ACCOUNT_GROUP").ok();
     let region = env::var("GENEVA_REGION").expect("GENEVA_REGION is required");
     let config_major_version: u32 = env::var("GENEVA_CONFIG_MAJOR_VERSION")
         .expect("GENEVA_CONFIG_MAJOR_VERSION is required")
@@ -98,6 +99,9 @@ async fn main() {
         environment,
         account,
         namespace,
+        account_routing: AccountRouting::new(
+            account_group.expect("GENEVA_ACCOUNT_GROUP must be set"),
+        ),
         region,
         config_major_version,
         tenant,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/basic_workload_identity_test.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic_workload_identity_test`
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
+use geneva_uploader::{AccountRouting, AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_exporter_geneva::GenevaExporter;
 use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
@@ -43,6 +43,7 @@ async fn main() {
     let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT is required");
     let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT is required");
     let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE is required");
+    let account_group = env::var("GENEVA_ACCOUNT_GROUP").ok();
     let region = env::var("GENEVA_REGION").expect("GENEVA_REGION is required");
     let config_major_version: u32 = env::var("GENEVA_CONFIG_MAJOR_VERSION")
         .expect("GENEVA_CONFIG_MAJOR_VERSION is required")
@@ -77,6 +78,9 @@ async fn main() {
         environment,
         account,
         namespace,
+        account_routing: AccountRouting::new(
+            account_group.expect("GENEVA_ACCOUNT_GROUP must be set"),
+        ),
         region,
         config_major_version,
         tenant,

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/examples/trace_basic.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example trace_basic
 
 use geneva_uploader::client::{GenevaClient, GenevaClientConfig};
-use geneva_uploader::{AuthMethod, LogsConfig, TracesConfig};
+use geneva_uploader::{AccountRouting, AuthMethod, LogsConfig, TracesConfig};
 use opentelemetry::{global, trace::Tracer, KeyValue};
 use opentelemetry_exporter_geneva::GenevaTraceExporter;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SimpleSpanProcessor};
@@ -28,6 +28,7 @@ async fn main() {
     let environment = env::var("GENEVA_ENVIRONMENT").expect("GENEVA_ENVIRONMENT is required");
     let account = env::var("GENEVA_ACCOUNT").expect("GENEVA_ACCOUNT is required");
     let namespace = env::var("GENEVA_NAMESPACE").expect("GENEVA_NAMESPACE is required");
+    let account_group = env::var("GENEVA_ACCOUNT_GROUP").ok();
     let region = env::var("GENEVA_REGION").expect("GENEVA_REGION is required");
     let cert_path =
         PathBuf::from(env::var("GENEVA_CERT_PATH").expect("GENEVA_CERT_PATH is required"));
@@ -47,6 +48,9 @@ async fn main() {
         environment,
         account,
         namespace,
+        account_routing: AccountRouting::new(
+            account_group.expect("GENEVA_ACCOUNT_GROUP must be set"),
+        ),
         region,
         config_major_version,
         auth_method: AuthMethod::Certificate {

--- a/stress/src/geneva_exporter.rs
+++ b/stress/src/geneva_exporter.rs
@@ -33,7 +33,9 @@
         Progress: 449360 ops completed (449360 successful, 100.0%) in 30.01s = 14976.14 ops/sec
 
 */
-use geneva_uploader::{AuthMethod, GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig};
+use geneva_uploader::{
+    AccountRouting, AuthMethod, GenevaClient, GenevaClientConfig, LogsConfig, TracesConfig,
+};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
@@ -114,6 +116,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             environment: std::env::var("GENEVA_ENV").unwrap_or_else(|_| "test".to_string()),
             account: std::env::var("GENEVA_ACCOUNT").unwrap_or_else(|_| "test".to_string()),
             namespace: std::env::var("GENEVA_NAMESPACE").unwrap_or_else(|_| "test".to_string()),
+            account_routing: AccountRouting::new(std::env::var("GENEVA_ACCOUNT_GROUP")?),
             region: std::env::var("GENEVA_REGION").unwrap_or_else(|_| "test".to_string()),
             config_major_version: std::env::var("GENEVA_CONFIG_MAJOR_VERSION")
                 .ok()
@@ -151,6 +154,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "test".to_string(),
+            account_routing: AccountRouting::new("testgroup"),
             region: "test".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,
@@ -215,6 +219,7 @@ async fn init_client() -> Result<(GenevaClient, Option<String>), Box<dyn std::er
             environment: "test".to_string(),
             account: "test".to_string(),
             namespace: "test".to_string(),
+            account_routing: AccountRouting::new("testgroup"),
             region: "test".to_string(),
             config_major_version: 1,
             auth_method: AuthMethod::MockAuth,


### PR DESCRIPTION
## Summary

- add required account routing with one default logical group and optional final-event-name overrides
- retain all logical-group-to-primary-moniker mappings returned by the configuration service
- route each encoded batch by its final event name, then resolve that group to its physical ingestion moniker
- enforce exact, case-sensitive group matching and exactly one primary moniker per group
- expose the same routing model through the C configuration API and agent-fed credentials

## Why

A configuration can contain several logical account groups. Physical moniker names are routing results and are not reliable selectors, so inspecting their names or depending on response ordering can send telemetry to the wrong destination.

The new flow is deterministic:

1. event-name processing produces the final event name and encoded batch
2. account routing maps that event name to a logical group, falling back to the configured default
3. the current configuration snapshot resolves the logical group to its primary physical moniker
4. the upload uses that moniker while sharing the snapshot's endpoint and token

## Breaking changes

- Rust configuration now requires `account_routing: AccountRouting`
- C configuration now requires `account_group` as the default and optionally accepts `account_group_mapping`
- agent-fed credentials now provide a logical-group-to-primary-moniker map

## Validation

- `cargo test -p geneva-uploader --all-features`
- `cargo test -p geneva-uploader-ffi --all-features`
- `cargo check -p stress --all-targets --all-features`
- `cargo clippy -p geneva-uploader -p opentelemetry-exporter-geneva -p geneva-uploader-ffi -p stress --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
