### PR TITLE
chore(config): align examples with workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "opentelemetry-aws",
     "opentelemetry-config",
+    "opentelemetry-config/examples/*",
     "opentelemetry-contrib",
     "opentelemetry-datadog",
     "opentelemetry-etw-logs",
@@ -53,4 +54,3 @@ tail_expr_drop_order = "allow"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = 1 }
-

--- a/opentelemetry-config/examples/application/Cargo.toml
+++ b/opentelemetry-config/examples/application/Cargo.toml
@@ -6,10 +6,8 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
 
-[workspace]
-
 [dependencies]
-opentelemetry-config = { path = "../../"}
-opentelemetry_sdk = "0.32.1"
+opentelemetry-config = { path = "../../" }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.9.34" }

--- a/opentelemetry-config/examples/custom/Cargo.toml
+++ b/opentelemetry-config/examples/custom/Cargo.toml
@@ -6,10 +6,8 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
 
-[workspace]
-
 [dependencies]
-opentelemetry-config = { path = "../../"}
-opentelemetry_sdk = "0.32.1"
+opentelemetry-config = { path = "../../" }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.9.34" }


### PR DESCRIPTION
## Summary

- add `opentelemetry-config/examples/*` to the root Cargo workspace
- remove the examples' standalone workspace declarations
- inherit the centrally managed `opentelemetry_sdk` version and enable the required metrics feature

This aligns the config examples with the repository's Actix and Tower example dependency management.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo check -p opentelemetry-config -p custom-application -p opentelemetry-config-custom-exporter-example --all-features`
