### PR TITLE
fix(config): update OpenTelemetry SDK dependency

### DIFF
--- a/opentelemetry-config/Cargo.toml
+++ b/opentelemetry-config/Cargo.toml
@@ -19,8 +19,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { version = "0.31.0" }
-opentelemetry_sdk = { version = "0.31.0", features = ["experimental_metrics_custom_reader"] }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = [
+    "experimental_metrics_custom_reader",
+    "logs",
+    "metrics",
+    "trace",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.9.34" }
 

--- a/opentelemetry-config/examples/application/Cargo.toml
+++ b/opentelemetry-config/examples/application/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = "1.75.0"
 
 [dependencies]
 opentelemetry-config = { path = "../../"}
-opentelemetry_sdk = { version = "0.31.0" }
+opentelemetry_sdk = "0.32.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.9.34" }

--- a/opentelemetry-config/examples/custom/Cargo.toml
+++ b/opentelemetry-config/examples/custom/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = "1.75.0"
 
 [dependencies]
 opentelemetry-config = { path = "../../"}
-opentelemetry_sdk = { version = "0.31.0" }
+opentelemetry_sdk = "0.32.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.9.34" }


### PR DESCRIPTION
## Summary

- make `opentelemetry-config` inherit the repository's workspace-managed OpenTelemetry versions
- enable the SDK signal features required because the workspace disables SDK default features
- update the two standalone config examples to `opentelemetry_sdk 0.32.1`

This addresses the open Dependabot alerts for GHSA-w9wp-h8wv-79jx without relying on committed lockfiles.

## Validation

- `cargo check -p opentelemetry-config --all-features`
- `cargo check --manifest-path opentelemetry-config/examples/application/Cargo.toml`
- `cargo check --manifest-path opentelemetry-config/examples/custom/Cargo.toml`
