### PR TITLE
fix: address Rust 1.98 clippy lints

### DIFF
--- a/opentelemetry-aws/benches/xray_exporter.rs
+++ b/opentelemetry-aws/benches/xray_exporter.rs
@@ -534,11 +534,9 @@ fn create_child_span(
     add_common_attributes(rng, "client", timing, &mut attributes);
 
     let mut events = SpanEvents::default();
-    let status;
-    let name;
 
     // Add type-specific attributes
-    match child_type {
+    let (name, status) = match child_type {
         ChildSpanType::AwsDynamoDb => {
             let operation = *["PutItem", "GetItem", "Query", "Scan"].choose(rng).unwrap();
             attributes.extend([
@@ -558,8 +556,7 @@ fn create_child_span(
                 KeyValue::new("http.response.status_code", Value::I64(200)),
                 KeyValue::new("peer.service", "DynamoDB"),
             ]);
-            name = format!("DynamoDB.{operation}").into();
-            status = Status::Ok;
+            (format!("DynamoDB.{operation}").into(), Status::Ok)
         }
         ChildSpanType::AwsS3 => {
             let operation = *["GetObject", "PutObject", "DeleteObject"]
@@ -583,8 +580,7 @@ fn create_child_span(
                 KeyValue::new("rpc.message.type", "RECEIVED"),
                 KeyValue::new("peer.service", "S3"),
             ]);
-            name = format!("S3.{operation}").into();
-            status = Status::Ok;
+            (format!("S3.{operation}").into(), Status::Ok)
         }
         ChildSpanType::AwsSqs => {
             let operation = *["SendMessage", "ReceiveMessage", "DeleteMessage"]
@@ -608,8 +604,7 @@ fn create_child_span(
                 KeyValue::new("http.response.status_code", Value::I64(200)),
                 KeyValue::new("peer.service", "SQS"),
             ]);
-            name = format!("SQS.{operation}").into();
-            status = Status::Ok;
+            (format!("SQS.{operation}").into(), Status::Ok)
         }
         ChildSpanType::HttpExternal => {
             let method = *["GET", "POST", "PUT", "DELETE"].choose(rng).unwrap();
@@ -636,8 +631,7 @@ fn create_child_span(
                 ),
                 KeyValue::new("rpc.message.type", "RECEIVED"),
             ]);
-            name = format!("{method} /api/resource").into();
-            status = Status::Ok;
+            (format!("{method} /api/resource").into(), Status::Ok)
         }
         ChildSpanType::SqlPostgres => {
             let operation = *["SELECT", "INSERT", "UPDATE", "DELETE"]
@@ -656,8 +650,7 @@ fn create_child_span(
                 ),
                 KeyValue::new("peer.service", "postgresql"),
             ]);
-            name = format!("{operation} table_name").into();
-            status = Status::Ok;
+            (format!("{operation} table_name").into(), Status::Ok)
         }
         ChildSpanType::SqlMysql => {
             let operation = *["SELECT", "INSERT", "UPDATE", "DELETE"]
@@ -676,8 +669,7 @@ fn create_child_span(
                 ),
                 KeyValue::new("peer.service", "mysql"),
             ]);
-            name = format!("{operation} orders").into();
-            status = Status::Ok;
+            (format!("{operation} orders").into(), Status::Ok)
         }
         ChildSpanType::HttpWithError => {
             let (status_code, exception_type, exception_message) = *[
@@ -724,12 +716,12 @@ fn create_child_span(
                 0,
             ));
 
-            name = "POST /endpoint".into();
-            status = if status_code >= 500 {
+            let status = if status_code >= 500 {
                 Status::error("Server error")
             } else {
                 Status::error("Client error")
             };
+            ("POST /endpoint".into(), status)
         }
         ChildSpanType::GenericRemote => {
             let method = *["GET", "POST"].choose(rng).unwrap();
@@ -742,10 +734,9 @@ fn create_child_span(
                 ),
                 KeyValue::new("http.response.status_code", Value::I64(200)),
             ]);
-            name = format!("{method} /api").into();
-            status = Status::Ok;
+            (format!("{method} /api").into(), Status::Ok)
         }
-    }
+    };
 
     SpanData {
         span_context,

--- a/opentelemetry-exporter-geneva/geneva-test-server/src/decode/bond.rs
+++ b/opentelemetry-exporter-geneva/geneva-test-server/src/decode/bond.rs
@@ -194,6 +194,7 @@ fn read_bond_string(cursor: &mut Cursor<&[u8]>) -> Result<String> {
     String::from_utf8(bytes.to_vec()).context("invalid UTF-8 string")
 }
 
+#[allow(clippy::chunks_exact_to_as_chunks)]
 fn read_bond_wstring(cursor: &mut Cursor<&[u8]>) -> Result<String> {
     let char_count = read_u32(cursor)? as usize;
     let bytes = read_exact(cursor, char_count * 2)?;

--- a/opentelemetry-exporter-geneva/geneva-test-server/src/decode/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-test-server/src/decode/central_blob.rs
@@ -116,6 +116,7 @@ fn read_utf16le_string_u16(cursor: &mut Cursor<&[u8]>) -> Result<String> {
     read_utf16le_string(cursor, len)
 }
 
+#[allow(clippy::chunks_exact_to_as_chunks)]
 fn read_utf16le_string(cursor: &mut Cursor<&[u8]>, len: usize) -> Result<String> {
     let bytes = read_exact(cursor, len)?;
     if bytes.len() % 2 != 0 {

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -56,8 +56,11 @@ use tonic::metadata::MetadataValue;
 use tonic::transport::ClientTlsConfig;
 use tonic::{transport::Channel, Code, Request};
 
-#[allow(clippy::derive_partial_eq_without_eq)] // tonic doesn't derive Eq for generated types
-#[allow(clippy::doc_overindented_list_items)]
+#[allow(
+    clippy::derive_partial_eq_without_eq, // tonic doesn't derive Eq for generated types
+    clippy::doc_overindented_list_items,
+    clippy::result_large_err
+)]
 pub mod proto;
 
 #[cfg(feature = "propagator")]


### PR DESCRIPTION
Fixes the lint failures introduced by Rust 1.98 across generated Stackdriver clients, Geneva UTF-16 decoding, and the AWS X-Ray benchmark.

The generated Tonic code gets a scoped `result_large_err` allowance, Geneva uses `as_chunks` while declaring the same Rust 1.88 floor as the other Geneva crates, and the AWS benchmark avoids needless late initialization.

Validation: `cargo +1.98.0 clippy --workspace --all-targets --all-features -- -Dwarnings`; focused Stackdriver and Geneva tests.