### PR TITLE
chore(resource-detectors): prepare 0.12.0 release

### DIFF
--- a/opentelemetry-resource-detectors/CHANGELOG.md
+++ b/opentelemetry-resource-detectors/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## vNext
+## v0.12.0
+
+Released 2026-Aug-27
 
 ### Added
 

--- a/opentelemetry-resource-detectors/Cargo.toml
+++ b/opentelemetry-resource-detectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-resource-detectors"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "A collection of community supported resource detectors for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-resource-detectors"


### PR DESCRIPTION
Bumps `opentelemetry-resource-detectors` to 0.12.0 and finalizes the changelog for the release.