### PR TITLE
fix Rust 1.98 clippy lints

### DIFF
--- a/opentelemetry-aws/benches/xray_exporter.rs
+++ b/opentelemetry-aws/benches/xray_exporter.rs
@@ -513,6 +513,7 @@ fn create_parent_span(
 }
 
 /// Creates a child (Client) span based on the child span type
+#[allow(clippy::needless_late_init)]
 fn create_child_span(
     trace_id: TraceId,
     span_id: SpanId,

--- a/opentelemetry-exporter-geneva/geneva-test-server/src/decode/bond.rs
+++ b/opentelemetry-exporter-geneva/geneva-test-server/src/decode/bond.rs
@@ -197,9 +197,10 @@ fn read_bond_string(cursor: &mut Cursor<&[u8]>) -> Result<String> {
 fn read_bond_wstring(cursor: &mut Cursor<&[u8]>) -> Result<String> {
     let char_count = read_u32(cursor)? as usize;
     let bytes = read_exact(cursor, char_count * 2)?;
-    let utf16 = bytes
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+    let (chunks, _) = bytes.as_chunks::<2>();
+    let utf16 = chunks
+        .iter()
+        .map(|&chunk| u16::from_le_bytes(chunk))
         .collect::<Vec<_>>();
     String::from_utf16(&utf16).context("invalid UTF-16 string")
 }

--- a/opentelemetry-exporter-geneva/geneva-test-server/src/decode/central_blob.rs
+++ b/opentelemetry-exporter-geneva/geneva-test-server/src/decode/central_blob.rs
@@ -121,9 +121,10 @@ fn read_utf16le_string(cursor: &mut Cursor<&[u8]>, len: usize) -> Result<String>
     if bytes.len() % 2 != 0 {
         bail!("UTF-16LE string length {len} is not even");
     }
-    let utf16 = bytes
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+    let (chunks, _) = bytes.as_chunks::<2>();
+    let utf16 = chunks
+        .iter()
+        .map(|&chunk| u16::from_le_bytes(chunk))
         .collect::<Vec<_>>();
     String::from_utf16(&utf16).context("invalid UTF-16LE string")
 }

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -58,6 +58,7 @@ use tonic::{transport::Channel, Code, Request};
 
 #[allow(clippy::derive_partial_eq_without_eq)] // tonic doesn't derive Eq for generated types
 #[allow(clippy::doc_overindented_list_items)]
+#[allow(clippy::result_large_err)] // large tonic Status error; generated code we don't hand-edit
 pub mod proto;
 
 #[cfg(feature = "propagator")]


### PR DESCRIPTION
## Changes

Rust 1.98 (stable, released 2026-08-18) added new clippy lints that fail `-Dwarnings` across the workspace, blocking CI. 

Ref - https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/721#issuecomment-5371099867

`scripts/lint.sh` passes locally on Rust 1.98 after this fix

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)