### PR TITLE
feat(aws): normalize the behavior and documentation of the Lambda resource detector

### DIFF
--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -12,6 +12,10 @@
 - `EcsResourceDetector` (`detector-aws-ecs` feature)
 - `EksResourceDetector` (`detector-aws-eks` feature)
 
+### Changed
+
+- the Lambda detector now add "cloud.platform = aws_lambda" and no longer set empty values in case of errors or missing environment variables
+
 ## v0.20.0
 
 Released 2026-May-13

--- a/opentelemetry-aws/src/detector/lambda.rs
+++ b/opentelemetry-aws/src/detector/lambda.rs
@@ -1,22 +1,73 @@
-use opentelemetry::{Array, KeyValue, StringValue, Value};
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::resource::ResourceDetector;
 use opentelemetry_sdk::Resource;
-use opentelemetry_semantic_conventions as semconv;
+use opentelemetry_semantic_conventions::attribute as semco;
 use std::env;
+
+use super::utils::{info_on_error, non_empty, opt_kv, opt_kv_array, warn_on_error};
 
 // For a complete list of reserved environment variables in Lambda, see:
 // https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
+
+/// Name reported in internal logs emitted by this detector.
+const DETECTOR: &str = "aws_lambda";
+/// Environment variable that holds the Lambda function name; also used as the platform probe.
 const AWS_LAMBDA_FUNCTION_NAME_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_NAME";
+/// Environment variable that holds the AWS Region the function runs in.
 const AWS_REGION_ENV_VAR: &str = "AWS_REGION";
+/// Environment variable that holds the function version alias or `$LATEST`.
 const AWS_LAMBDA_FUNCTION_VERSION_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_VERSION";
+/// Environment variable that holds the CloudWatch Logs stream name for the invocation.
 const AWS_LAMBDA_LOG_STREAM_NAME_ENV_VAR: &str = "AWS_LAMBDA_LOG_STREAM_NAME";
+/// Environment variable that holds the function's configured memory limit in megabytes.
 const AWS_LAMBDA_MEMORY_LIMIT_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE";
+/// Environment variable that holds the CloudWatch Logs group name for the function.
 const AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR: &str = "AWS_LAMBDA_LOG_GROUP_NAME";
 
 #[cfg(target_os = "linux")]
 const ACCOUNT_ID_SYMLINK_PATH: &str = "/tmp/.otel-aws-account-id";
 
