### PR TITLE
fix(geneva-uploader): remove obsolete time upper bound

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -40,10 +40,9 @@ lz4_flex = { version = "0.11", features = ["safe-encode"], default-features = fa
 azure_identity = { version = "0.29", default-features = false }
 azure_core = { version = "0.29", default-features = false, features = ["reqwest", "reqwest_gzip", "reqwest_deflate"] }
 tracing = "0.1"
-# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix; upper bound excludes
-# 0.3.48 which introduces a trait impl that conflicts with typespec_client_core
-# (transitive via azure_core) and breaks the build (E0119). Not used directly.
-time = ">=0.3.47, <0.3.54"
+# Pinned to >=0.3.47 to pick up the RUSTSEC-2026-0009 fix because the
+# workspace's MSRV-aware resolution otherwise selects 0.3.41. Not used directly.
+time = ">=0.3.47"
 bytes = "1.9"
 secrecy = { version = "0.10", features = ["serde"] }
 


### PR DESCRIPTION
## Summary

- retain the `time >=0.3.47` security floor required to avoid RUSTSEC-2026-0009
- remove the obsolete upper bound introduced for the temporary `time 0.3.48` compatibility issue
- document why the explicit dependency remains necessary for MSRV-aware workspace resolution

Supersedes #734.

## Validation

- fresh lockfile resolution selects `time 0.3.55`
- `cargo check -p geneva-uploader --all-features`
