### PR TITLE
ci: ignore h2 advisory RUSTSEC-2026-0258

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -34,4 +34,7 @@ ignore = [
     # quick-xml 0.26.0; dev-only via pprof -> inferno. No upstream fix yet.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # h2 0.3.27 via actix-web (opentelemetry-instrumentation-actix-web).
+    # Fix is in h2 >=0.4.16 but actix-web 4.x pins 0.3.x. No upstream fix yet.
+    "RUSTSEC-2026-0258",
 ]


### PR DESCRIPTION
Discussed in #721 

## Changes

RUSTSEC-2026-0258 (h2 "unbounded empty DATA frames") started failing cargo-deny across the repo after it was published on 2026-08-17. `h2` reaches the tree only via `opentelemetry-instrumentation-actix-web`. The fix is in h2 >=0.4.16, but actix-web 4.x pins h2 0.3.x, so there's no upstream fix available yet. The hyper-side h2 (0.4.x) already resolves to a patched release and is unaffected.

Ignoring the advisory in `deny.toml` to unblock CI until actix-web bumps it upstream

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