-/// Resource detector that collects resource information from AWS Lambda environment.
+/// Lambda resource detector (`detector-aws-lambda` feature).
+///
+/// Reads the AWS Lambda [reserved environment variables] and a known (Linux only) filesystem symlink,
+/// and returns an OTel [`Resource`] with the following attributes:
+///
+/// | OTel attribute        | Source                                                                                     |
+/// |-----------------------|--------------------------------------------------------------------------------------------|
+/// | `cloud.provider`      | hardcoded `"aws"`                                                                          |
+/// | `cloud.platform`      | hardcoded `"aws_lambda"`                                                                   |
+/// | `cloud.region`        | `AWS_REGION` environment variable                                                          |
+/// | `cloud.account.id`    | symlink target at `/tmp/.otel-aws-account-id` (Linux only), accepted only when exactly 12 ASCII decimal digits  |
+/// | `faas.name`           | `AWS_LAMBDA_FUNCTION_NAME` environment variable                                            |
+/// | `faas.version`        | `AWS_LAMBDA_FUNCTION_VERSION` environment variable                                         |
+/// | `faas.instance`       | `AWS_LAMBDA_LOG_STREAM_NAME` environment variable                                          |
+/// | `faas.max_memory`     | `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` environment variable, converted from megabytes to bytes  |
+/// | `aws.log.group.names` | `AWS_LAMBDA_LOG_GROUP_NAME` environment variable, wrapped in a one-element array           |
+///
+/// Values that cannot be found or parsed are skipped.
+///
+/// # Probing
+///
+/// If `AWS_LAMBDA_FUNCTION_NAME` is unset the environment is assumed not to be
+/// Lambda and an empty [`Resource`] is returned immediately.
+///
+/// # Examples
+///
+/// Register the detector with the OpenTelemetry SDK so that Lambda attributes
+/// are automatically merged into the global resource:
+///
+/// ```no_run
+/// // Requires a running Lambda environment with AWS_LAMBDA_FUNCTION_NAME set.
+/// use opentelemetry_aws::detector::LambdaResourceDetector;
+/// use opentelemetry_sdk::Resource;
+///
+/// let resource = Resource::builder()
+///     .with_detector(Box::new(LambdaResourceDetector))
+///     .build();
+/// ```
+///
+/// [reserved environment variables]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
+/// [`Resource`]: opentelemetry_sdk::Resource
 pub struct LambdaResourceDetector;
 
 impl ResourceDetector for LambdaResourceDetector {
@@ -42,7 +93,7 @@ impl LambdaResourceDetector {
                 if account_id_str.len() == 12 && account_id_str.chars().all(|c| c.is_ascii_digit())
                 {
                     extra.push(KeyValue::new(
-                        semconv::resource::CLOUD_ACCOUNT_ID,
+                        semco::CLOUD_ACCOUNT_ID,
                         account_id_str.to_string(),
                     ));
                 }
@@ -52,40 +103,51 @@ impl LambdaResourceDetector {
     }
 
     fn build_resource(extra_attributes: Vec<KeyValue>) -> Resource {
-        let lambda_name = env::var(AWS_LAMBDA_FUNCTION_NAME_ENV_VAR).unwrap_or_default();
-        // If no lambda name is provided, it means that
-        // we're not on a Lambda environment, so we return empty resource.
-        if lambda_name.is_empty() {
+        // Platform probe: AWS_LAMBDA_FUNCTION_NAME is always set by the Lambda
+        // runtime; its absence means we are not running on Lambda.
+        let Some(lambda_name) =
+            info_on_error(DETECTOR, env::var(AWS_LAMBDA_FUNCTION_NAME_ENV_VAR)).and_then(non_empty)
+        else {
             return Resource::builder_empty().build();
-        }
+        };
 
-        let aws_region = env::var(AWS_REGION_ENV_VAR).unwrap_or_default();
-        let function_version = env::var(AWS_LAMBDA_FUNCTION_VERSION_ENV_VAR).unwrap_or_default();
-        // Convert memory limit from MB (string) to Bytes (int) as required by semantic conventions.
-        let function_memory_limit = env::var(AWS_LAMBDA_MEMORY_LIMIT_ENV_VAR)
-            .map(|s| s.parse::<i64>().unwrap_or_default() * 1024 * 1024)
-            .unwrap_or_default();
-        // Instance attributes corresponds to the log stream name for AWS Lambda;
-        // See the FaaS resource specification for more details.
-        let instance = env::var(AWS_LAMBDA_LOG_STREAM_NAME_ENV_VAR).unwrap_or_default();
-        let log_group_name = env::var(AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR).unwrap_or_default();
+        // Convert memory limit from MB (string) to bytes (i64) as required by
+        // semantic conventions.
+        let function_memory_limit =
+            warn_on_error(DETECTOR, env::var(AWS_LAMBDA_MEMORY_LIMIT_ENV_VAR))
+                .and_then(|s| warn_on_error(DETECTOR, s.parse::<i64>()))
+                .map(|mb| KeyValue::new(semco::FAAS_MAX_MEMORY, mb * 1024 * 1024));
 
-        let mut attributes = vec![
-            KeyValue::new(semconv::resource::CLOUD_PROVIDER, "aws"),
-            KeyValue::new(semconv::resource::CLOUD_REGION, aws_region),
-            KeyValue::new(semconv::resource::FAAS_INSTANCE, instance),
-            KeyValue::new(semconv::resource::FAAS_NAME, lambda_name),
-            KeyValue::new(semconv::resource::FAAS_VERSION, function_version),
-            KeyValue::new(semconv::resource::FAAS_MAX_MEMORY, function_memory_limit),
-            KeyValue::new(
-                semconv::resource::AWS_LOG_GROUP_NAMES,
-                Value::Array(Array::from(vec![StringValue::from(log_group_name)])),
+        // aws.log.group.names is typed as string[] by semantic conventions;
+        // Lambda exposes a single group name, so it is wrapped in a one-element array.
+        let log_group_names = warn_on_error(DETECTOR, env::var(AWS_LAMBDA_LOG_GROUP_NAME_ENV_VAR))
+            .and_then(non_empty);
+
+        let attribute_options = [
+            Some(KeyValue::new(semco::CLOUD_PROVIDER, "aws")),
+            Some(KeyValue::new(semco::CLOUD_PLATFORM, "aws_lambda")),
+            Some(KeyValue::new(semco::FAAS_NAME, lambda_name)),
+            opt_kv(
+                semco::CLOUD_REGION,
+                warn_on_error(DETECTOR, env::var(AWS_REGION_ENV_VAR)),
             ),
+            opt_kv(
+                semco::FAAS_VERSION,
+                warn_on_error(DETECTOR, env::var(AWS_LAMBDA_FUNCTION_VERSION_ENV_VAR)),
+            ),
+            // Instance attribute corresponds to the log stream name for AWS Lambda;
+            // See https://opentelemetry.io/docs/specs/semconv/faas/faas-spans/ for more details.
+            opt_kv(
+                semco::FAAS_INSTANCE,
+                warn_on_error(DETECTOR, env::var(AWS_LAMBDA_LOG_STREAM_NAME_ENV_VAR)),
+            ),
+            function_memory_limit,
+            opt_kv_array(semco::AWS_LOG_GROUP_NAMES, log_group_names),
         ];
-        attributes.extend(extra_attributes);
 
         Resource::builder_empty()
-            .with_attributes(attributes)
+            .with_attributes(attribute_options.into_iter().flatten())
+            .with_attributes(extra_attributes)
             .build()
     }
 }
@@ -93,6 +155,7 @@ impl LambdaResourceDetector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opentelemetry::{Array, StringValue, Value};
     use sealed_test::prelude::*;
 
     #[sealed_test]
@@ -115,17 +178,18 @@ mod tests {
             || {
                 let expected = Resource::builder_empty()
                     .with_attributes([
-                        KeyValue::new(semconv::resource::CLOUD_PROVIDER, "aws"),
-                        KeyValue::new(semconv::resource::CLOUD_REGION, "eu-west-3"),
+                        KeyValue::new(semco::CLOUD_PROVIDER, "aws"),
+                        KeyValue::new(semco::CLOUD_PLATFORM, "aws_lambda"),
+                        KeyValue::new(semco::CLOUD_REGION, "eu-west-3"),
                         KeyValue::new(
-                            semconv::resource::FAAS_INSTANCE,
+                            semco::FAAS_INSTANCE,
                             "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc",
                         ),
-                        KeyValue::new(semconv::resource::FAAS_NAME, "my-lambda-function"),
-                        KeyValue::new(semconv::resource::FAAS_VERSION, "$LATEST"),
-                        KeyValue::new(semconv::resource::FAAS_MAX_MEMORY, 128 * 1024 * 1024),
+                        KeyValue::new(semco::FAAS_NAME, "my-lambda-function"),
+                        KeyValue::new(semco::FAAS_VERSION, "$LATEST"),
+                        KeyValue::new(semco::FAAS_MAX_MEMORY, 128 * 1024 * 1024),
                         KeyValue::new(
-                            semconv::resource::AWS_LOG_GROUP_NAMES,
+                            semco::AWS_LOG_GROUP_NAMES,
                             Value::Array(Array::from(vec![StringValue::from(
                                 "/aws/lambda/my-lambda-function".to_string(),
                             )])),
@@ -176,7 +240,7 @@ mod tests {
 
                 let account_id = got
                     .iter()
-                    .find(|(k, _)| k.as_str() == semconv::resource::CLOUD_ACCOUNT_ID);
+                    .find(|(k, _)| k.as_str() == semco::CLOUD_ACCOUNT_ID);
                 assert!(
                     account_id.is_some(),
                     "cloud.account.id attribute should be present"
@@ -217,7 +281,7 @@ mod tests {
 
                 let account_id = got
                     .iter()
-                    .find(|(k, _)| k.as_str() == semconv::resource::CLOUD_ACCOUNT_ID);
+                    .find(|(k, _)| k.as_str() == semco::CLOUD_ACCOUNT_ID);
                 assert!(
                     account_id.is_none(),
                     "cloud.account.id should not be set for a corrupted symlink target"
@@ -255,7 +319,7 @@ mod tests {
 
                 let account_id = got
                     .iter()
-                    .find(|(k, _)| k.as_str() == semconv::resource::CLOUD_ACCOUNT_ID);
+                    .find(|(k, _)| k.as_str() == semco::CLOUD_ACCOUNT_ID);
                 assert!(
                     account_id.is_none(),
                     "cloud.account.id attribute should not be present when symlink is missing"

--- a/opentelemetry-aws/src/detector/mod.rs
+++ b/opentelemetry-aws/src/detector/mod.rs
@@ -26,6 +26,7 @@ pub use eks::EksResourceDetector;
 mod imds;
 
 #[cfg(any(
+    feature = "detector-aws-lambda",
     feature = "detector-aws-ec2",
     feature = "detector-aws-ecs",
     feature = "detector-aws-eks"

--- a/opentelemetry-aws/src/detector/utils.rs
+++ b/opentelemetry-aws/src/detector/utils.rs
@@ -1,7 +1,7 @@
 //! Helpers shared by the AWS resource detectors.
 
 use opentelemetry::KeyValue;
-#[cfg(feature = "detector-aws-ecs")]
+#[cfg(any(feature = "detector-aws-ecs", feature = "detector-aws-lambda"))]
 use opentelemetry::{Array, StringValue, Value};
 
 /// Builds a blocking HTTP client with proxying disabled and a global timeout.
@@ -70,7 +70,7 @@ pub(super) fn opt_kv(key: &'static str, value: Option<String>) -> Option<KeyValu
 
 /// [`opt_kv`] for the attributes that semantic conventions type as `string[]`,
 /// wrapping the single value the metadata endpoints expose in a one-element array.
-#[cfg(feature = "detector-aws-ecs")]
+#[cfg(any(feature = "detector-aws-ecs", feature = "detector-aws-lambda"))]
 pub(super) fn opt_kv_array(key: &'static str, value: Option<String>) -> Option<KeyValue> {
     value
         .and_then(non_empty)


### PR DESCRIPTION
Part of #94
Follows on #721

## Changes

Brings the existing `LambdaResourceDetector` on par with the EC2, ECS and EKS detectors added in #721, both in behavior and in documentation.

### Behavior

- **Adds `cloud.platform = "aws_lambda"`.** The Lambda detector previously did not emit `cloud.platform` at all; it now reports it as a fixed value, matching the other AWS detectors.
- **Stops emitting empty attribute values.** The previous implementation used `unwrap_or_default()`, which could theorically populate keys with empty strings when an environment variable was missing or unparsable. It now reuses the `#721` helpers (`non_empty` / `opt_kv` / `opt_kv_array` and the `warn_on_error` / `info_on_error` logging wrappers) so that absent or invalid values are skipped instead of written as empty — consistent with the empty-value filtering the new detectors apply.

The platform probe (`AWS_LAMBDA_FUNCTION_NAME`) and the Linux-only `cloud.account.id` symlink logic are unchanged.

### Documentation

- Full doc-comment rewrite for `LambdaResourceDetector`: attribute-source table, a "Probing" section, and a runnable example, matching the style established for the EC2/ECS/EKS detectors in #721.

### Styling
```rs
use opentelemetry_semantic_conventions as semconv;
``` 
has been replaced by the less verbose:
```rs
use opentelemetry_semantic_conventions::attribute as semco;
``` 
used in other detector modules.

The diff therefor contains a lot of (e.g.) `semconv::resource::FAAS_NAME` => `semco::FAAS_NAME`.

### Testing

Existing unit tests still pass and were extended to cover the new `cloud.platform` attribute. No other changes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user
