### PR TITLE
chore(deps): schedule monthly Rust toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
+  - package-ecosystem: rust-toolchain
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

- configure Dependabot to monitor `rust-toolchain.toml`
- schedule Rust toolchain update pull requests monthly
- limit open Rust toolchain update PRs to one

This complements #753 by ensuring the pinned development toolchain is advanced through dedicated update PRs.
