### PR TITLE
chore(ci): pin the Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,12 @@ jobs:
   test:
     strategy:
       matrix:
-        # test both stable and beta versions of Rust on ubuntu-latest
+        # `stable` means the version pinned in rust-toolchain.toml. The label is
+        # retained because branch rules require the existing check names.
+        # Beta uses the moving beta channel and is non-blocking.
         os: [ubuntu-latest]
         rust: [stable, beta]
-        # test only stable version of Rust on Windows and MacOS
+        # Run stable (pinned per rust-toolchain.toml) on additional platforms.
         include:
           - rust: stable
             os: windows-latest
@@ -49,12 +51,12 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
-    - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-      with:
-        toolchain: ${{ matrix.rust }}
-        components: rustfmt
-    - name: "Set rustup profile"
-      run: rustup set profile minimal
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      if: ${{ matrix.rust == 'stable' }}
+      run: rustup show active-toolchain
+    - name: Install Rust beta
+      if: ${{ matrix.rust == 'beta' }}
+      run: rustup toolchain install beta --profile minimal --component clippy
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,9 +64,18 @@ jobs:
       if: ${{ matrix.os == 'windows-latest'}}
       run: ./scripts/test.ps1
       shell: pwsh
+      env:
+        RUSTUP_TOOLCHAIN: ${{ matrix.rust == 'beta' && 'beta' || '' }}
     - name: Test (Unix)
       if: ${{ matrix.os != 'windows-latest'}}
       run: bash ./scripts/test.sh
+      env:
+        RUSTUP_TOOLCHAIN: ${{ matrix.rust == 'beta' && 'beta' || '' }}
+    - name: Lint with Rust beta
+      if: ${{ matrix.rust == 'beta' }}
+      run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
+      env:
+        RUSTUP_TOOLCHAIN: beta
   geneva-uploader-test-server-integration-test:
     runs-on: ubuntu-latest
     steps:
@@ -75,9 +86,8 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
-    - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-      with:
-        toolchain: stable
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      run: rustup show active-toolchain
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,10 +108,8 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
-    - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-      with:
-        toolchain: stable
-        components: rustfmt,clippy
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      run: rustup show active-toolchain
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -129,9 +137,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-msrv
@@ -173,9 +180,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: 1.88.0
+      - name: Install Rust 1.88.0
+        run: rustup toolchain install 1.88.0 --profile minimal
       - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-msrv
@@ -205,9 +211,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -228,10 +233,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
-          components: llvm-tools-preview
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
+      - name: Install llvm-tools-preview for pinned stable Rust
+        run: rustup component add llvm-tools-preview
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -260,9 +265,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-machete
@@ -280,9 +284,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-workspace-lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       run: rustup show active-toolchain
     - name: Install Rust beta
       if: ${{ matrix.rust == 'beta' }}
-      run: rustup toolchain install beta --profile minimal --component clippy
+      run: rustup toolchain install beta --profile minimal --component clippy,rustfmt
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/etw.yml
+++ b/.github/workflows/etw.yml
@@ -13,6 +13,7 @@ on:
       - 'opentelemetry-etw-metrics/**'
       - 'opentelemetry-etw-traces/**'
       - 'Cargo.toml'
+      - 'rust-toolchain.toml'
       - '.github/workflows/etw.yml'
   merge_group:
   push:
@@ -23,6 +24,7 @@ on:
       - 'opentelemetry-etw-metrics/**'
       - 'opentelemetry-etw-traces/**'
       - 'Cargo.toml'
+      - 'rust-toolchain.toml'
       - '.github/workflows/etw.yml'
 
 concurrency:
@@ -40,10 +42,10 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
-    - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-      with:
-        toolchain: stable
-        components: llvm-tools-preview
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      run: rustup show active-toolchain
+    - name: Install llvm-tools-preview for pinned stable Rust
+      run: rustup component add llvm-tools-preview
     - name: cargo install cargo-llvm-cov
       uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
       with:

