### PR TITLE
  chore: [Geneva Uploader] use published otel-arrow pdata crates

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -9,10 +9,9 @@
 
 ### Changed
 - Bump opentelemetry-proto version to 0.32.
-- Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
-  to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`
-  version and avoid duplicate `LogsDataView` trait errors. API-compatible;
-  the view trait signatures are unchanged.
+- Replace the Git-pinned `otap-df-pdata` and `otap-df-pdata-views`
+  dependencies with the published `otel-arrow-dfe-pdata` and
+  `otel-arrow-dfe-pdata-views` 0.53.0 crates.
 
 ## [0.5.0] - 2026-04-13
 

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b", optional = true }
+otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
+otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -27,10 +27,9 @@
   required and `account_group_mapping` supplies optional final-event-name
   overrides.
 - Bump opentelemetry-proto version to 0.32.
-- Bump pinned `otel-arrow` rev for `otap-df-pdata` and `otap-df-pdata-views`
-  to `4f522d2e` so consumers can unify on a single `otap-df-pdata-views`
-  version and avoid duplicate `LogsDataView` trait errors. API-compatible;
-  the view trait signatures are unchanged.
+- Replace the Git-pinned `otap-df-pdata` and `otap-df-pdata-views`
+  dependencies with the published `otel-arrow-dfe-pdata` and
+  `otel-arrow-dfe-pdata-views` 0.53.0 crates.
 - `GenevaClientConfig` now applies signal-specific defaults consistently on emitted batches: when `logs.default_event_name` / `spans.default_event_name` is set, encoded batches use that value as `event_name`; when unset, they fall back to `Log` and `Span` respectively.
 - **Breaking:** `GenevaClientConfig.logs` and `.spans` changed from `LogsConfig` / `TracesConfig` to `Option<LogsConfig>` / `Option<TracesConfig>`. Pass `None` to use the default `Log` / `Span` table names.
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
+otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -76,7 +76,7 @@ default = ["tls-native"]
 
 [dev-dependencies]
 geneva-test-server = { path = "../geneva-test-server", features = ["testing"] }
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
+otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
@@ -8,10 +8,8 @@
 
 ### Changed
 - Bump opentelemetry, opentelemetry_sdk, and opentelemetry-proto versions to 0.32.
-- Bump pinned `otel-arrow` rev for `otap-df-pdata-views` to `4f522d2e` so
-  consumers can unify on a single `otap-df-pdata-views` version and avoid
-  duplicate `LogsDataView` trait errors. API-compatible; the view trait
-  signatures are unchanged.
+- Replace the Git-pinned `otap-df-pdata-views` dependency with the published
+  `otel-arrow-dfe-pdata-views` 0.53.0 crate.
 
 ## [0.5.0] - 2026-04-13
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["l
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
 futures = "0.3"
-otap-df-pdata-views = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
+otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
 
 [features]
 # TLS backend selection is forwarded to geneva-uploader. `tls-native` (default)

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { git = "https://github.com/open-telemetry/otel-arrow", rev = "a8e27f29d859ed987277498d1126603c0e25a10b" }
+otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0" }
 prost = "0.14"
 
 [features]


### PR DESCRIPTION
 ## Changes

  - Replace the Git-pinned `otap-df-pdata-views` dependency with `otel-arrow-dfe-pdata-views` v0.53.0
  - Replace the Git-pinned `otap-df-pdata` dependency with `otel-arrow-dfe-pdata` v0.53.0
  - Preserve the existing crate aliases to avoid code changes
  - Update Geneva uploader, exporter, FFI, and stress manifests

  ## Validation

  - `cargo check -p geneva-uploader`
  - `cargo check -p geneva-uploader --all-targets --features mock_auth`
  - `cargo check -p geneva-uploader-ffi --features otlp_bytes`
  - `cargo check -p opentelemetry-exporter-geneva`
  - `cargo check -p stress`