--- a/.github/workflows/user-events.yml
+++ b/.github/workflows/user-events.yml
@@ -13,6 +13,7 @@ on:
       - 'opentelemetry-user-events-metrics/**'
       - 'opentelemetry-user-events-trace/**'
       - 'Cargo.toml'
+      - 'rust-toolchain.toml'
       - '.github/workflows/user-events.yml'
   merge_group:
   push:
@@ -23,6 +24,7 @@ on:
       - 'opentelemetry-user-events-metrics/**'
       - 'opentelemetry-user-events-trace/**'
       - 'Cargo.toml'
+      - 'rust-toolchain.toml'
       - '.github/workflows/user-events.yml'
 
 concurrency:
@@ -40,10 +42,10 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
-    - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-      with:
-        toolchain: stable
-        components: llvm-tools-preview
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      run: rustup show active-toolchain
+    - name: Install llvm-tools-preview for pinned stable Rust
+      run: rustup component add llvm-tools-preview
     - name: cargo install cargo-llvm-cov
       uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
       with:

--- a/.github/workflows/weaver-live-check-actix.yml
+++ b/.github/workflows/weaver-live-check-actix.yml
@@ -20,6 +20,7 @@ on:
   pull_request:
     paths:
       - 'opentelemetry-instrumentation-actix-web/**'
+      - 'rust-toolchain.toml'
       - '.github/workflows/weaver-live-check-actix.yml'
   merge_group:
   push:
@@ -27,6 +28,7 @@ on:
       - main
     paths:
       - 'opentelemetry-instrumentation-actix-web/**'
+      - 'rust-toolchain.toml'
       - '.github/workflows/weaver-live-check-actix.yml'
 
 concurrency:
@@ -44,9 +46,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install stable Rust
-        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/weaver-live-check-tower.yml
+++ b/.github/workflows/weaver-live-check-tower.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     paths:
       - 'opentelemetry-instrumentation-tower/**'
+      - 'rust-toolchain.toml'
       - '.github/workflows/weaver-live-check-tower.yml'
   merge_group:
   push:
@@ -26,6 +27,7 @@ on:
       - main
     paths:
       - 'opentelemetry-instrumentation-tower/**'
+      - 'rust-toolchain.toml'
       - '.github/workflows/weaver-live-check-tower.yml'
 
 concurrency:
@@ -43,9 +45,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install stable Rust
-        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,20 @@ GitHub pull requests (PRs).
 git clone https://github.com/open-telemetry/opentelemetry-rust-contrib
 ```
 
+### Rust toolchain
+
+The repository pins the Rust version used for local development and required CI
+in [`rust-toolchain.toml`](rust-toolchain.toml). This keeps local checks and CI
+on the same compiler and prevents a new Rust release from breaking unrelated
+pull requests.
+
+Run `cargo` from within the repository so `rustup` applies the pinned toolchain.
+The non-blocking beta CI lane explicitly overrides the pin to provide early
+warning of upcoming compiler changes.
+
+Update the pinned version in a dedicated pull request that includes any lint or
+compile fixes required by the new compiler.
+
 Enter the newly created directory and add your fork as a new remote:
 
 ```sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Pin the repository's default development and required CI toolchain to Rust 1.98.0 so compiler upgrades happen in dedicated pull requests instead of breaking unrelated changes when the stable channel moves. This is independent of each crate's declared MSRV, which continues to be validated separately with `cargo-msrv`.

The Rust 1.98 compatibility fixes landed in #752 before this pin. The required test lane retains its existing `stable` check names for ruleset compatibility, but resolves the exact version from `rust-toolchain.toml`. The non-blocking beta lane explicitly overrides the pin and runs both tests and workspace-wide Clippy to warn about upcoming compiler and lint changes.

Coverage, platform integration, and Weaver workflows resolve the pinned toolchain and run when the pin changes.

Validation: pinned `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`, beta workspace Clippy, `cargo fmt --all -- --check`, and `actionlint -shellcheck='' .github/workflows/*.yml`.