### PR TITLE
perf(user-events-metrics): batch multiple data points into a single user_events write

### DIFF
--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 - Pack multiple metric data points into each `user_events` write instead of
   emitting one event per data point. The resource/scope/metric envelope is now
-  amortized across every data point that fits within the 64KB tracepoint limit,
-  which substantially reduces both the bytes written to the per-CPU perf ring
-  buffer and the number of writes per export cycle. Batching is per-metric: a
-  single event never mixes data points from different metrics or scopes.
+  amortized across every data point that fits within a single event, which
+  substantially reduces both the bytes written to the per-CPU perf ring buffer
+  and the number of writes per export cycle. Batching is per-metric: a single
+  event never mixes data points from different metrics or scopes.
+- Fixed the maximum tracepoint event size, which was previously set to 64KB.
+  When a `user_events` tracepoint is consumed through perf, the kernel copies
+  the record into a `PERF_MAX_TRACE_SIZE` (8192 byte) per-CPU buffer, and an
+  event that does not fit is dropped without any error being reported to the
+  writer. The limit is now derived from that bound. This had no effect before
+  batching, because a single data point never approached 64KB.
 
 ## v0.13.0
 

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+- Pack multiple metric data points into each `user_events` write instead of
+  emitting one event per data point. The resource/scope/metric envelope is now
+  amortized across every data point that fits within the 64KB tracepoint limit,
+  which substantially reduces both the bytes written to the per-CPU perf ring
+  buffer and the number of writes per export cycle. Batching is per-metric: a
+  single event never mixes data points from different metrics or scopes.
+
 ## v0.13.0
 
 Released 2026-May-13

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -14,6 +14,11 @@
   event that does not fit is dropped without any error being reported to the
   writer. The limit is now derived from that bound. This had no effect before
   batching, because a single data point never approached 64KB.
+- Fixed the aggregation temporality written to the wire. The SDK's `Temporality`
+  and OTLP's `AggregationTemporality` do not use the same discriminants, and the
+  exporter cast between them directly. Cumulative data — which is what the SDK
+  produces for `UpDownCounter` and `ObservableUpDownCounter` — was therefore
+  written as `AGGREGATION_TEMPORALITY_UNSPECIFIED`.
 
 ## v0.13.0
 

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -20,6 +20,7 @@ prost = "0.14"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "std", "fmt"] }
+criterion = "0.8"
 
 # Linux-only: in-process user_events consumer used by the integration tests to
 # read the `otlp_metrics` tracepoint directly from the perf ring buffer instead
@@ -30,6 +31,10 @@ one_collect = "0.1.34532"
 [features]
 internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
 default = ["internal-logs"]
+
+[[bench]]
+name = "metrics"
+harness = false
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]

--- a/opentelemetry-user-events-metrics/benches/metrics.rs
+++ b/opentelemetry-user-events-metrics/benches/metrics.rs
@@ -1,0 +1,121 @@
+/*
+    Benchmarks a full collect + export cycle for the user_events metrics
+    exporter.
+
+    Each iteration records `series` data points and then forces a flush, so the
+    measurement covers aggregation, OTLP serialization and the tracepoint
+    writes. Recording cost is identical across implementations, so the numbers
+    are meaningful when comparing two revisions of the exporter (for example
+    one-event-per-data-point versus batched writes).
+
+    IMPORTANT: the exporter short-circuits when the tracepoint has no listener,
+    in which case nothing is serialized and the numbers only reflect collection.
+    Run on Linux with the tracepoint enabled to measure the export path:
+
+      sudo -E ~/.cargo/bin/cargo bench --bench metrics
+      # in another shell, once the tracepoint is registered:
+      echo 1 | sudo tee /sys/kernel/tracing/events/user_events/otlp_metrics/enable
+
+    To compare against another revision:
+
+      git checkout main     && cargo bench --bench metrics -- --save-baseline before
+      git checkout <branch> && cargo bench --bench metrics -- --baseline before
+*/
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::Resource;
+use opentelemetry_user_events_metrics::MetricsExporter;
+
+/// A deliberately small resource, matching what production agents carry. The
+/// envelope it produces is what batching amortizes away.
+fn resource() -> Resource {
+    Resource::builder_empty()
+        .with_attributes([
+            KeyValue::new("service.name", "bench-ingest"),
+            KeyValue::new(
+                "service.instance.id",
+                "9f1c2b7e-4a3d-4c11-9b02-7e5f8a1d3c44",
+            ),
+            KeyValue::new("cloud.region", "eastus2"),
+            KeyValue::new("host.name", "node-bench-0731"),
+        ])
+        .build()
+}
+
+/// Attribute sets for `count` dimensions. The high-cardinality `partition` key
+/// comes first so every dimension count still yields distinct series.
+fn dims(i: usize, count: usize) -> Vec<KeyValue> {
+    let all = [
+        KeyValue::new("partition", format!("p{i:04}")),
+        KeyValue::new("operation", "GetBlobProperties"),
+        KeyValue::new("status_code", "200"),
+        KeyValue::new("client_version", "2024-11-04"),
+        KeyValue::new("protocol", "https"),
+    ];
+    all.into_iter().take(count).collect()
+}
+
+fn provider() -> SdkMeterProvider {
+    SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(MetricsExporter::new()).build())
+        .with_resource(resource())
+        .build()
+}
+
+fn bench_counter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("export_cycle_counter");
+    for series in [100usize, 1000] {
+        for n_dims in [2usize, 5] {
+            group.throughput(Throughput::Elements(series as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{n_dims}_dims"), series),
+                &series,
+                |b, &series| {
+                    let provider = provider();
+                    let counter = provider
+                        .meter("bench")
+                        .u64_counter("bench.requests")
+                        .build();
+                    let attrs: Vec<Vec<KeyValue>> = (0..series).map(|i| dims(i, n_dims)).collect();
+                    b.iter(|| {
+                        for a in &attrs {
+                            counter.add(1, a);
+                        }
+                        let _ = provider.force_flush();
+                    });
+                    let _ = provider.shutdown();
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_histogram(c: &mut Criterion) {
+    let mut group = c.benchmark_group("export_cycle_histogram");
+    for series in [100usize, 1000] {
+        group.throughput(Throughput::Elements(series as u64));
+        group.bench_with_input(BenchmarkId::new("3_dims", series), &series, |b, &series| {
+            let provider = provider();
+            let hist = provider
+                .meter("bench")
+                .f64_histogram("bench.latency")
+                .build();
+            let attrs: Vec<Vec<KeyValue>> = (0..series).map(|i| dims(i, 3)).collect();
+            b.iter(|| {
+                for a in &attrs {
+                    hist.record(12.5, a);
+                }
+                let _ = provider.force_flush();
+            });
+            let _ = provider.shutdown();
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_counter, bench_histogram);
+criterion_main!(benches);

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -16,7 +16,14 @@ use prost::Message;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
-const MAX_EVENT_SIZE: usize = 65360;
+/// Upper bound on the encoded size of a single tracepoint event.
+///
+/// A perf ring buffer record carries its length in a `__u16`, so a record can
+/// never exceed 65535 bytes in total. The payload budget is set slightly below
+/// that to leave room for the perf record header and the tracepoint's own
+/// fields, so a maximally packed event is still guaranteed to be representable
+/// (and therefore readable) by a perf consumer.
+pub(crate) const MAX_EVENT_SIZE: usize = 65360;
 
 /// Safety margin, in bytes, reserved when deciding whether another data point
 /// fits into the current batch.
@@ -26,7 +33,7 @@ const MAX_EVENT_SIZE: usize = 65360;
 /// `ResourceMetrics`. Each of those four varints grows by at most 2 bytes as
 /// the payload approaches `MAX_EVENT_SIZE`, so 8 bytes is the true bound; 32
 /// gives ample headroom while costing nothing measurable in packing density.
-const SIZE_SLACK: usize = 32;
+pub(crate) const SIZE_SLACK: usize = 32;
 
 /// Abstracts the destination of an encoded OTLP payload.
 ///

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -1,5 +1,6 @@
 use opentelemetry::{otel_debug, otel_info};
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::metrics::v1::metric::Data as ProtoData;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::metrics::data::AggregatedMetrics;
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
@@ -16,6 +17,69 @@ use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
 const MAX_EVENT_SIZE: usize = 65360;
+
+/// Safety margin, in bytes, reserved when deciding whether another data point
+/// fits into the current batch.
+///
+/// Adding data points grows the protobuf length-delimiter of every enclosing
+/// message: `Sum`/`Gauge`/`Histogram` -> `Metric` -> `ScopeMetrics` ->
+/// `ResourceMetrics`. Each of those four varints grows by at most 2 bytes as
+/// the payload approaches `MAX_EVENT_SIZE`, so 8 bytes is the true bound; 32
+/// gives ample headroom while costing nothing measurable in packing density.
+const SIZE_SLACK: usize = 32;
+
+/// Abstracts the destination of an encoded OTLP payload.
+///
+/// Production uses [`TracepointWriter`]. Tests substitute an in-memory writer so
+/// the encoding and batching logic can be exercised on any platform, not just
+/// Linux hosts with `user_events` available.
+trait EventWriter: Send + Sync {
+    fn enabled(&self) -> bool;
+    fn write(&self, buffer: &[u8]) -> i32;
+}
+
+struct TracepointWriter {
+    trace_point: Pin<Box<ehi::TracepointState>>,
+}
+
+impl TracepointWriter {
+    fn new() -> Self {
+        let trace_point = Box::pin(ehi::TracepointState::new(0));
+        // This is unsafe because if the code is used in a shared object,
+        // the event MUST be unregistered before the shared object unloads.
+        unsafe {
+            let _result = tracepoint::register(trace_point.as_ref());
+        }
+        TracepointWriter { trace_point }
+    }
+}
+
+impl EventWriter for TracepointWriter {
+    fn enabled(&self) -> bool {
+        self.trace_point.enabled()
+    }
+
+    fn write(&self, buffer: &[u8]) -> i32 {
+        tracepoint::write(&self.trace_point, buffer)
+    }
+}
+
+/// Number of bytes a single data point contributes to its enclosing
+/// `repeated` field: a 1-byte tag (all four data-point fields are field 1),
+/// the length varint, and the encoded body.
+fn data_point_cost<P: Message>(point: &P) -> usize {
+    let len = point.encoded_len();
+    1 + varint_len(len) + len
+}
+
+fn varint_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
 
 trait Numeric: Copy {
     // lossy at large values for u64 and i64 but otlp histograms only handle float values
@@ -62,18 +126,16 @@ impl Numeric for f64 {
 }
 
 pub struct MetricsExporter {
-    trace_point: Pin<Box<ehi::TracepointState>>,
+    writer: Box<dyn EventWriter>,
+    max_event_size: usize,
 }
 
 impl MetricsExporter {
     pub fn new() -> MetricsExporter {
-        let trace_point = Box::pin(ehi::TracepointState::new(0));
-        // This is unsafe because if the code is used in a shared object,
-        // the event MUST be unregistered before the shared object unloads.
-        unsafe {
-            let _result = tracepoint::register(trace_point.as_ref());
+        MetricsExporter {
+            writer: Box::new(TracepointWriter::new()),
+            max_event_size: MAX_EVENT_SIZE,
         }
-        MetricsExporter { trace_point }
     }
 }
 
@@ -98,339 +160,295 @@ fn to_nanos(time: SystemTime) -> u64 {
 impl MetricsExporter {
     fn process_numeric_metrics<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         data: &MetricData<T>,
     ) -> usize {
         match data {
-            MetricData::Gauge(gauge) => self.process_gauge(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                gauge,
-            ),
-            MetricData::Sum(sum) => self.process_sum(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                sum,
-            ),
-            MetricData::Histogram(hist) => self.process_histogram(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                hist,
-            ),
-            MetricData::ExponentialHistogram(hist) => self.process_exponential_histogram(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                hist,
-            ),
+            MetricData::Gauge(gauge) => self.process_gauge(request, byte_array, metric, gauge),
+            MetricData::Sum(sum) => self.process_sum(request, byte_array, metric, sum),
+            MetricData::Histogram(hist) => {
+                self.process_histogram(request, byte_array, metric, hist)
+            }
+            MetricData::ExponentialHistogram(hist) => {
+                self.process_exponential_histogram(request, byte_array, metric, hist)
+            }
+        }
+    }
+
+    /// Installs a `Metric` shell (name/description/unit, no data) as the single
+    /// metric of the single scope in `request`.
+    fn set_metric_shell(
+        request: &mut ExportMetricsServiceRequest,
+        metric: &opentelemetry_sdk::metrics::data::Metric,
+    ) {
+        request.resource_metrics[0].scope_metrics[0].metrics =
+            vec![opentelemetry_proto::tonic::metrics::v1::Metric {
+                name: metric.name().to_string(),
+                description: metric.description().to_string(),
+                unit: metric.unit().to_string(),
+                metadata: vec![],
+                data: None,
+            }];
+    }
+
+    /// Packs `points` into as few tracepoint events as possible.
+    ///
+    /// Data points are accumulated until adding one more would push the encoded
+    /// `ExportMetricsServiceRequest` past `max_event_size`, at which point the
+    /// batch is flushed and a new one is started with the remaining points. The
+    /// resource, scope and metric metadata (the "envelope") is therefore written
+    /// once per event rather than once per data point.
+    ///
+    /// Returns the number of data points that could not be exported.
+    fn emit_batched<P, F>(
+        &self,
+        request: &mut ExportMetricsServiceRequest,
+        byte_array: &mut Vec<u8>,
+        metric: &opentelemetry_sdk::metrics::data::Metric,
+        points: impl Iterator<Item = P>,
+        make_data: F,
+    ) -> usize
+    where
+        P: Message,
+        F: Fn(Vec<P>) -> ProtoData,
+    {
+        // Encode the envelope once (metric present, zero data points) to learn
+        // the fixed per-event cost.
+        request.resource_metrics[0].scope_metrics[0].metrics[0].data = Some(make_data(Vec::new()));
+        let envelope_len = request.encoded_len();
+
+        let mut batch: Vec<P> = Vec::new();
+        let mut batch_len = 0usize;
+        let mut failed_count = 0usize;
+
+        for point in points {
+            let cost = data_point_cost(&point);
+
+            if !batch.is_empty()
+                && envelope_len + batch_len + cost + SIZE_SLACK > self.max_event_size
+            {
+                failed_count +=
+                    self.flush_batch(request, byte_array, metric, &mut batch, &make_data);
+                batch_len = 0;
+            }
+
+            batch_len += cost;
+            batch.push(point);
+        }
+
+        if !batch.is_empty() {
+            failed_count += self.flush_batch(request, byte_array, metric, &mut batch, &make_data);
+        }
+
+        failed_count
+    }
+
+    /// Encodes and writes the accumulated batch, leaving `batch` empty.
+    fn flush_batch<P, F>(
+        &self,
+        request: &mut ExportMetricsServiceRequest,
+        byte_array: &mut Vec<u8>,
+        metric: &opentelemetry_sdk::metrics::data::Metric,
+        batch: &mut Vec<P>,
+        make_data: &F,
+    ) -> usize
+    where
+        P: Message,
+        F: Fn(Vec<P>) -> ProtoData,
+    {
+        let point_count = batch.len();
+        request.resource_metrics[0].scope_metrics[0].metrics[0].data =
+            Some(make_data(std::mem::take(batch)));
+
+        byte_array.clear();
+        if self
+            .encode_and_emit_metric(request, byte_array, metric)
+            .is_err()
+        {
+            point_count
+        } else {
+            0
         }
     }
 
     fn process_gauge<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         gauge: &opentelemetry_sdk::metrics::data::Gauge<T>,
     ) -> usize {
-        // Store and reuse common values for all data points in this gauge
-        let gauge_start_time = gauge.start_time().map(to_nanos).unwrap_or_default();
-        let gauge_time = to_nanos(gauge.time());
+        let start_time = gauge.start_time().map(to_nanos).unwrap_or_default();
+        let time = to_nanos(gauge.time());
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this gauge metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + value).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in gauge.data_points() {
-            let number_data_point = opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+        let points = gauge.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
                 attributes: dp.attributes().map(Into::into).collect(),
-                start_time_unix_nano: gauge_start_time,
-                time_unix_nano: gauge_time,
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
                 exemplars: Vec::new(), // No support for exemplars
                 flags: default_flags,
                 value: Some(dp.value().into_number_data_point_value()),
-            };
-
-            let gauge_point_proto = opentelemetry_proto::tonic::metrics::v1::Gauge {
-                data_points: vec![number_data_point],
-            };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(
-                opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(gauge_point_proto),
-            );
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::Gauge(opentelemetry_proto::tonic::metrics::v1::Gauge { data_points })
+        })
     }
 
     fn process_sum<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         sum: &opentelemetry_sdk::metrics::data::Sum<T>,
     ) -> usize {
-        // Pre-compute common values for all data points in this sum
-        let sum_start_time = to_nanos(sum.start_time());
-        let sum_time = to_nanos(sum.time());
-        let sum_is_monotonic = sum.is_monotonic();
+        let start_time = to_nanos(sum.start_time());
+        let time = to_nanos(sum.time());
+        let is_monotonic = sum.is_monotonic();
+        let temporality = sum.temporality() as i32;
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this sum metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + value).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in sum.data_points() {
-            let number_data_point = opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+        let points = sum.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
                 attributes: dp.attributes().map(Into::into).collect(),
-                start_time_unix_nano: sum_start_time,
-                time_unix_nano: sum_time,
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
                 exemplars: Vec::new(), // No support for exemplars
                 flags: default_flags,
                 value: Some(dp.value().into_number_data_point_value()),
-            };
-
-            let sum_point_proto = opentelemetry_proto::tonic::metrics::v1::Sum {
-                aggregation_temporality: sum.temporality() as i32,
-                is_monotonic: sum_is_monotonic,
-                data_points: vec![number_data_point],
-            };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
-                sum_point_proto,
-            ));
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::Sum(opentelemetry_proto::tonic::metrics::v1::Sum {
+                aggregation_temporality: temporality,
+                is_monotonic,
+                data_points,
+            })
+        })
     }
 
     fn process_histogram<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         hist: &opentelemetry_sdk::metrics::data::Histogram<T>,
     ) -> usize {
-        // Pre-compute common values for all data points in this histogram
-        let hist_start_time = to_nanos(hist.start_time());
-        let hist_time = to_nanos(hist.time());
+        let start_time = to_nanos(hist.start_time());
+        let time = to_nanos(hist.time());
+        let temporality = hist.temporality() as i32;
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this histogram metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + buckets).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in hist.data_points() {
-            let histogram_data_point =
-                opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint {
-                    attributes: dp.attributes().map(Into::into).collect(),
-                    start_time_unix_nano: hist_start_time,
-                    time_unix_nano: hist_time,
-                    count: dp.count(),
-                    sum: Some(dp.sum().into_f64()),
-                    bucket_counts: dp.bucket_counts().collect(),
-                    explicit_bounds: dp.bounds().collect(),
-                    exemplars: Vec::new(), // No support for exemplars
-                    flags: default_flags,
-                    min: dp.min().map(|v| v.into_f64()),
-                    max: dp.max().map(|v| v.into_f64()),
-                };
-
-            let histogram_point_proto = opentelemetry_proto::tonic::metrics::v1::Histogram {
-                aggregation_temporality: hist.temporality() as i32,
-                data_points: vec![histogram_data_point],
-            };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(
-                opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(
-                    histogram_point_proto,
-                ),
-            );
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
+        let points = hist.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint {
+                attributes: dp.attributes().map(Into::into).collect(),
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
+                count: dp.count(),
+                sum: Some(dp.sum().into_f64()),
+                bucket_counts: dp.bucket_counts().collect(),
+                explicit_bounds: dp.bounds().collect(),
+                exemplars: Vec::new(), // No support for exemplars
+                flags: default_flags,
+                min: dp.min().map(|v| v.into_f64()),
+                max: dp.max().map(|v| v.into_f64()),
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::Histogram(opentelemetry_proto::tonic::metrics::v1::Histogram {
+                aggregation_temporality: temporality,
+                data_points,
+            })
+        })
     }
 
     fn process_exponential_histogram<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         hist: &opentelemetry_sdk::metrics::data::ExponentialHistogram<T>,
     ) -> usize {
-        // Pre-compute common values for all data points in this histogram
-        let hist_start_time = to_nanos(hist.start_time());
-        let hist_time = to_nanos(hist.time());
+        let start_time = to_nanos(hist.start_time());
+        let time = to_nanos(hist.time());
+        let temporality = hist.temporality() as i32;
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this exponential histogram metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + buckets).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in hist.data_points() {
-            let histogram_data_point = opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint {
+        let points = hist.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint {
                 attributes: dp.attributes().map(Into::into).collect(),
-                start_time_unix_nano: hist_start_time,
-                time_unix_nano: hist_time,
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
                 count: dp.count() as u64,
                 sum: Some(dp.sum().into_f64()),
                 scale: dp.scale().into(),
                 zero_count: dp.zero_count(),
-                positive: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
-                    offset: dp.positive_bucket().offset(),
-                    bucket_counts: dp.positive_bucket().counts().collect(),
-                }),
-                negative: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
-                    offset: dp.negative_bucket().offset(),
-                    bucket_counts: dp.negative_bucket().counts().collect(),
-                }),
+                positive: Some(
+                    opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
+                        offset: dp.positive_bucket().offset(),
+                        bucket_counts: dp.positive_bucket().counts().collect(),
+                    },
+                ),
+                negative: Some(
+                    opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
+                        offset: dp.negative_bucket().offset(),
+                        bucket_counts: dp.negative_bucket().counts().collect(),
+                    },
+                ),
                 exemplars: Vec::new(), // No support for exemplars
                 flags: default_flags,
                 min: dp.min().map(|v| v.into_f64()),
                 max: dp.max().map(|v| v.into_f64()),
                 zero_threshold: dp.zero_threshold(),
-            };
-
-            let histogram_point_proto =
-                opentelemetry_proto::tonic::metrics::v1::ExponentialHistogram {
-                    aggregation_temporality: hist.temporality() as i32,
-                    data_points: vec![histogram_data_point],
-                };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(
-                opentelemetry_proto::tonic::metrics::v1::metric::Data::ExponentialHistogram(
-                    histogram_point_proto,
-                ),
-            );
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::ExponentialHistogram(
+                opentelemetry_proto::tonic::metrics::v1::ExponentialHistogram {
+                    aggregation_temporality: temporality,
+                    data_points,
+                },
+            )
+        })
     }
 
     fn encode_and_emit_metric(
         &self,
-        export_metric_service_request_common: &ExportMetricsServiceRequest,
+        request: &ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
     ) -> Result<(), String> {
-        match export_metric_service_request_common.encode(byte_array) {
+        match request.encode(byte_array) {
             Ok(_) => {
-                otel_debug!(name: "SerializationSucceeded", 
+                otel_debug!(name: "SerializationSucceeded",
                     metric_name = metric.name(),
                     size = byte_array.len());
 
-                if byte_array.len() > MAX_EVENT_SIZE {
-                    let error_msg = format!("Encoded event size exceeds maximum allowed limit of {MAX_EVENT_SIZE} bytes. Event will be dropped.");
+                if byte_array.len() > self.max_event_size {
+                    let error_msg = format!(
+                        "Encoded event size exceeds maximum allowed limit of {} bytes. Event will be dropped.",
+                        self.max_event_size
+                    );
                     otel_debug!(
                         name: "EventSizeExceeded",
                         reason = &error_msg,
@@ -440,7 +458,7 @@ impl MetricsExporter {
                     Err(error_msg)
                 } else {
                     // Write to the tracepoint
-                    let result = tracepoint::write(&self.trace_point, byte_array);
+                    let result = self.writer.write(byte_array);
                     if result == 0 {
                         otel_debug!(name: "TracepointWriteSucceeded", message = "Encoded data successfully written to tracepoint", size = byte_array.len(), metric_name = metric.name());
                         Ok(())
@@ -464,46 +482,17 @@ impl MetricsExporter {
 
     fn export_resource_metrics(&self, resource_metric: &ResourceMetrics) -> OTelSdkResult {
         // Custom transformation to protobuf structs is used instead of upstream
-        // transforms because tracepoint has a 64kB size limit. Encoding each
-        // data point separately ensures we stay within this limit and avoid
-        // data loss. Some upstream transforms are reused where appropriate for
-        // consistency. TODO: Optimize by batching multiple data points until
-        // the size limit is reached, rather than writing one data point at a
-        // time.
-
-        // OVERALL EXPORT FLOW: This method implements a 3-level nested loop
-        // structure:
+        // transforms because the tracepoint has a 64kB size limit. Data points
+        // are packed into as few events as possible while respecting that limit,
+        // so the resource/scope/metric envelope is amortized across many data
+        // points instead of being repeated for every one.
         //
-        // LOOP 1: Resource → Scopes (Instrumentation Libraries)
-        //   - Iterate through each scope/instrumentation library in the
-        //     resource
-        //   - Each scope contains multiple metrics from the same library
-        //
-        // LOOP 2: Scope → Metrics
-        //   - For each scope, iterate through all metrics (counters, gauges,
-        //     histograms)
-        //   - Each metric contains multiple data points with different
-        //     attribute combinations
-        //
-        // LOOP 3: Metric → Data Points
-        //   - For each metric, iterate through individual data points
-        //   - Each data point represents a unique combination of metric +
-        //     attributes + timestamp
-        //   - SERIALIZATION HAPPENS HERE: Each data point is encoded and
-        //     emitted individually
-        //
-        // PERFORMANCE OPTIMIZATIONS:
-        // - Reuse protobuf structure templates at each level to avoid repeated
-        //   allocations
-        // - Single byte_array is reused throughout: cleared between uses but
-        //   capacity retained
-        // - Common values (timestamps, flags, metadata) pre-computed (but not
-        //   pre-serialized) per metric to avoid duplication
-        // - Only the innermost data varies between serializations, parent
-        //   structures stay constant
+        // Batching is currently per-metric: a single event never mixes data
+        // points from different metrics or scopes. Packing across metrics would
+        // amortize the envelope further and is left as a follow-up.
         let mut byte_array = Vec::new();
         let mut has_failures = false;
-        let mut export_metric_service_request_common = ExportMetricsServiceRequest {
+        let mut request = ExportMetricsServiceRequest {
             resource_metrics: vec![opentelemetry_proto::tonic::metrics::v1::ResourceMetrics {
                 resource: Some((resource_metric.resource()).into()),
                 scope_metrics: vec![],
@@ -515,56 +504,29 @@ impl MetricsExporter {
             }],
         };
 
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 1: RESOURCE → SCOPES (Instrumentation Libraries)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each scope (instrumentation library) within this resource.
-        // Each scope groups metrics that originate from the same library/component.
         for scope_metric in resource_metric.scope_metrics() {
-            // Create reusable scope_metric_proto template with empty metrics
-            let scope_metric_proto = opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
-                scope: Some((scope_metric.scope(), None).into()),
-                metrics: vec![],
-                schema_url: scope_metric
-                    .scope()
-                    .schema_url()
-                    .unwrap_or_default()
-                    .to_string(),
-            };
+            request.resource_metrics[0].scope_metrics =
+                vec![opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
+                    scope: Some((scope_metric.scope(), None).into()),
+                    metrics: vec![],
+                    schema_url: scope_metric
+                        .scope()
+                        .schema_url()
+                        .unwrap_or_default()
+                        .to_string(),
+                }];
 
-            export_metric_service_request_common.resource_metrics[0].scope_metrics =
-                vec![scope_metric_proto];
-
-            // ═══════════════════════════════════════════════════════════════════════════════════
-            // LOOP 2: SCOPE → METRICS (Counters, Gauges, Histograms, etc.)
-            // ═══════════════════════════════════════════════════════════════════════════════════
-            // For each scope, iterate through all metrics of different types.
-            // Each metric will be processed by type-specific handlers that implement LOOP 3.
             for metric in scope_metric.metrics() {
                 let failed_count = match metric.data() {
                     AggregatedMetrics::F64(data) => {
-                        // → DELEGATES TO LOOP 3: process_* methods iterate through data points
-                        // → SERIALIZATION: Each data point encoded & emitted individually
-                        // → REUSE: Same byte_array cleared & reused for performance
-                        self.process_numeric_metrics(
-                            &mut export_metric_service_request_common,
-                            &mut byte_array,
-                            metric,
-                            data,
-                        )
+                        self.process_numeric_metrics(&mut request, &mut byte_array, metric, data)
                     }
-                    AggregatedMetrics::U64(data) => self.process_numeric_metrics(
-                        &mut export_metric_service_request_common,
-                        &mut byte_array,
-                        metric,
-                        data,
-                    ),
-                    AggregatedMetrics::I64(data) => self.process_numeric_metrics(
-                        &mut export_metric_service_request_common,
-                        &mut byte_array,
-                        metric,
-                        data,
-                    ),
+                    AggregatedMetrics::U64(data) => {
+                        self.process_numeric_metrics(&mut request, &mut byte_array, metric, data)
+                    }
+                    AggregatedMetrics::I64(data) => {
+                        self.process_numeric_metrics(&mut request, &mut byte_array, metric, data)
+                    }
                 };
 
                 // Log failure counts if any data points failed to export
@@ -590,7 +552,7 @@ impl MetricsExporter {
 impl PushMetricExporter for MetricsExporter {
     async fn export(&self, resource_metrics: &ResourceMetrics) -> OTelSdkResult {
         otel_debug!(name: "ExportStarted", message = "Starting metrics export");
-        if !self.trace_point.enabled() {
+        if !self.writer.enabled() {
             // TODO - This can flood the logs if the tracepoint is disabled for long periods of time
             otel_info!(name: "TracepointDisabled", message = "Tracepoint is disabled, skipping export");
             Ok(())
@@ -615,5 +577,430 @@ impl PushMetricExporter for MetricsExporter {
 
     fn shutdown(&self) -> OTelSdkResult {
         self.shutdown_with_timeout(Duration::from_secs(5))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry::KeyValue;
+    use opentelemetry_proto::tonic::metrics::v1::metric::Data as PData;
+    use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+    use opentelemetry_sdk::Resource;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct CollectingWriter {
+        events: Arc<Mutex<Vec<Vec<u8>>>>,
+    }
+
+    impl CollectingWriter {
+        fn take(&self) -> Vec<Vec<u8>> {
+            std::mem::take(&mut *self.events.lock().unwrap())
+        }
+    }
+
+    impl EventWriter for CollectingWriter {
+        fn enabled(&self) -> bool {
+            true
+        }
+
+        fn write(&self, buffer: &[u8]) -> i32 {
+            self.events.lock().unwrap().push(buffer.to_vec());
+            0
+        }
+    }
+
+    impl MetricsExporter {
+        fn for_test(writer: CollectingWriter, max_event_size: usize) -> Self {
+            MetricsExporter {
+                writer: Box::new(writer),
+                max_event_size,
+            }
+        }
+    }
+
+    /// Replaces the data points of `request` with `data_points`, preserving the
+    /// metric type and its type-specific fields.
+    fn with_data_points(
+        request: &ExportMetricsServiceRequest,
+        indices: &[usize],
+    ) -> ExportMetricsServiceRequest {
+        let mut out = request.clone();
+        let data = out.resource_metrics[0].scope_metrics[0].metrics[0]
+            .data
+            .as_mut()
+            .expect("metric has data");
+        fn keep<T: Clone>(points: &mut Vec<T>, indices: &[usize]) {
+            let all = std::mem::take(points);
+            *points = indices.iter().map(|&i| all[i].clone()).collect();
+        }
+        match data {
+            PData::Gauge(g) => keep(&mut g.data_points, indices),
+            PData::Sum(s) => keep(&mut s.data_points, indices),
+            PData::Histogram(h) => keep(&mut h.data_points, indices),
+            PData::ExponentialHistogram(h) => keep(&mut h.data_points, indices),
+            PData::Summary(s) => keep(&mut s.data_points, indices),
+        }
+        out
+    }
+
+    /// Encoded cost of the first data point of `request`, as charged by the
+    /// batching accounting in the exporter.
+    fn first_point_cost(request: &ExportMetricsServiceRequest) -> usize {
+        match request.resource_metrics[0].scope_metrics[0].metrics[0]
+            .data
+            .as_ref()
+            .expect("metric has data")
+        {
+            PData::Gauge(g) => data_point_cost(&g.data_points[0]),
+            PData::Sum(s) => data_point_cost(&s.data_points[0]),
+            PData::Histogram(h) => data_point_cost(&h.data_points[0]),
+            PData::ExponentialHistogram(h) => data_point_cost(&h.data_points[0]),
+            PData::Summary(s) => data_point_cost(&s.data_points[0]),
+        }
+    }
+
+    fn data_point_count(request: &ExportMetricsServiceRequest) -> usize {
+        match request.resource_metrics[0].scope_metrics[0].metrics[0]
+            .data
+            .as_ref()
+            .expect("metric has data")
+        {
+            PData::Gauge(g) => g.data_points.len(),
+            PData::Sum(s) => s.data_points.len(),
+            PData::Histogram(h) => h.data_points.len(),
+            PData::ExponentialHistogram(h) => h.data_points.len(),
+            PData::Summary(s) => s.data_points.len(),
+        }
+    }
+
+    #[derive(Debug)]
+    struct Stats {
+        batched_events: usize,
+        batched_bytes: usize,
+        baseline_events: usize,
+        baseline_bytes: usize,
+        data_points: usize,
+        envelope_bytes: usize,
+    }
+
+    impl Stats {
+        fn byte_ratio(&self) -> f64 {
+            self.baseline_bytes as f64 / self.batched_bytes as f64
+        }
+        fn write_ratio(&self) -> f64 {
+            self.baseline_events as f64 / self.batched_events as f64
+        }
+        /// Share of the unbatched payload that is pure repeated envelope.
+        fn baseline_waste_pct(&self) -> f64 {
+            (self.envelope_bytes * self.baseline_events) as f64 / self.baseline_bytes as f64 * 100.0
+        }
+    }
+
+    /// Measures what the exporter actually wrote, and what the same data would
+    /// have cost under the previous one-event-per-data-point scheme.
+    fn measure(events: &[Vec<u8>]) -> Stats {
+        let mut stats = Stats {
+            batched_events: events.len(),
+            batched_bytes: events.iter().map(|e| e.len()).sum(),
+            baseline_events: 0,
+            baseline_bytes: 0,
+            data_points: 0,
+            envelope_bytes: 0,
+        };
+
+        for raw in events {
+            let request =
+                ExportMetricsServiceRequest::decode(raw.as_slice()).expect("decodes as OTLP");
+            let count = data_point_count(&request);
+            stats.data_points += count;
+            stats.baseline_events += count;
+            for i in 0..count {
+                stats.baseline_bytes += with_data_points(&request, &[i]).encoded_len();
+            }
+            // Envelope = the same event with zero data points. Recorded from the
+            // first event only; it is identical across events of a metric.
+            if stats.envelope_bytes == 0 {
+                stats.envelope_bytes = with_data_points(&request, &[]).encoded_len();
+            }
+        }
+
+        stats
+    }
+
+    fn report(label: &str, stats: &Stats, expected_dps: usize) {
+        assert_eq!(
+            stats.data_points, expected_dps,
+            "{label}: scenario did not produce the expected number of series"
+        );
+        println!(
+            "{label:<44} | {:>7} | {:>6} | {:>10} | {:>10} | {:>5.2}x | {:>5.0}x | {:>5.1}%",
+            stats.data_points,
+            stats.envelope_bytes,
+            stats.baseline_bytes,
+            stats.batched_bytes,
+            stats.byte_ratio(),
+            stats.write_ratio(),
+            stats.baseline_waste_pct(),
+        );
+    }
+
+    fn header() {
+        println!(
+            "\n{:<44} | {:>7} | {:>6} | {:>10} | {:>10} | {:>6} | {:>6} | {:>6}",
+            "scenario", "dps", "envlp", "unbatched", "batched", "bytes", "writes", "waste"
+        );
+        println!("{}", "-".repeat(120));
+    }
+
+    /// Runs `record` against a meter provider wired to a collecting exporter and
+    /// returns the raw events the exporter produced.
+    fn run_scenario<F>(max_event_size: usize, record: F) -> Vec<Vec<u8>>
+    where
+        F: FnOnce(&opentelemetry::metrics::Meter),
+    {
+        let writer = CollectingWriter::default();
+        let exporter = MetricsExporter::for_test(writer.clone(), max_event_size);
+        let reader = PeriodicReader::builder(exporter).build();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes([
+                        KeyValue::new("service.name", "contoso-ingest"),
+                        KeyValue::new(
+                            "service.instance.id",
+                            "9f1c2b7e-4a3d-4c11-9b02-7e5f8a1d3c44",
+                        ),
+                        KeyValue::new("cloud.region", "eastus2"),
+                        KeyValue::new("host.name", "node-prod-0731"),
+                    ])
+                    .build(),
+            )
+            .build();
+
+        record(&provider.meter("contoso.ingest.meter"));
+        // Flush may legitimately report failure when a scenario deliberately
+        // configures a size limit that some data point cannot satisfy; callers
+        // assert on the emitted events instead.
+        let _ = provider.force_flush();
+        // Collect before shutdown: shutdown performs another collection, which
+        // would invoke observable callbacks a second time and double-count.
+        let events = writer.take();
+        let _ = provider.shutdown();
+        events
+    }
+
+    /// Attribute sets for `count` dimensions. The high-cardinality `partition`
+    /// key comes first so that every dimension count still yields distinct
+    /// series.
+    fn dims(i: usize, count: usize) -> Vec<KeyValue> {
+        let all = [
+            KeyValue::new("partition", format!("p{i:04}")),
+            KeyValue::new("operation", "GetBlobProperties"),
+            KeyValue::new("status_code", "200"),
+            KeyValue::new("client_version", "2024-11-04"),
+            KeyValue::new("protocol", "https"),
+        ];
+        all.into_iter().take(count).collect()
+    }
+
+    const SERIES: usize = 1000;
+
+    #[test]
+    fn batching_savings_report() {
+        header();
+
+        // Counter, 5 dimensions.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(1, &dims(i, 5));
+            }
+        });
+        let stats = measure(&events);
+        report("counter, 5 dims", &stats, SERIES);
+
+        // Counter, 2 dimensions: smaller payload against the same envelope, so
+        // the relative waste is worse.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(1, &dims(i, 2));
+            }
+        });
+        let stats = measure(&events);
+        report("counter, 2 dims", &stats, SERIES);
+
+        // Observable gauge.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            meter
+                .u64_observable_gauge("contoso.ingest.queue_depth")
+                .with_callback(|obs| {
+                    for i in 0..SERIES {
+                        obs.observe(i as u64, &dims(i, 4));
+                    }
+                })
+                .build();
+        });
+        let stats = measure(&events);
+        report("observable gauge, 4 dims", &stats, SERIES);
+
+        // Histogram: much larger data points (bucket counts + bounds), so the
+        // envelope is proportionally less significant.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            let h = meter.f64_histogram("contoso.ingest.latency").build();
+            for i in 0..SERIES {
+                h.record(12.5, &dims(i, 3));
+            }
+        });
+        let stats = measure(&events);
+        report("histogram, 3 dims", &stats, SERIES);
+
+        println!();
+    }
+
+    #[test]
+    fn every_event_is_within_the_size_limit() {
+        for max in [MAX_EVENT_SIZE, 8192, 2048, 512] {
+            let events = run_scenario(max, |meter| {
+                let c = meter.u64_counter("contoso.ingest.requests").build();
+                for i in 0..SERIES {
+                    c.add(1, &dims(i, 5));
+                }
+            });
+            assert!(!events.is_empty(), "max={max} produced no events");
+            for event in &events {
+                assert!(
+                    event.len() <= max,
+                    "event of {} bytes exceeds max_event_size {max}",
+                    event.len()
+                );
+            }
+            let stats = measure(&events);
+            assert_eq!(
+                stats.data_points, SERIES,
+                "max={max} lost or duplicated data points"
+            );
+
+            // Every event except the last must have been flushed because the
+            // next data point genuinely did not fit, not because the size
+            // accounting gave up early.
+            for i in 0..events.len().saturating_sub(1) {
+                let next = ExportMetricsServiceRequest::decode(events[i + 1].as_slice()).unwrap();
+                let next_cost = first_point_cost(&next);
+                let remaining = max - events[i].len();
+                assert!(
+                    remaining < next_cost + SIZE_SLACK,
+                    "event left {remaining} bytes unused but the next data point \
+                     needs only {next_cost} (max={max}); accounting is too conservative"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn batching_preserves_every_data_point_exactly_once() {
+        let events = run_scenario(4096, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(i as u64, &dims(i, 5));
+            }
+        });
+
+        let mut seen: Vec<(String, u64)> = Vec::new();
+        for raw in &events {
+            let request = ExportMetricsServiceRequest::decode(raw.as_slice()).unwrap();
+            let PData::Sum(sum) = request.resource_metrics[0].scope_metrics[0].metrics[0]
+                .data
+                .as_ref()
+                .unwrap()
+            else {
+                panic!("counter should encode as Sum");
+            };
+            for dp in &sum.data_points {
+                let partition = dp
+                    .attributes
+                    .iter()
+                    .find(|kv| kv.key == "partition")
+                    .and_then(|kv| kv.value.as_ref())
+                    .and_then(|v| match v.value.as_ref() {
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                s,
+                            ),
+                        ) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .expect("partition attribute present");
+                let value = match dp.value.as_ref().unwrap() {
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => {
+                        *v as u64
+                    }
+                    _ => panic!("counter should encode as int"),
+                };
+                seen.push((partition, value));
+            }
+        }
+
+        assert_eq!(seen.len(), SERIES, "wrong number of data points");
+        seen.sort();
+        seen.dedup_by(|a, b| a.0 == b.0);
+        assert_eq!(seen.len(), SERIES, "duplicate series across batches");
+        for (partition, value) in &seen {
+            let i: usize = partition.trim_start_matches('p').parse().unwrap();
+            assert_eq!(*value, i as u64, "value mismatch for {partition}");
+        }
+    }
+
+    #[test]
+    fn metric_metadata_is_repeated_in_every_event() {
+        // Each event must be independently decodable: resource, scope and metric
+        // identity are required in all of them, not just the first.
+        let events = run_scenario(2048, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(1, &dims(i, 5));
+            }
+        });
+        assert!(
+            events.len() > 1,
+            "expected the batch to span several events"
+        );
+        for raw in &events {
+            let request = ExportMetricsServiceRequest::decode(raw.as_slice()).unwrap();
+            let rm = &request.resource_metrics[0];
+            assert_eq!(rm.resource.as_ref().unwrap().attributes.len(), 4);
+            let sm = &rm.scope_metrics[0];
+            assert_eq!(sm.scope.as_ref().unwrap().name, "contoso.ingest.meter");
+            assert_eq!(sm.metrics[0].name, "contoso.ingest.requests");
+        }
+    }
+
+    #[test]
+    fn oversized_single_data_point_is_dropped_without_panicking() {
+        // A max_event_size below the envelope size means no data point can ever
+        // fit. The exporter must drop them and stay alive.
+        let events = run_scenario(64, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..10 {
+                c.add(1, &dims(i, 5));
+            }
+        });
+        assert!(
+            events.is_empty(),
+            "nothing should be written when no data point fits"
+        );
+    }
+
+    #[test]
+    fn varint_len_matches_prost() {
+        for len in [0usize, 1, 127, 128, 16_383, 16_384, 65_360, 2_097_151] {
+            let mut buf = Vec::new();
+            prost::encoding::encode_varint(len as u64, &mut buf);
+            assert_eq!(varint_len(len), buf.len(), "varint_len({len})");
+        }
     }
 }

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -16,14 +16,35 @@ use prost::Message;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
-/// Upper bound on the encoded size of a single tracepoint event.
+/// Maximum number of protobuf payload bytes that may be written in a single
+/// tracepoint event.
 ///
-/// A perf ring buffer record carries its length in a `__u16`, so a record can
-/// never exceed 65535 bytes in total. The payload budget is set slightly below
-/// that to leave room for the perf record header and the tracepoint's own
-/// fields, so a maximally packed event is still guaranteed to be representable
-/// (and therefore readable) by a perf consumer.
-pub(crate) const MAX_EVENT_SIZE: usize = 65360;
+/// A `user_events` tracepoint consumed through perf goes through
+/// `user_event_perf()`, which copies the record into a per-CPU scratch buffer
+/// obtained from `perf_trace_buf_alloc()`. That buffer is `PERF_MAX_TRACE_SIZE`
+/// (8192) bytes. If the record does not fit, `perf_trace_buf_alloc()` returns
+/// NULL and `user_event_perf()` returns without submitting anything, so the
+/// write silently succeeds from userspace while the event never reaches the
+/// consumer.
+///
+/// The size the kernel accounts for is
+/// `ALIGN(sizeof(struct trace_entry) + bytes_written_after_the_write_index, 8)`:
+///
+/// | component                         | bytes |
+/// |-----------------------------------|-------|
+/// | `struct trace_entry`              | 8     |
+/// | `u32 protocol`                    | 4     |
+/// | `char[8] version`                 | 8     |
+/// | `__rel_loc` descriptor for buffer | 4     |
+/// | **fixed overhead**                | 24    |
+///
+/// which leaves `8192 - 24 = 8168` bytes for the payload itself. See
+/// `src/tracepoint/mod.rs` for the field layout this is derived from.
+///
+/// Note that a consumer reading the same tracepoint through ftrace rather than
+/// perf is bounded by the trace ring buffer's per-event limit (roughly one
+/// page) instead, which is smaller still.
+pub(crate) const MAX_EVENT_SIZE: usize = 8168;
 
 /// Safety margin, in bytes, reserved when deciding whether another data point
 /// fits into the current batch.
@@ -489,7 +510,8 @@ impl MetricsExporter {
 
     fn export_resource_metrics(&self, resource_metric: &ResourceMetrics) -> OTelSdkResult {
         // Custom transformation to protobuf structs is used instead of upstream
-        // transforms because the tracepoint has a 64kB size limit. Data points
+        // transforms because a tracepoint event has a hard size limit (see
+        // MAX_EVENT_SIZE). Data points
         // are packed into as few events as possible while respecting that limit,
         // so the resource/scope/metric envelope is amortized across many data
         // points instead of being repeated for every one.

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -125,7 +125,15 @@ impl Numeric for u64 {
     fn into_number_data_point_value(
         self,
     ) -> opentelemetry_proto::tonic::metrics::v1::number_data_point::Value {
-        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(self as i64)
+        // OTLP carries integer data points as a signed `i64`, so a `u64` above
+        // `i64::MAX` has no faithful representation. `opentelemetry-proto` maps
+        // those to zero, and this matches it so that the same counter is
+        // reported identically over OTLP and over `user_events`. A raw `as`
+        // cast would instead surface such a value as a negative number, which
+        // is far worse for a monotonic counter.
+        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+            i64::try_from(self).unwrap_or_default(),
+        )
     }
 }
 
@@ -194,20 +202,15 @@ fn to_nanos(time: SystemTime) -> u64 {
 /// else: cumulative data would be written as UNSPECIFIED, which a consumer is
 /// entitled to reject or misinterpret.
 ///
-/// `LowMemory` is a reader-level preference rather than a property of collected
-/// data, so it should never reach this function; it is mapped to delta because
-/// that is the temporality it selects for the synchronous instruments it
-/// applies to.
+/// This defers to the conversion in `opentelemetry-proto` so that a metric is
+/// labelled identically whether it leaves the process over OTLP or over
+/// `user_events`. That conversion also owns the handling of `LowMemory`, which
+/// is a reader-level preference rather than a property of collected data and so
+/// should never reach an exporter.
 fn to_otlp_temporality(temporality: Temporality) -> i32 {
     use opentelemetry_proto::tonic::metrics::v1::AggregationTemporality;
 
-    match temporality {
-        Temporality::Delta | Temporality::LowMemory => AggregationTemporality::Delta as i32,
-        Temporality::Cumulative => AggregationTemporality::Cumulative as i32,
-        // `Temporality` is #[non_exhaustive]; a newly added variant is safer
-        // reported as unspecified than silently mislabelled as a known one.
-        _ => AggregationTemporality::Unspecified as i32,
-    }
+    AggregationTemporality::from(temporality) as i32
 }
 
 impl MetricsExporter {

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -185,6 +185,31 @@ fn to_nanos(time: SystemTime) -> u64 {
         .as_nanos() as u64
 }
 
+/// Maps the SDK's temporality to the OTLP wire value.
+///
+/// These two enums are *not* numbered the same. The SDK orders them
+/// `Cumulative = 0, Delta = 1, LowMemory = 2`, while OTLP uses
+/// `UNSPECIFIED = 0, DELTA = 1, CUMULATIVE = 2`. Casting the SDK value directly
+/// therefore happens to be correct for delta and silently wrong for everything
+/// else: cumulative data would be written as UNSPECIFIED, which a consumer is
+/// entitled to reject or misinterpret.
+///
+/// `LowMemory` is a reader-level preference rather than a property of collected
+/// data, so it should never reach this function; it is mapped to delta because
+/// that is the temporality it selects for the synchronous instruments it
+/// applies to.
+fn to_otlp_temporality(temporality: Temporality) -> i32 {
+    use opentelemetry_proto::tonic::metrics::v1::AggregationTemporality;
+
+    match temporality {
+        Temporality::Delta | Temporality::LowMemory => AggregationTemporality::Delta as i32,
+        Temporality::Cumulative => AggregationTemporality::Cumulative as i32,
+        // `Temporality` is #[non_exhaustive]; a newly added variant is safer
+        // reported as unspecified than silently mislabelled as a known one.
+        _ => AggregationTemporality::Unspecified as i32,
+    }
+}
+
 impl MetricsExporter {
     fn process_numeric_metrics<T: Numeric>(
         &self,
@@ -341,7 +366,7 @@ impl MetricsExporter {
         let start_time = to_nanos(sum.start_time());
         let time = to_nanos(sum.time());
         let is_monotonic = sum.is_monotonic();
-        let temporality = sum.temporality() as i32;
+        let temporality = to_otlp_temporality(sum.temporality());
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
@@ -376,7 +401,7 @@ impl MetricsExporter {
     ) -> usize {
         let start_time = to_nanos(hist.start_time());
         let time = to_nanos(hist.time());
-        let temporality = hist.temporality() as i32;
+        let temporality = to_otlp_temporality(hist.temporality());
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
@@ -415,7 +440,7 @@ impl MetricsExporter {
     ) -> usize {
         let start_time = to_nanos(hist.start_time());
         let time = to_nanos(hist.time());
-        let temporality = hist.temporality() as i32;
+        let temporality = to_otlp_temporality(hist.temporality());
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -45,6 +45,17 @@ mod tests {
         /// pipeline with a self-contained, in-process consumer (no external tools,
         /// no temp files, no `sudo` shell-outs).
         pub fn collect_otlp_metrics<F: FnOnce()>(emit: F) -> Vec<ExportMetricsServiceRequest> {
+            collect_otlp_metrics_with_pages(32, emit)
+        }
+
+        /// Same as [`collect_otlp_metrics`], but with a configurable per-CPU ring
+        /// buffer size. High-cardinality scenarios emit several hundred kilobytes
+        /// in a single export cycle and will silently lose records if the ring
+        /// buffer is left at the default 32 pages (128 KiB).
+        pub fn collect_otlp_metrics_with_pages<F: FnOnce()>(
+            page_count: usize,
+            emit: F,
+        ) -> Vec<ExportMetricsServiceRequest> {
             let need_permission = "Need permission to access tracefs/perf_events (run via sudo?)";
 
             let tracefs = TraceFS::open().expect(need_permission);
@@ -70,7 +81,7 @@ mod tests {
             });
 
             let mut session = RingBufSessionBuilder::new()
-                .with_page_count(32)
+                .with_page_count(page_count)
                 .with_tracepoint_events(RingBufBuilder::for_tracepoint())
                 .with_target_pid(std::process::id() as i32)
                 .build()
@@ -189,6 +200,172 @@ mod tests {
                     actual_attributes
                 })
                 .collect()
+        }
+
+        /// A decoded numeric data point value.
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub enum Num {
+            I(i64),
+            D(f64),
+        }
+
+        /// Renders an OTLP `AnyValue` into a stable string form so tests can
+        /// assert on attribute values of any type without a match arm per type.
+        pub fn render_value(value: &opentelemetry_proto::tonic::common::v1::AnyValue) -> String {
+            use opentelemetry_proto::tonic::common::v1::any_value::Value;
+            match value.value.as_ref() {
+                Some(Value::StringValue(s)) => s.clone(),
+                Some(Value::BoolValue(b)) => b.to_string(),
+                Some(Value::IntValue(i)) => i.to_string(),
+                Some(Value::DoubleValue(d)) => d.to_string(),
+                Some(Value::ArrayValue(a)) => {
+                    let rendered: Vec<String> = a.values.iter().map(render_value).collect();
+                    format!("[{}]", rendered.join(","))
+                }
+                Some(Value::BytesValue(b)) => format!("{b:?}"),
+                Some(Value::KvlistValue(_)) => "<kvlist>".to_string(),
+                Some(other) => format!("{other:?}"),
+                None => "<empty>".to_string(),
+            }
+        }
+
+        /// Extracts a data point's attributes as sorted `(key, rendered value)`
+        /// pairs.
+        pub fn attrs_of(
+            attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+        ) -> Vec<(String, String)> {
+            let mut out: Vec<(String, String)> = attributes
+                .iter()
+                .map(|a| {
+                    let rendered = a.value.as_ref().map(render_value).unwrap_or_default();
+                    (a.key.clone(), rendered)
+                })
+                .collect();
+            out.sort();
+            out
+        }
+
+        /// Returns every occurrence of `name` across all events. A metric appears
+        /// once per event it was batched into, so this legitimately returns more
+        /// than one entry for a high-cardinality metric.
+        pub fn find_metrics<'a>(
+            requests: &'a [ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<&'a opentelemetry_proto::tonic::metrics::v1::Metric> {
+            requests
+                .iter()
+                .flat_map(|r| &r.resource_metrics)
+                .flat_map(|rm| &rm.scope_metrics)
+                .flat_map(|sm| &sm.metrics)
+                .filter(|m| m.name == name)
+                .collect()
+        }
+
+        /// Flattens every `NumberDataPoint` of `name` across all events into
+        /// `(sorted attributes, value)` pairs.
+        pub fn number_points(
+            requests: &[ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<(Vec<(String, String)>, Num)> {
+            use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+            use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
+
+            let mut out = Vec::new();
+            for metric in find_metrics(requests, name) {
+                let points = match metric.data.as_ref().expect("metric data missing") {
+                    Data::Sum(s) => &s.data_points,
+                    Data::Gauge(g) => &g.data_points,
+                    other => panic!("metric {name} is not a Sum or Gauge: {other:?}"),
+                };
+                for dp in points {
+                    let value = match dp.value.as_ref().expect("data point value missing") {
+                        Value::AsInt(i) => Num::I(*i),
+                        Value::AsDouble(d) => Num::D(*d),
+                    };
+                    out.push((attrs_of(&dp.attributes), value));
+                }
+            }
+            out
+        }
+
+        /// Flattens every `HistogramDataPoint` of `name` across all events.
+        pub fn histogram_points(
+            requests: &[ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<(
+            Vec<(String, String)>,
+            opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint,
+        )> {
+            use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+
+            let mut out = Vec::new();
+            for metric in find_metrics(requests, name) {
+                let Data::Histogram(h) = metric.data.as_ref().expect("metric data missing") else {
+                    panic!("metric {name} is not a Histogram");
+                };
+                for dp in &h.data_points {
+                    out.push((attrs_of(&dp.attributes), dp.clone()));
+                }
+            }
+            out
+        }
+
+        /// Asserts that no event exceeds the exporter's per-event size budget.
+        ///
+        /// This is the invariant the whole batching scheme rests on: a perf ring
+        /// buffer record length is a `__u16`, so an event that overshoots would be
+        /// silently unreadable rather than merely large. Because these payloads
+        /// came back out of the kernel, this also proves the bound end to end.
+        pub fn assert_all_events_within_size_limit(requests: &[ExportMetricsServiceRequest]) {
+            for (index, request) in requests.iter().enumerate() {
+                let len = request.encoded_len();
+                assert!(
+                    len <= crate::exporter::MAX_EVENT_SIZE,
+                    "event {} is {} bytes, over the {} byte limit",
+                    index,
+                    len,
+                    crate::exporter::MAX_EVENT_SIZE
+                );
+            }
+        }
+
+        /// Asserts that every event repeats the full resource and scope envelope.
+        ///
+        /// Batching amortizes the envelope across the data points inside one
+        /// event, but each event must remain independently decodable, so the
+        /// envelope must still be present in all of them.
+        pub fn assert_envelope_repeated(
+            requests: &[ExportMetricsServiceRequest],
+            expected_resource_attrs: &[(&str, &str)],
+            expected_scope_name: &str,
+        ) {
+            assert!(!requests.is_empty(), "expected at least one event");
+            for (index, request) in requests.iter().enumerate() {
+                assert_eq!(
+                    request.resource_metrics.len(),
+                    1,
+                    "event {index} should carry exactly one resource_metrics"
+                );
+                let rm = &request.resource_metrics[0];
+                let resource = rm.resource.as_ref().expect("resource missing");
+                let actual = attrs_of(&resource.attributes);
+                for (key, value) in expected_resource_attrs {
+                    assert!(
+                        actual.contains(&((*key).to_string(), (*value).to_string())),
+                        "event {index} is missing resource attribute {key}={value}, got {actual:?}"
+                    );
+                }
+                assert_eq!(
+                    rm.scope_metrics.len(),
+                    1,
+                    "event {index} should carry exactly one scope_metrics"
+                );
+                let scope = rm.scope_metrics[0].scope.as_ref().expect("scope missing");
+                assert_eq!(
+                    scope.name, expected_scope_name,
+                    "event {index} has the wrong scope name"
+                );
+            }
         }
     }
 
@@ -644,5 +821,804 @@ mod tests {
             .collect();
         actual_attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
         assert_eq!(actual_attrs, vec![KeyValue::new("mykey1", "myvalue1")]);
+    }
+
+    /// Builds a provider whose resource carries a few attributes, mirroring a
+    /// realistic (small) Overlake-style resource.
+    fn test_provider() -> SdkMeterProvider {
+        SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![
+                        KeyValue::new("service.name", "metric-demo"),
+                        KeyValue::new("service.namespace", "demo-ns"),
+                        KeyValue::new("host.name", "test-host"),
+                    ])
+                    .build(),
+            )
+            .with_periodic_exporter(MetricsExporter::new())
+            .build()
+    }
+
+    const RESOURCE_ATTRS: &[(&str, &str)] = &[
+        ("service.name", "metric-demo"),
+        ("service.namespace", "demo-ns"),
+        ("host.name", "test-host"),
+    ];
+
+    /// High-cardinality end-to-end batching test.
+    ///
+    /// This is the test that actually proves the batching change against the
+    /// kernel rather than against a mock: 2000 distinct series are exported,
+    /// read back out of the perf ring buffer, and checked for exact
+    /// preservation. It also proves that a maximally packed event survives the
+    /// `__u16` perf record length limit, which is the reason `MAX_EVENT_SIZE`
+    /// exists at all.
+    #[ignore]
+    #[test]
+    fn integration_test_batching_high_cardinality() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 2000;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_high_cardinality").build();
+
+        for i in 0..SERIES {
+            counter.add(
+                1,
+                &[
+                    KeyValue::new("partition", format!("p{i}")),
+                    KeyValue::new("region", "westus2"),
+                    KeyValue::new("cluster", "cluster-a"),
+                ],
+            );
+        }
+
+        // 2000 series is a few hundred KiB; the default 32-page ring buffer
+        // would drop records and make this test flaky.
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+
+        // Batching must collapse many data points into far fewer events. With
+        // ~60 byte data points and a 65360 byte budget this should be a ~1000x
+        // reduction; assert a very loose 10x so the test is about the behaviour,
+        // not about a particular encoding size.
+        assert!(
+            decoded.len() * 10 < SERIES,
+            "expected batching to produce far fewer than {} events, got {}",
+            SERIES,
+            decoded.len()
+        );
+
+        let points = test_utils::number_points(&decoded, "counter_high_cardinality");
+        assert_eq!(
+            points.len(),
+            SERIES,
+            "every data point must be exported exactly once"
+        );
+
+        let mut partitions: Vec<String> = points
+            .iter()
+            .map(|(attrs, value)| {
+                assert_eq!(*value, test_utils::Num::I(1), "unexpected counter value");
+                assert!(
+                    attrs.contains(&("region".to_string(), "westus2".to_string())),
+                    "data point lost its constant attributes: {attrs:?}"
+                );
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing")
+            })
+            .collect();
+        partitions.sort();
+        partitions.dedup();
+        assert_eq!(
+            partitions.len(),
+            SERIES,
+            "data points were duplicated or dropped"
+        );
+    }
+
+    /// Every event except the last must be packed until the next data point no
+    /// longer fits. This guards against a regression that silently flushes early
+    /// and gives back the byte savings.
+    #[ignore]
+    #[test]
+    fn integration_test_batching_packs_events_to_capacity() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use prost::Message;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_packing").build();
+
+        for i in 0..3000 {
+            counter.add(1, &[KeyValue::new("partition", format!("p{i:05}"))]);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        assert!(
+            decoded.len() > 1,
+            "test needs enough data points to fill more than one event, got {} events",
+            decoded.len()
+        );
+        test_utils::assert_all_events_within_size_limit(&decoded);
+
+        // The most expensive data point anywhere in the export. If an event has
+        // at least this much room left over, the batcher could have fitted
+        // another point into it and flushed too early.
+        let point_cost = |dp: &opentelemetry_proto::tonic::metrics::v1::NumberDataPoint| {
+            let len = dp.encoded_len();
+            // field tag (1 byte, field number 1) + length delimiter + payload
+            1 + prost::length_delimiter_len(len) + len
+        };
+        let max_point_cost = decoded
+            .iter()
+            .flat_map(|r| &r.resource_metrics)
+            .flat_map(|rm| &rm.scope_metrics)
+            .flat_map(|sm| &sm.metrics)
+            .map(|m| {
+                let Data::Sum(sum) = m.data.as_ref().expect("metric data missing") else {
+                    panic!("expected Sum data");
+                };
+                sum.data_points.iter().map(point_cost).max().unwrap_or(0)
+            })
+            .max()
+            .expect("no data points were exported");
+
+        // Records from a single export can land in different per-CPU ring
+        // buffers if the exporter thread migrates, so the order they are read
+        // back in is not guaranteed. Assert an order-independent property
+        // instead: only the final (partial) event may be under-filled.
+        let underfilled = decoded
+            .iter()
+            .filter(|request| {
+                crate::exporter::MAX_EVENT_SIZE - request.encoded_len()
+                    >= max_point_cost + crate::exporter::SIZE_SLACK
+            })
+            .count();
+        assert!(
+            underfilled <= 1,
+            "{} of {} events had room for another data point; only the final partial event may be \
+             under-filled (largest data point costs {} bytes)",
+            underfilled,
+            decoded.len(),
+            max_point_cost
+        );
+    }
+
+    /// A single data point too large to ever fit in one event is dropped, and
+    /// crucially the surrounding data points are still exported.
+    #[ignore]
+    #[test]
+    fn integration_test_oversized_data_point_is_dropped_but_others_survive() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_oversized").build();
+
+        counter.add(1, &[KeyValue::new("partition", "small-a")]);
+        // Comfortably larger than MAX_EVENT_SIZE on its own.
+        counter.add(1, &[KeyValue::new("partition", "X".repeat(70_000))]);
+        counter.add(1, &[KeyValue::new("partition", "small-b")]);
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            // The dropped data point surfaces as an export error, which is the
+            // documented behaviour; the test asserts on what was exported.
+            let _ = provider.shutdown();
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+
+        let points = test_utils::number_points(&decoded, "counter_oversized");
+        let partitions: Vec<String> = points
+            .iter()
+            .map(|(attrs, _)| {
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing")
+            })
+            .collect();
+
+        assert!(
+            partitions.iter().any(|p| p == "small-a"),
+            "small data point before the oversized one was lost: {partitions:?}"
+        );
+        assert!(
+            partitions.iter().any(|p| p == "small-b"),
+            "small data point after the oversized one was lost: {partitions:?}"
+        );
+        assert!(
+            !partitions.iter().any(|p| p.len() > 1000),
+            "oversized data point should have been dropped"
+        );
+    }
+
+    /// Batching is per-metric, so three instruments in one export cycle produce
+    /// three independent events, each carrying its own full envelope.
+    #[ignore]
+    #[test]
+    fn integration_test_multiple_metrics_in_one_cycle() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        meter
+            .u64_counter("multi_counter")
+            .build()
+            .add(7, &[KeyValue::new("k", "v")]);
+        meter
+            .u64_gauge("multi_gauge")
+            .build()
+            .record(11, &[KeyValue::new("k", "v")]);
+        meter
+            .f64_histogram("multi_histogram")
+            .build()
+            .record(2.5, &[KeyValue::new("k", "v")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+
+        assert_eq!(
+            decoded.len(),
+            3,
+            "expected one event per metric, got {}",
+            decoded.len()
+        );
+        for request in &decoded {
+            assert_eq!(
+                request.resource_metrics[0].scope_metrics[0].metrics.len(),
+                1,
+                "each event should carry exactly one metric"
+            );
+        }
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "multi_counter"),
+            vec![(
+                vec![("k".to_string(), "v".to_string())],
+                test_utils::Num::I(7)
+            )]
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "multi_gauge"),
+            vec![(
+                vec![("k".to_string(), "v".to_string())],
+                test_utils::Num::I(11)
+            )]
+        );
+        let hist = test_utils::histogram_points(&decoded, "multi_histogram");
+        assert_eq!(hist.len(), 1);
+        assert_eq!(hist[0].1.count, 1);
+        assert_eq!(hist[0].1.sum, Some(2.5));
+    }
+
+    /// Each instrumentation scope must be emitted in its own event with its own
+    /// scope metadata (name, version, schema URL).
+    #[ignore]
+    #[test]
+    fn integration_test_multiple_meters_keep_scope_metadata() {
+        use opentelemetry::InstrumentationScope;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+
+        let meter_a = provider.meter_with_scope(
+            InstrumentationScope::builder("scope.a")
+                .with_version("1.2.3")
+                .with_schema_url("https://example.com/schema/a")
+                .build(),
+        );
+        let meter_b = provider.meter_with_scope(
+            InstrumentationScope::builder("scope.b")
+                .with_version("4.5.6")
+                .build(),
+        );
+
+        meter_a
+            .u64_counter("scoped_counter_a")
+            .build()
+            .add(1, &[KeyValue::new("k", "v")]);
+        meter_b
+            .u64_counter("scoped_counter_b")
+            .build()
+            .add(2, &[KeyValue::new("k", "v")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert_eq!(decoded.len(), 2, "expected one event per scope");
+
+        let mut scopes: Vec<(String, String, String)> = decoded
+            .iter()
+            .map(|r| {
+                let sm = &r.resource_metrics[0].scope_metrics[0];
+                let scope = sm.scope.as_ref().expect("scope missing");
+                (
+                    scope.name.clone(),
+                    scope.version.clone(),
+                    sm.schema_url.clone(),
+                )
+            })
+            .collect();
+        scopes.sort();
+
+        assert_eq!(
+            scopes,
+            vec![
+                (
+                    "scope.a".to_string(),
+                    "1.2.3".to_string(),
+                    "https://example.com/schema/a".to_string()
+                ),
+                ("scope.b".to_string(), "4.5.6".to_string(), String::new()),
+            ]
+        );
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "scoped_counter_a")[0].1,
+            test_utils::Num::I(1)
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "scoped_counter_b")[0].1,
+            test_utils::Num::I(2)
+        );
+    }
+
+    /// Asynchronous instruments go through the same batching path as synchronous
+    /// ones, and must preserve monotonicity and aggregation temporality.
+    #[ignore]
+    #[test]
+    fn integration_test_observable_instruments() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use opentelemetry_proto::tonic::metrics::v1::AggregationTemporality;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        let _obs_counter = meter
+            .u64_observable_counter("obs_counter")
+            .with_callback(|o| {
+                o.observe(100, &[KeyValue::new("k", "a")]);
+                o.observe(200, &[KeyValue::new("k", "b")]);
+            })
+            .build();
+        let _obs_udc = meter
+            .i64_observable_up_down_counter("obs_updowncounter")
+            .with_callback(|o| o.observe(-5, &[KeyValue::new("k", "a")]))
+            .build();
+        let _obs_gauge = meter
+            .u64_observable_gauge("obs_gauge")
+            .with_callback(|o| o.observe(42, &[KeyValue::new("k", "a")]))
+            .build();
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+
+        let mut counter_points = test_utils::number_points(&decoded, "obs_counter");
+        counter_points.sort_by_key(|(attrs, _)| attrs.clone());
+        assert_eq!(
+            counter_points,
+            vec![
+                (
+                    vec![("k".to_string(), "a".to_string())],
+                    test_utils::Num::I(100)
+                ),
+                (
+                    vec![("k".to_string(), "b".to_string())],
+                    test_utils::Num::I(200)
+                ),
+            ]
+        );
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "obs_updowncounter"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(-5)
+            )]
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "obs_gauge"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(42)
+            )]
+        );
+
+        // Monotonicity and temporality must survive batching.
+        for metric in test_utils::find_metrics(&decoded, "obs_counter") {
+            let Data::Sum(sum) = metric.data.as_ref().unwrap() else {
+                panic!("obs_counter should be a Sum");
+            };
+            assert!(sum.is_monotonic, "observable counter must be monotonic");
+            assert_eq!(
+                sum.aggregation_temporality,
+                AggregationTemporality::Delta as i32,
+                "exporter declares Delta temporality"
+            );
+        }
+        for metric in test_utils::find_metrics(&decoded, "obs_updowncounter") {
+            let Data::Sum(sum) = metric.data.as_ref().unwrap() else {
+                panic!("obs_updowncounter should be a Sum");
+            };
+            assert!(
+                !sum.is_monotonic,
+                "observable updowncounter must be non-monotonic"
+            );
+        }
+        for metric in test_utils::find_metrics(&decoded, "obs_gauge") {
+            assert!(
+                matches!(metric.data.as_ref().unwrap(), Data::Gauge(_)),
+                "obs_gauge should be a Gauge"
+            );
+        }
+    }
+
+    /// Floating point instruments must round-trip as `AsDouble`, not be coerced
+    /// to integers.
+    #[ignore]
+    #[test]
+    fn integration_test_f64_instruments() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        let counter = meter.f64_counter("counter_f64").build();
+        counter.add(1.5, &[KeyValue::new("k", "a")]);
+        counter.add(2.25, &[KeyValue::new("k", "a")]);
+
+        let udc = meter.f64_up_down_counter("updown_f64").build();
+        udc.add(-0.5, &[KeyValue::new("k", "a")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert_eq!(
+            test_utils::number_points(&decoded, "counter_f64"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::D(3.75)
+            )]
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "updown_f64"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::D(-0.5)
+            )]
+        );
+    }
+
+    /// Attribute values of every supported type must survive encoding. The
+    /// batching path re-encodes data points individually, so this guards against
+    /// a type being lost or coerced during that step.
+    #[ignore]
+    #[test]
+    fn integration_test_attribute_value_types() {
+        use opentelemetry::{Array, StringValue, Value};
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_attr_types").build();
+
+        counter.add(
+            1,
+            &[
+                KeyValue::new("str", "text"),
+                KeyValue::new("bool", true),
+                KeyValue::new("int", 42i64),
+                KeyValue::new("double", 1.5f64),
+                KeyValue::new(
+                    "str_array",
+                    Value::Array(Array::String(vec![
+                        StringValue::from("a"),
+                        StringValue::from("b"),
+                    ])),
+                ),
+            ],
+        );
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        let points = test_utils::number_points(&decoded, "counter_attr_types");
+        assert_eq!(points.len(), 1);
+
+        let expected = vec![
+            ("bool".to_string(), "true".to_string()),
+            ("double".to_string(), "1.5".to_string()),
+            ("int".to_string(), "42".to_string()),
+            ("str".to_string(), "text".to_string()),
+            ("str_array".to_string(), "[a,b]".to_string()),
+        ];
+        assert_eq!(points[0].0, expected);
+    }
+
+    /// A data point with no attributes at all must still be exported.
+    #[ignore]
+    #[test]
+    fn integration_test_no_attributes() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        meter.u64_counter("counter_no_attrs").build().add(9, &[]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert_eq!(
+            test_utils::number_points(&decoded, "counter_no_attrs"),
+            vec![(Vec::new(), test_utils::Num::I(9))]
+        );
+    }
+
+    /// `force_flush` must export the current cycle, and because the exporter
+    /// declares Delta temporality a subsequent cycle must carry only what was
+    /// recorded since the previous export.
+    #[ignore]
+    #[test]
+    fn integration_test_force_flush_across_cycles_is_delta() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_delta").build();
+
+        counter.add(3, &[KeyValue::new("k", "a")]);
+        let first = test_utils::collect_otlp_metrics(|| {
+            provider.force_flush().expect("first force_flush failed");
+        });
+        assert_eq!(
+            test_utils::number_points(&first, "counter_delta"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(3)
+            )]
+        );
+
+        counter.add(4, &[KeyValue::new("k", "a")]);
+        let second = test_utils::collect_otlp_metrics(|| {
+            provider.force_flush().expect("second force_flush failed");
+        });
+        assert_eq!(
+            test_utils::number_points(&second, "counter_delta"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(4)
+            )],
+            "Delta temporality means the second cycle reports only the increment"
+        );
+
+        provider.shutdown().expect("shutdown failed");
+    }
+
+    /// An export cycle with nothing recorded must not emit any event.
+    #[ignore]
+    #[test]
+    fn integration_test_no_metrics_emits_no_events() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let _meter = provider.meter("user-event-test");
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        assert!(
+            decoded.is_empty(),
+            "expected no events when nothing was recorded, got {}",
+            decoded.len()
+        );
+    }
+
+    /// Exponential histograms use a different data point type than every other
+    /// instrument, so they exercise a distinct arm of the batching code.
+    #[ignore]
+    #[test]
+    fn integration_test_exponential_histogram() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use opentelemetry_sdk::metrics::{Aggregation, Instrument, Stream};
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let view = |i: &Instrument| {
+            if i.name() == "exp_histogram" {
+                Some(
+                    Stream::builder()
+                        .with_aggregation(Aggregation::Base2ExponentialHistogram {
+                            max_size: 160,
+                            max_scale: 20,
+                            record_min_max: true,
+                        })
+                        .build()
+                        .unwrap(),
+                )
+            } else {
+                None
+            }
+        };
+
+        let provider = SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![
+                        KeyValue::new("service.name", "metric-demo"),
+                        KeyValue::new("service.namespace", "demo-ns"),
+                        KeyValue::new("host.name", "test-host"),
+                    ])
+                    .build(),
+            )
+            .with_periodic_exporter(MetricsExporter::new())
+            .with_view(view)
+            .build();
+
+        let meter = provider.meter("user-event-test");
+        let hist = meter.f64_histogram("exp_histogram").build();
+        for attr in ["a", "b"] {
+            let attrs = [KeyValue::new("k", attr)];
+            hist.record(1.0, &attrs);
+            hist.record(4.0, &attrs);
+            hist.record(16.0, &attrs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        assert_eq!(
+            decoded.len(),
+            1,
+            "both attribute sets should be packed into one event"
+        );
+
+        let metrics = test_utils::find_metrics(&decoded, "exp_histogram");
+        assert_eq!(metrics.len(), 1);
+        let Data::ExponentialHistogram(exp) = metrics[0].data.as_ref().unwrap() else {
+            panic!("expected ExponentialHistogram data");
+        };
+        assert_eq!(
+            exp.data_points.len(),
+            2,
+            "both attribute sets must be batched into the same event"
+        );
+        for dp in &exp.data_points {
+            assert_eq!(dp.count, 3);
+            assert_eq!(dp.sum, Some(21.0));
+            assert_eq!(dp.min, Some(1.0));
+            assert_eq!(dp.max, Some(16.0));
+        }
+    }
+
+    /// Histogram data points are much larger than number data points, so this
+    /// checks that batching stays correct (and within the size limit) for the
+    /// data point type most likely to overflow an event.
+    #[ignore]
+    #[test]
+    fn integration_test_histogram_batching_many_attribute_sets() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 500;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let hist = meter.f64_histogram("histogram_batched").build();
+
+        for i in 0..SERIES {
+            let attrs = [KeyValue::new("partition", format!("p{i:04}"))];
+            hist.record(1.0, &attrs);
+            hist.record(3.0, &attrs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        assert!(
+            decoded.len() > 1,
+            "histogram data points are large enough that 500 series should span several events"
+        );
+
+        let points = test_utils::histogram_points(&decoded, "histogram_batched");
+        assert_eq!(
+            points.len(),
+            SERIES,
+            "every histogram data point must survive"
+        );
+
+        let mut partitions: Vec<String> = points
+            .iter()
+            .map(|(attrs, dp)| {
+                assert_eq!(dp.count, 2);
+                assert_eq!(dp.sum, Some(4.0));
+                assert_eq!(dp.min, Some(1.0));
+                assert_eq!(dp.max, Some(3.0));
+                assert_eq!(
+                    dp.bucket_counts.len(),
+                    dp.explicit_bounds.len() + 1,
+                    "bucket layout must survive batching"
+                );
+                assert_eq!(dp.bucket_counts.iter().sum::<u64>(), dp.count);
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing")
+            })
+            .collect();
+        partitions.sort();
+        partitions.dedup();
+        assert_eq!(
+            partitions.len(),
+            SERIES,
+            "histogram data points were duplicated or dropped"
+        );
     }
 }

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -312,10 +312,12 @@ mod tests {
 
         /// Asserts that no event exceeds the exporter's per-event size budget.
         ///
-        /// This is the invariant the whole batching scheme rests on: a perf ring
-        /// buffer record length is a `__u16`, so an event that overshoots would be
-        /// silently unreadable rather than merely large. Because these payloads
-        /// came back out of the kernel, this also proves the bound end to end.
+        /// This is the invariant the whole batching scheme rests on. A record
+        /// that exceeds `PERF_MAX_TRACE_SIZE` is refused by
+        /// `perf_trace_buf_alloc()` and never submitted, while the write still
+        /// reports success, so an event that overshoots is silently lost rather
+        /// than merely large. Because these payloads came back out of the
+        /// kernel, this also proves the bound end to end.
         pub fn assert_all_events_within_size_limit(requests: &[ExportMetricsServiceRequest]) {
             for (index, request) in requests.iter().enumerate() {
                 let len = request.encoded_len();
@@ -851,9 +853,10 @@ mod tests {
     /// This is the test that actually proves the batching change against the
     /// kernel rather than against a mock: 2000 distinct series are exported,
     /// read back out of the perf ring buffer, and checked for exact
-    /// preservation. It also proves that a maximally packed event survives the
-    /// `__u16` perf record length limit, which is the reason `MAX_EVENT_SIZE`
-    /// exists at all.
+    /// preservation. Because every data point must be accounted for, it also
+    /// proves that events packed up to `MAX_EVENT_SIZE` are actually delivered
+    /// rather than silently refused by `perf_trace_buf_alloc()`, which is the
+    /// reason `MAX_EVENT_SIZE` exists at all.
     #[ignore]
     #[test]
     fn integration_test_batching_high_cardinality() {
@@ -888,7 +891,7 @@ mod tests {
         test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
 
         // Batching must collapse many data points into far fewer events. With
-        // ~60 byte data points and a 65360 byte budget this should be a ~1000x
+        // ~60 byte data points and an 8168 byte budget this is roughly a 100x
         // reduction; assert a very loose 10x so the test is about the behaviour,
         // not about a particular encoding size.
         assert!(
@@ -960,6 +963,18 @@ mod tests {
             decoded.len()
         );
         test_utils::assert_all_events_within_size_limit(&decoded);
+
+        // Packing density is only meaningful if nothing was lost on the way.
+        // An event packed a few bytes over the real kernel budget is refused by
+        // `perf_trace_buf_alloc()` without any error surfacing to the writer, so
+        // without this check a `MAX_EVENT_SIZE` that is slightly too large would
+        // still satisfy every assertion below.
+        let points = test_utils::number_points(&decoded, "counter_packing");
+        assert_eq!(
+            points.len(),
+            3000,
+            "every data point must survive the round trip through the kernel"
+        );
 
         // The most expensive data point anywhere in the export. If an event has
         // at least this much room left over, the batcher could have fitted

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -132,61 +132,63 @@ mod tests {
             }
         }
 
-        /// Extract and validate data point from metric data (supports Sum and Gauge types)
-        /// Returns the attributes from the single data point after validation
+        /// Extracts the sorted attribute set of every data point in `metric`,
+        /// validating each value against `expected_value`.
+        ///
+        /// The exporter packs as many data points as fit into one event, so a
+        /// single payload legitimately carries several data points.
         pub fn extract_and_validate_metric_data(
             metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
             expected_value: u64,
             request_index: usize,
-        ) -> Vec<opentelemetry::KeyValue> {
-            if let Some(data) = &metric.data {
-                // Use helper method to extract data points based on metric type
-                let data_points = extract_metric_data(data, request_index);
+        ) -> Vec<Vec<opentelemetry::KeyValue>> {
+            let Some(data) = &metric.data else {
+                panic!("Metric data is missing in request {}", request_index + 1);
+            };
 
-                // Validate exactly one data point
-                assert_eq!(
-                    data_points.len(),
-                    1,
-                    "Request {} should have exactly one data point",
-                    request_index + 1
-                );
+            let data_points = extract_metric_data(data, request_index);
+            assert!(
+                !data_points.is_empty(),
+                "Request {} should carry at least one data point",
+                request_index + 1
+            );
 
-                let data_point = &data_points[0];
-
-                // Validate counter value
-                if let Some(value) = &data_point.value {
-                    match value {
-                        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(int_val) => {
-                            assert_eq!(*int_val as u64, expected_value,
-                                "Counter value should match expected value in request {}", request_index + 1);
+            data_points
+                .iter()
+                .map(|data_point| {
+                    // Validate counter value
+                    if let Some(value) = &data_point.value {
+                        match value {
+                            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(int_val) => {
+                                assert_eq!(*int_val as u64, expected_value,
+                                    "Counter value should match expected value in request {}", request_index + 1);
+                            }
+                            _ => panic!("Expected integer value for u64 counter in request {}", request_index + 1),
                         }
-                        _ => panic!("Expected integer value for u64 counter in request {}", request_index + 1),
                     }
-                }
 
-                // Extract attributes from data point
-                let mut actual_attributes: Vec<opentelemetry::KeyValue> = Vec::new();
-                for attr in &data_point.attributes {
-                    if let Some(value) = &attr.value {
-                        if let Some(string_value) = &value.value {
-                            match string_value {
-                                opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
-                                    actual_attributes.push(opentelemetry::KeyValue::new(attr.key.clone(), s.clone()));
-                                }
-                                _ => {
-                                    panic!("Unsupported attribute value type for key: {} in request {}", attr.key, request_index + 1);
+                    // Extract attributes from data point
+                    let mut actual_attributes: Vec<opentelemetry::KeyValue> = Vec::new();
+                    for attr in &data_point.attributes {
+                        if let Some(value) = &attr.value {
+                            if let Some(string_value) = &value.value {
+                                match string_value {
+                                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
+                                        actual_attributes.push(opentelemetry::KeyValue::new(attr.key.clone(), s.clone()));
+                                    }
+                                    _ => {
+                                        panic!("Unsupported attribute value type for key: {} in request {}", attr.key, request_index + 1);
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                // Sort attributes for consistent comparison
-                actual_attributes.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
-                actual_attributes
-            } else {
-                panic!("Metric data is missing in request {}", request_index + 1);
-            }
+                    // Sort attributes for consistent comparison
+                    actual_attributes.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+                    actual_attributes
+                })
+                .collect()
         }
     }
 
@@ -258,11 +260,12 @@ mod tests {
         let expected_service_name = "metric-demo";
         let expected_meter_name = "user-event-test";
 
-        // STEP 1: Validate upfront that we have exactly 2 entries
+        // STEP 1: Both data points are small and share one metric, so the
+        // exporter must pack them into a single event.
         assert_eq!(
             decoded_metrics.len(),
-            2,
-            "Expected exactly 2 metrics payloads (one per data point)"
+            1,
+            "Expected a single batched payload carrying both data points"
         );
 
         // STEP 2: Do common validation on both entries (resource, scope, metric metadata)
@@ -339,7 +342,7 @@ mod tests {
             }
         }
 
-        // STEP 3: Validate that each entry has exactly one data point and collect attributes
+        // STEP 3: Collect the attribute set of every data point across all events
         let mut actual_attribute_sets = Vec::new();
 
         for (index, metrics_request) in decoded_metrics.iter().enumerate() {
@@ -350,12 +353,13 @@ mod tests {
                     for metric in &scope_metric.metrics {
                         if metric.name == expected_counter_name {
                             // Use helper method to extract and validate metric data
-                            let actual_attributes = test_utils::extract_and_validate_metric_data(
-                                metric,
-                                expected_value,
-                                index,
+                            actual_attribute_sets.extend(
+                                test_utils::extract_and_validate_metric_data(
+                                    metric,
+                                    expected_value,
+                                    index,
+                                ),
                             );
-                            actual_attribute_sets.push(actual_attributes);
                         }
                     }
                 }
@@ -429,8 +433,8 @@ mod tests {
 
         assert_eq!(
             decoded.len(),
-            2,
-            "Expected one event per data point (2 attribute sets)"
+            1,
+            "Expected both attribute sets to be packed into a single event"
         );
 
         let mut values: Vec<(u64, Vec<KeyValue>)> = Vec::new();
@@ -441,25 +445,25 @@ mod tests {
                         assert_eq!(m.name, "gauge_u64_test");
                         let data = m.data.as_ref().expect("metric data missing");
                         let dps = test_utils::extract_metric_data(data, 0);
-                        assert_eq!(dps.len(), 1, "expected 1 data point per event");
-                        let dp = &dps[0];
-                        let value = match dp.value.as_ref().expect("value missing") {
-                            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v as u64,
-                            _ => panic!("expected integer value for u64 gauge"),
-                        };
-                        let mut attrs: Vec<KeyValue> = dp
-                            .attributes
-                            .iter()
-                            .map(|a| {
-                                let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
-                                    Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
-                                    _ => panic!("unexpected attribute value type"),
-                                };
-                                KeyValue::new(a.key.clone(), v)
-                            })
-                            .collect();
-                        attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
-                        values.push((value, attrs));
+                        for dp in dps {
+                            let value = match dp.value.as_ref().expect("value missing") {
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v as u64,
+                                _ => panic!("expected integer value for u64 gauge"),
+                            };
+                            let mut attrs: Vec<KeyValue> = dp
+                                .attributes
+                                .iter()
+                                .map(|a| {
+                                    let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
+                                        _ => panic!("unexpected attribute value type"),
+                                    };
+                                    KeyValue::new(a.key.clone(), v)
+                                })
+                                .collect();
+                            attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+                            values.push((value, attrs));
+                        }
                     }
                 }
             }
@@ -510,7 +514,11 @@ mod tests {
                 .expect("Failed to shutdown meter provider");
         });
 
-        assert_eq!(decoded.len(), 2, "Expected one event per attribute set");
+        assert_eq!(
+            decoded.len(),
+            1,
+            "Expected both attribute sets to be packed into a single event"
+        );
 
         let mut results: Vec<(i64, Vec<KeyValue>, bool)> = Vec::new();
         for req in &decoded {
@@ -524,25 +532,25 @@ mod tests {
                             _ => panic!("expected Sum data for updowncounter"),
                         };
                         assert!(!sum.is_monotonic, "updowncounter sum must be non-monotonic");
-                        assert_eq!(sum.data_points.len(), 1);
-                        let dp = &sum.data_points[0];
-                        let value = match dp.value.as_ref().expect("value missing") {
-                            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v,
-                            _ => panic!("expected integer value for i64 updowncounter"),
-                        };
-                        let mut attrs: Vec<KeyValue> = dp
-                            .attributes
-                            .iter()
-                            .map(|a| {
-                                let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
-                                    Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
-                                    _ => panic!("unexpected attribute value type"),
-                                };
-                                KeyValue::new(a.key.clone(), v)
-                            })
-                            .collect();
-                        attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
-                        results.push((value, attrs, sum.is_monotonic));
+                        for dp in &sum.data_points {
+                            let value = match dp.value.as_ref().expect("value missing") {
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v,
+                                _ => panic!("expected integer value for i64 updowncounter"),
+                            };
+                            let mut attrs: Vec<KeyValue> = dp
+                                .attributes
+                                .iter()
+                                .map(|a| {
+                                    let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
+                                        _ => panic!("unexpected attribute value type"),
+                                    };
+                                    KeyValue::new(a.key.clone(), v)
+                                })
+                                .collect();
+                            attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+                            results.push((value, attrs, sum.is_monotonic));
+                        }
                     }
                 }
             }

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -947,7 +947,15 @@ mod tests {
         let meter = provider.meter("user-event-test");
         let counter = meter.u64_counter("counter_packing").build();
 
-        for i in 0..3000 {
+        // Stay at or below the SDK's default cardinality limit (2000 series per
+        // instrument). Beyond it the SDK folds the excess into a single
+        // `otel.metric.overflow` data point, which would make the count below
+        // ambiguous: a shortfall could mean either aggregation overflow or an
+        // event lost in the kernel, and this test needs to detect only the
+        // latter. 2000 series still fills many events at MAX_EVENT_SIZE.
+        const SERIES: usize = 2000;
+
+        for i in 0..SERIES {
             counter.add(1, &[KeyValue::new("partition", format!("p{i:05}"))]);
         }
 
@@ -972,7 +980,7 @@ mod tests {
         let points = test_utils::number_points(&decoded, "counter_packing");
         assert_eq!(
             points.len(),
-            3000,
+            SERIES,
             "every data point must survive the round trip through the kernel"
         );
 

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -1874,8 +1874,9 @@ mod tests {
             );
             assert_eq!(
                 sum.aggregation_temporality,
-                AggregationTemporality::Delta as i32,
-                "occurrence {index} lost delta temporality"
+                AggregationTemporality::Cumulative as i32,
+                "occurrence {index} has the wrong temporality; the SDK aggregates \
+                 up/down counters cumulatively"
             );
         }
 
@@ -2563,5 +2564,70 @@ mod tests {
                 "{name} was never exported"
             );
         }
+    }
+
+    /// Pins the mapping from the SDK's `Temporality` to the OTLP wire value.
+    ///
+    /// The two enums are numbered differently (`Cumulative` is 0 in the SDK but
+    /// 2 in OTLP, where 0 means UNSPECIFIED), so a direct cast is wrong for
+    /// everything except delta. This asserts the actual bytes a consumer reads
+    /// for both a delta instrument and a cumulative one.
+    #[ignore]
+    #[test]
+    fn integration_test_temporality_uses_otlp_wire_values() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use opentelemetry_proto::tonic::metrics::v1::AggregationTemporality;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        meter
+            .u64_counter("temporality_counter")
+            .build()
+            .add(1, &[KeyValue::new("k", "a")]);
+        meter
+            .i64_up_down_counter("temporality_updown")
+            .build()
+            .add(1, &[KeyValue::new("k", "a")]);
+        meter
+            .f64_histogram("temporality_histogram")
+            .build()
+            .record(1.0, &[KeyValue::new("k", "a")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        let temporality_of = |name: &str| -> i32 {
+            let metrics = test_utils::find_metrics(&decoded, name);
+            assert!(!metrics.is_empty(), "{name} was never exported");
+            match metrics[0].data.as_ref().expect("metric data missing") {
+                Data::Sum(s) => s.aggregation_temporality,
+                Data::Histogram(h) => h.aggregation_temporality,
+                other => panic!("{name} has unexpected data {other:?}"),
+            }
+        };
+
+        // A monotonic counter is aggregated as delta, which is 1 in both enums.
+        assert_eq!(
+            temporality_of("temporality_counter"),
+            AggregationTemporality::Delta as i32
+        );
+        assert_eq!(
+            temporality_of("temporality_histogram"),
+            AggregationTemporality::Delta as i32
+        );
+
+        // An up/down counter is aggregated cumulatively, which is 2 on the wire.
+        // A direct enum cast would write 0 here, which OTLP defines as
+        // UNSPECIFIED.
+        let updown = temporality_of("temporality_updown");
+        assert_ne!(
+            updown,
+            AggregationTemporality::Unspecified as i32,
+            "cumulative temporality must not be written as UNSPECIFIED"
+        );
+        assert_eq!(updown, AggregationTemporality::Cumulative as i32);
     }
 }

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -2389,8 +2389,10 @@ mod tests {
     /// An instrument that reports no observations must not produce an event,
     /// and must not disturb a populated metric exported in the same cycle.
     ///
-    /// This exercises `emit_batched` with an empty data point iterator, which
-    /// is the path where a stale batch from the previous metric could leak out.
+    /// This asserts the externally visible behaviour only. SDK 0.32 drops a
+    /// metric whose aggregation produced no data points before calling the
+    /// exporter, so the exporter's empty-batch path is not reached from here;
+    /// this test exists to notice if that ever stops being true.
     #[ignore]
     #[test]
     fn integration_test_observable_with_no_observations_emits_no_event() {
@@ -2551,6 +2553,33 @@ mod tests {
                  regardless of how they are split across {} event(s)",
                 decoded.len()
             );
+
+            // Counting is not enough: losing one point and duplicating the
+            // other also yields two. The two payloads are distinguishable by
+            // their first byte, so assert exactly one of each survived intact.
+            let mut prefixes: Vec<char> = points
+                .iter()
+                .map(|(attrs, value)| {
+                    assert_eq!(
+                        *value,
+                        test_utils::Num::I(1),
+                        "size {size}: data point value was altered"
+                    );
+                    attrs
+                        .iter()
+                        .find(|(k, _)| k == "payload")
+                        .map(|(_, v)| v.chars().next().expect("payload is never empty"))
+                        .expect("payload attribute missing")
+                })
+                .collect();
+            prefixes.sort_unstable();
+            assert_eq!(
+                prefixes,
+                vec!['a', 'b'],
+                "size {size}: expected both distinct data points to survive the split, \
+                 got payload prefixes {prefixes:?}"
+            );
+
             decoded.len()
         };
 

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -70,12 +70,20 @@ mod tests {
 
             let collected = Writable::<Vec<ExportMetricsServiceRequest>>::new(Vec::new());
             let sink = collected.clone();
+            // A captured event that does not decode is a wire-format failure and
+            // must fail the test. Recording it here rather than panicking keeps
+            // the panic out of the perf callback, where it would unwind through
+            // the parsing library.
+            let decode_errors = Writable::<Vec<String>>::new(Vec::new());
+            let error_sink = decode_errors.clone();
 
             event.add_callback(move |data| {
                 let buffer = data.format().get_data(buffer_ref, data.event_data());
                 match ExportMetricsServiceRequest::decode(buffer) {
                     Ok(request) => sink.write(|out| out.push(request)),
-                    Err(e) => eprintln!("Failed to decode OTLP metrics from buffer: {e}"),
+                    Err(e) => error_sink.write(|out| {
+                        out.push(format!("{} byte event failed to decode: {e}", buffer.len()))
+                    }),
                 }
                 Ok(())
             });
@@ -107,6 +115,14 @@ mod tests {
             session
                 .parse_all()
                 .expect("Failed to parse perf ring buffer");
+
+            let mut errors = Vec::new();
+            decode_errors.read(|v| errors = v.clone());
+            assert!(
+                errors.is_empty(),
+                "the exporter wrote {} event(s) that are not valid OTLP: {errors:#?}",
+                errors.len()
+            );
 
             let mut decoded_metrics = Vec::new();
             collected.read(|v| decoded_metrics = v.clone());
@@ -1155,17 +1171,24 @@ mod tests {
             })
             .collect();
 
-        assert!(
-            partitions.iter().any(|p| p == "small-a"),
-            "small data point before the oversized one was lost: {partitions:?}"
+        assert_eq!(
+            partitions.len(),
+            2,
+            "expected exactly the two small data points to survive, got {partitions:?}"
+        );
+        let mut sorted = partitions.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted,
+            vec!["small-a".to_string(), "small-b".to_string()],
+            "the oversized data point must be dropped and the two small ones emitted \
+             exactly once each: {partitions:?}"
         );
         assert!(
-            partitions.iter().any(|p| p == "small-b"),
-            "small data point after the oversized one was lost: {partitions:?}"
-        );
-        assert!(
-            !partitions.iter().any(|p| p.len() > 1000),
-            "oversized data point should have been dropped"
+            points
+                .iter()
+                .all(|(_, value)| *value == test_utils::Num::I(1)),
+            "surviving data point values were altered: {points:?}"
         );
     }
 
@@ -2283,6 +2306,306 @@ mod tests {
         }
     }
 
+    /// Every split event must repeat the full scope and resource identity, not
+    /// just the scope name.
+    ///
+    /// A consumer receives these events independently and cannot reconstruct a
+    /// missing version or schema URL from a neighbouring event, so dropping
+    /// them on continuation events would silently change how the data is
+    /// attributed.
+    #[ignore]
+    #[test]
+    fn integration_test_scope_and_resource_identity_repeated_on_every_split_event() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.30.0";
+        const SERIES: usize = 900;
+
+        let provider = SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("service.name", "metric-demo")])
+                    .with_schema_url(Vec::<KeyValue>::new(), SCHEMA_URL)
+                    .build(),
+            )
+            .with_periodic_exporter(MetricsExporter::new())
+            .build();
+
+        let meter = provider.meter_with_scope(
+            opentelemetry::InstrumentationScope::builder("scoped-meter")
+                .with_version("4.5.6")
+                .with_schema_url(SCHEMA_URL)
+                .build(),
+        );
+        let counter = meter.u64_counter("counter_scope_identity").build();
+        for i in 0..SERIES {
+            counter.add(1, &[KeyValue::new("partition", format!("p{i:04}"))]);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert!(
+            decoded.len() > 1,
+            "expected the metric to split across several events, got {}",
+            decoded.len()
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "counter_scope_identity").len(),
+            SERIES,
+            "data points were lost while splitting"
+        );
+
+        for (index, request) in decoded.iter().enumerate() {
+            let resource_metrics = &request.resource_metrics;
+            assert_eq!(resource_metrics.len(), 1, "event {index}");
+            let rm = &resource_metrics[0];
+            assert_eq!(
+                rm.schema_url, SCHEMA_URL,
+                "event {index} lost the resource schema URL"
+            );
+            assert!(
+                rm.resource.is_some(),
+                "event {index} lost the resource entirely"
+            );
+
+            assert_eq!(rm.scope_metrics.len(), 1, "event {index}");
+            let sm = &rm.scope_metrics[0];
+            assert_eq!(
+                sm.schema_url, SCHEMA_URL,
+                "event {index} lost the scope schema URL"
+            );
+            let scope = sm.scope.as_ref().expect("scope missing");
+            assert_eq!(scope.name, "scoped-meter", "event {index}");
+            assert_eq!(
+                scope.version, "4.5.6",
+                "event {index} lost the scope version"
+            );
+        }
+    }
+
+    /// An instrument that reports no observations must not produce an event,
+    /// and must not disturb a populated metric exported in the same cycle.
+    ///
+    /// This exercises `emit_batched` with an empty data point iterator, which
+    /// is the path where a stale batch from the previous metric could leak out.
+    #[ignore]
+    #[test]
+    fn integration_test_observable_with_no_observations_emits_no_event() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        let _empty = meter
+            .u64_observable_counter("counter_never_observed")
+            .with_callback(|_observer| {
+                // Deliberately reports nothing.
+            })
+            .build();
+
+        meter
+            .u64_counter("counter_populated")
+            .build()
+            .add(7, &[KeyValue::new("partition", "only")]);
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert!(
+            test_utils::find_metrics(&decoded, "counter_never_observed").is_empty(),
+            "an instrument with no observations must not be exported"
+        );
+
+        let points = test_utils::number_points(&decoded, "counter_populated");
+        assert_eq!(
+            points,
+            vec![(
+                vec![("partition".to_string(), "only".to_string())],
+                test_utils::Num::I(7)
+            )],
+            "the populated metric was altered by the empty instrument"
+        );
+    }
+
+    /// Pins the exact byte at which a single data point stops being emitted.
+    ///
+    /// The monotonicity test above only brackets the cutoff; it would still
+    /// pass if the exporter were wildly over-conservative and silently dropped
+    /// points that the kernel would have accepted. This binary-searches the
+    /// exact attribute size at which delivery stops, then asserts that the
+    /// largest delivered event genuinely fills the budget. That is what proves
+    /// the accounting is tight rather than merely safe.
+    #[ignore]
+    #[test]
+    fn integration_test_single_data_point_cutoff_is_exact() {
+        use prost::Message;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        // Returns the encoded size of the delivered event, or None if the data
+        // point was dropped.
+        let probe = |size: usize| -> Option<usize> {
+            let provider = test_provider();
+            let meter = provider.meter("user-event-test");
+            let counter = meter.u64_counter("counter_cutoff").build();
+            counter.add(1, &[KeyValue::new("payload", "x".repeat(size))]);
+
+            let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+                // A data point that cannot be encoded within the limit is
+                // reported as an export error, which is expected here.
+                let _ = provider.shutdown();
+            });
+
+            test_utils::assert_all_events_within_size_limit(&decoded);
+            if test_utils::number_points(&decoded, "counter_cutoff").is_empty() {
+                None
+            } else {
+                assert_eq!(decoded.len(), 1, "size {size} produced more than one event");
+                Some(decoded[0].encoded_len())
+            }
+        };
+
+        let mut lo = 1024;
+        let mut hi = 16384;
+        assert!(probe(lo).is_some(), "a 1 KiB data point must be delivered");
+        assert!(probe(hi).is_none(), "a 16 KiB data point must be dropped");
+
+        // Invariant: `lo` is always delivered and `hi` is always dropped.
+        while hi - lo > 1 {
+            let mid = lo + (hi - lo) / 2;
+            if probe(mid).is_some() {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+
+        let largest = probe(lo).expect("the search invariant guarantees lo is delivered");
+        println!("cutoff: attribute size {lo} delivered as a {largest} byte event, {hi} dropped");
+
+        assert!(
+            largest <= crate::exporter::MAX_EVENT_SIZE,
+            "the largest delivered event is {largest} bytes, over the {} byte budget",
+            crate::exporter::MAX_EVENT_SIZE
+        );
+
+        // Growing the attribute by one byte grows the encoded request by one
+        // byte (plus at most a few bytes of varint growth in the enclosing
+        // length delimiters), so a tight implementation must land within
+        // `SIZE_SLACK` of the budget. A larger gap means usable space is being
+        // given away and near-limit data points are dropped unnecessarily.
+        let headroom = crate::exporter::MAX_EVENT_SIZE - largest;
+        assert!(
+            headroom <= crate::exporter::SIZE_SLACK,
+            "the largest deliverable data point leaves {headroom} bytes of the {} byte \
+             budget unused, which is more than the {} bytes of slack the encoder reserves; \
+             the size accounting is over-conservative and is dropping valid data points",
+            crate::exporter::MAX_EVENT_SIZE,
+            crate::exporter::SIZE_SLACK
+        );
+    }
+
+    /// Pins the exact byte at which a second data point is pushed into a new
+    /// event, and proves nothing is lost at that split.
+    ///
+    /// This is the counterpart to the test above: that one exercises the
+    /// "single point does not fit at all" path, this one exercises the "batch
+    /// is full, start another event" path at single-byte granularity.
+    #[ignore]
+    #[test]
+    fn integration_test_batch_split_boundary_is_exact() {
+        use prost::Message;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        // Emits two equally sized data points and returns how many events they
+        // were spread across, asserting no loss either way.
+        let probe = |size: usize| -> usize {
+            let provider = test_provider();
+            let meter = provider.meter("user-event-test");
+            let counter = meter.u64_counter("counter_split_cutoff").build();
+            counter.add(
+                1,
+                &[KeyValue::new("payload", format!("a{}", "x".repeat(size)))],
+            );
+            counter.add(
+                1,
+                &[KeyValue::new("payload", format!("b{}", "x".repeat(size)))],
+            );
+
+            let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+                provider.shutdown().expect("shutdown failed");
+            });
+
+            test_utils::assert_all_events_within_size_limit(&decoded);
+            let points = test_utils::number_points(&decoded, "counter_split_cutoff");
+            assert_eq!(
+                points.len(),
+                2,
+                "size {size}: both data points fit individually, so neither may be lost \
+                 regardless of how they are split across {} event(s)",
+                decoded.len()
+            );
+            decoded.len()
+        };
+
+        // At 512 bytes each both points share one event; at 4096 bytes each
+        // they cannot.
+        let mut lo = 512;
+        let mut hi = 4096;
+        assert_eq!(
+            probe(lo),
+            1,
+            "two 512 byte data points must share one event"
+        );
+        assert_eq!(probe(hi), 2, "two 4 KiB data points cannot share one event");
+
+        // Invariant: `lo` fits in one event, `hi` requires two.
+        while hi - lo > 1 {
+            let mid = lo + (hi - lo) / 2;
+            if probe(mid) == 1 {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+
+        println!(
+            "split boundary: two {lo} byte points share an event, two {hi} byte points do not"
+        );
+
+        // Confirm the boundary is where the encoder says it is: the combined
+        // event at `lo` must genuinely be near the budget, not split early.
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_split_full").build();
+        counter.add(
+            1,
+            &[KeyValue::new("payload", format!("a{}", "x".repeat(lo)))],
+        );
+        counter.add(
+            1,
+            &[KeyValue::new("payload", format!("b{}", "x".repeat(lo)))],
+        );
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+        assert_eq!(decoded.len(), 1);
+        let filled = decoded[0].encoded_len();
+        let headroom = crate::exporter::MAX_EVENT_SIZE - filled;
+        assert!(
+            headroom <= crate::exporter::SIZE_SLACK,
+            "the last two data points to share an event only filled {filled} of the {} byte \
+             budget, leaving {headroom} bytes unused; the batch is being split early",
+            crate::exporter::MAX_EVENT_SIZE
+        );
+    }
+
     // ---------------------------------------------------------------------
     // Value and attribute edge cases.
     // ---------------------------------------------------------------------
@@ -2298,6 +2621,9 @@ mod tests {
 
         let big = meter.u64_counter("counter_u64_max").build();
         big.add(u64::MAX, &[KeyValue::new("k", "max")]);
+
+        let representable = meter.u64_counter("counter_u64_representable").build();
+        representable.add(i64::MAX as u64, &[KeyValue::new("k", "max_i64")]);
 
         let small = meter.i64_up_down_counter("updown_i64_min").build();
         small.add(i64::MIN, &[KeyValue::new("k", "min")]);
@@ -2315,15 +2641,27 @@ mod tests {
         test_utils::assert_all_events_within_size_limit(&decoded);
 
         // OTLP represents integral data points as a signed 64-bit value, so a
-        // u64 above i64::MAX arrives with the same bit pattern reinterpreted.
-        // This is a property of the wire format rather than of batching; the
-        // assertion pins the behaviour so a future encoding change is noticed.
+        // u64 above i64::MAX has no faithful representation. `opentelemetry-proto`
+        // clamps those to zero, and this exporter matches it so that the same
+        // counter is reported identically over OTLP and over `user_events`. The
+        // assertion is written against the value a consumer actually sees: a
+        // reinterpreted bit pattern would surface as a negative monotonic
+        // counter, which is worse than a zero.
         let big_points = test_utils::number_points(&decoded, "counter_u64_max");
         assert_eq!(big_points.len(), 1);
-        let test_utils::Num::I(raw) = big_points[0].1 else {
-            panic!("expected an integer data point");
-        };
-        assert_eq!(raw as u64, u64::MAX, "u64::MAX must round-trip bitwise");
+        assert_eq!(
+            big_points[0].1,
+            test_utils::Num::I(0),
+            "a u64 above i64::MAX must not be written as a negative value"
+        );
+
+        let representable = test_utils::number_points(&decoded, "counter_u64_representable");
+        assert_eq!(representable.len(), 1);
+        assert_eq!(
+            representable[0].1,
+            test_utils::Num::I(i64::MAX),
+            "the largest representable u64 must round-trip exactly"
+        );
 
         let small_points = test_utils::number_points(&decoded, "updown_i64_min");
         assert_eq!(small_points.len(), 1);

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -331,6 +331,98 @@ mod tests {
             }
         }
 
+        /// Flattens every `ExponentialHistogramDataPoint` of `name` across all
+        /// events.
+        pub fn exp_histogram_points(
+            requests: &[ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<(
+            Vec<(String, String)>,
+            opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint,
+        )> {
+            use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+
+            let mut out = Vec::new();
+            for metric in find_metrics(requests, name) {
+                let Data::ExponentialHistogram(h) =
+                    metric.data.as_ref().expect("metric data missing")
+                else {
+                    panic!("metric {name} is not an ExponentialHistogram");
+                };
+                for dp in &h.data_points {
+                    out.push((attrs_of(&dp.attributes), dp.clone()));
+                }
+            }
+            out
+        }
+
+        /// Asserts that every event carries exactly one scope holding exactly one
+        /// metric.
+        ///
+        /// The exporter reuses a single `ExportMetricsServiceRequest` across
+        /// metrics and scopes, mutating it in place. If a metric's data were ever
+        /// left behind when the next metric is processed, a consumer would see
+        /// duplicated or misattributed data points. This is the assertion that
+        /// would catch that.
+        pub fn assert_one_metric_per_event(requests: &[ExportMetricsServiceRequest]) {
+            for (index, request) in requests.iter().enumerate() {
+                assert_eq!(
+                    request.resource_metrics.len(),
+                    1,
+                    "event {index} should carry exactly one resource_metrics"
+                );
+                let scope_metrics = &request.resource_metrics[0].scope_metrics;
+                assert_eq!(
+                    scope_metrics.len(),
+                    1,
+                    "event {index} should carry exactly one scope_metrics"
+                );
+                assert_eq!(
+                    scope_metrics[0].metrics.len(),
+                    1,
+                    "event {index} should carry exactly one metric, got {:?}",
+                    scope_metrics[0]
+                        .metrics
+                        .iter()
+                        .map(|m| m.name.clone())
+                        .collect::<Vec<_>>()
+                );
+            }
+        }
+
+        /// Returns the scope name attached to each event.
+        pub fn scope_names(requests: &[ExportMetricsServiceRequest]) -> Vec<String> {
+            requests
+                .iter()
+                .flat_map(|r| &r.resource_metrics)
+                .flat_map(|rm| &rm.scope_metrics)
+                .map(|sm| sm.scope.as_ref().expect("scope missing").name.clone())
+                .collect()
+        }
+
+        /// Asserts that every event carrying `name` repeats its identifying
+        /// metadata. Batching must not emit a bare continuation event that a
+        /// consumer could not interpret on its own.
+        pub fn assert_metric_metadata_repeated(
+            requests: &[ExportMetricsServiceRequest],
+            name: &str,
+            expected_description: &str,
+            expected_unit: &str,
+        ) {
+            let metrics = find_metrics(requests, name);
+            assert!(!metrics.is_empty(), "metric {name} was never exported");
+            for (index, metric) in metrics.iter().enumerate() {
+                assert_eq!(
+                    metric.description, expected_description,
+                    "occurrence {index} of {name} lost its description"
+                );
+                assert_eq!(
+                    metric.unit, expected_unit,
+                    "occurrence {index} of {name} lost its unit"
+                );
+            }
+        }
+
         /// Asserts that every event repeats the full resource and scope envelope.
         ///
         /// Batching amortizes the envelope across the data points inside one
@@ -1643,5 +1735,833 @@ mod tests {
             SERIES,
             "histogram data points were duplicated or dropped"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Batching across events, per instrument type.
+    //
+    // The batching code has a separate arm for each data point type. Sums and
+    // histograms are covered above; these cover the remaining arms and, more
+    // importantly, assert that the type-specific metadata (temporality,
+    // monotonicity, bucket layout) is repeated on every event a metric is split
+    // across, not just the first.
+    // ---------------------------------------------------------------------
+
+    /// An observable gauge with enough distinct attribute sets to span several
+    /// events. Gauges carry no temporality, so the invariant here is simply that
+    /// every point survives and every event is independently decodable.
+    #[ignore]
+    #[test]
+    fn integration_test_gauge_batching_splits_across_events() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 800;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        meter
+            .u64_observable_gauge("gauge_batched")
+            .with_callback(|obs| {
+                for i in 0..SERIES {
+                    obs.observe(
+                        i as u64,
+                        &[
+                            KeyValue::new("partition", format!("p{i:05}")),
+                            KeyValue::new("region", "westus2"),
+                        ],
+                    );
+                }
+            })
+            .build();
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        test_utils::assert_one_metric_per_event(&decoded);
+        assert!(
+            decoded.len() > 1,
+            "expected the gauge to span several events, got {}",
+            decoded.len()
+        );
+
+        let points = test_utils::number_points(&decoded, "gauge_batched");
+        assert_eq!(points.len(), SERIES, "every gauge point must be exported");
+
+        let mut seen: Vec<(String, test_utils::Num)> = points
+            .iter()
+            .map(|(attrs, value)| {
+                let partition = attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing");
+                (partition, *value)
+            })
+            .collect();
+        seen.sort_by(|a, b| a.0.cmp(&b.0));
+        seen.dedup_by(|a, b| a.0 == b.0);
+        assert_eq!(
+            seen.len(),
+            SERIES,
+            "gauge points were duplicated or dropped"
+        );
+
+        for (partition, value) in seen {
+            let index: usize = partition
+                .trim_start_matches('p')
+                .parse()
+                .expect("partition should be p<number>");
+            assert_eq!(
+                value,
+                test_utils::Num::I(index as i64),
+                "gauge point {partition} carries the wrong value"
+            );
+        }
+    }
+
+    /// A non-monotonic sum split across events. `is_monotonic` and the
+    /// temporality live on the `Sum` message, which is rebuilt for every event,
+    /// so a batching bug could easily produce a first event that is correct and
+    /// later events that are not.
+    #[ignore]
+    #[test]
+    fn integration_test_updowncounter_batching_preserves_sum_flags() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use opentelemetry_proto::tonic::metrics::v1::AggregationTemporality;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 600;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let udc = meter.i64_up_down_counter("updown_batched").build();
+        for i in 0..SERIES {
+            // Alternate sign so the values cannot be confused with a counter.
+            let delta = if i % 2 == 0 { 5 } else { -5 };
+            udc.add(delta, &[KeyValue::new("partition", format!("p{i:05}"))]);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_one_metric_per_event(&decoded);
+        assert!(
+            decoded.len() > 1,
+            "expected the up/down counter to span several events, got {}",
+            decoded.len()
+        );
+
+        let metrics = test_utils::find_metrics(&decoded, "updown_batched");
+        assert_eq!(
+            metrics.len(),
+            decoded.len(),
+            "every event should carry the metric"
+        );
+        for (index, metric) in metrics.iter().enumerate() {
+            let Data::Sum(sum) = metric.data.as_ref().expect("metric data missing") else {
+                panic!("occurrence {index} is not a Sum");
+            };
+            assert!(
+                !sum.is_monotonic,
+                "occurrence {index} lost is_monotonic=false; a consumer would treat \
+                 an up/down counter as a monotonic counter"
+            );
+            assert_eq!(
+                sum.aggregation_temporality,
+                AggregationTemporality::Delta as i32,
+                "occurrence {index} lost delta temporality"
+            );
+        }
+
+        let points = test_utils::number_points(&decoded, "updown_batched");
+        assert_eq!(points.len(), SERIES, "every data point must be exported");
+        let negatives = points
+            .iter()
+            .filter(|(_, v)| *v == test_utils::Num::I(-5))
+            .count();
+        assert_eq!(
+            negatives,
+            SERIES / 2,
+            "negative deltas must survive batching intact"
+        );
+    }
+
+    /// Exponential histogram data points are the largest and most structured of
+    /// the four types, with nested positive/negative bucket messages. This packs
+    /// enough of them to span several events and verifies the nested structure
+    /// survives in each.
+    #[ignore]
+    #[test]
+    fn integration_test_exponential_histogram_batching_splits_across_events() {
+        use opentelemetry_sdk::metrics::{Aggregation, Instrument, Stream};
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 300;
+
+        let view = |i: &Instrument| {
+            if i.name() == "exp_histogram_batched" {
+                Some(
+                    Stream::builder()
+                        .with_aggregation(Aggregation::Base2ExponentialHistogram {
+                            max_size: 160,
+                            max_scale: 20,
+                            record_min_max: true,
+                        })
+                        .build()
+                        .unwrap(),
+                )
+            } else {
+                None
+            }
+        };
+
+        let provider = SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![
+                        KeyValue::new("service.name", "metric-demo"),
+                        KeyValue::new("service.namespace", "demo-ns"),
+                        KeyValue::new("host.name", "test-host"),
+                    ])
+                    .build(),
+            )
+            .with_periodic_exporter(MetricsExporter::new())
+            .with_view(view)
+            .build();
+
+        let meter = provider.meter("user-event-test");
+        let hist = meter.f64_histogram("exp_histogram_batched").build();
+        for i in 0..SERIES {
+            let attrs = [KeyValue::new("partition", format!("p{i:05}"))];
+            // A spread of magnitudes so the buckets are genuinely populated,
+            // including a negative value and an exact zero.
+            hist.record(0.0, &attrs);
+            hist.record(1.5, &attrs);
+            hist.record(64.0, &attrs);
+            hist.record(-2.0, &attrs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        test_utils::assert_one_metric_per_event(&decoded);
+        assert!(
+            decoded.len() > 1,
+            "expected the exponential histogram to span several events, got {}",
+            decoded.len()
+        );
+
+        let points = test_utils::exp_histogram_points(&decoded, "exp_histogram_batched");
+        assert_eq!(points.len(), SERIES, "every data point must be exported");
+
+        let mut partitions = Vec::new();
+        for (attrs, dp) in &points {
+            assert_eq!(dp.count, 4, "each series recorded four measurements");
+            assert_eq!(
+                dp.zero_count, 1,
+                "the 0.0 measurement must land in zero_count"
+            );
+            assert!(
+                dp.positive.is_some() && dp.negative.is_some(),
+                "both bucket sets must be present after batching"
+            );
+            let negative = dp.negative.as_ref().unwrap();
+            assert_eq!(
+                negative.bucket_counts.iter().sum::<u64>(),
+                1,
+                "the -2.0 measurement must land in a negative bucket"
+            );
+            assert_eq!(dp.min, Some(-2.0), "min must survive batching");
+            assert_eq!(dp.max, Some(64.0), "max must survive batching");
+            partitions.push(
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing"),
+            );
+        }
+        partitions.sort();
+        partitions.dedup();
+        assert_eq!(
+            partitions.len(),
+            SERIES,
+            "exponential histogram points were duplicated or dropped"
+        );
+    }
+
+    /// Identifying metadata must be repeated on every event a metric is split
+    /// across. An event that arrived without it would be undecodable on its own,
+    /// and since events can be reordered or individually lost, a consumer cannot
+    /// recover it from a neighbour.
+    #[ignore]
+    #[test]
+    fn integration_test_metric_metadata_repeated_on_every_split_event() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 1500;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter
+            .u64_counter("counter_with_metadata")
+            .with_description("requests handled by the ingest tier")
+            .with_unit("{request}")
+            .build();
+        for i in 0..SERIES {
+            counter.add(1, &[KeyValue::new("partition", format!("p{i:05}"))]);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert!(
+            decoded.len() > 1,
+            "expected the metric to span several events, got {}",
+            decoded.len()
+        );
+        test_utils::assert_metric_metadata_repeated(
+            &decoded,
+            "counter_with_metadata",
+            "requests handled by the ingest tier",
+            "{request}",
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "counter_with_metadata").len(),
+            SERIES
+        );
+    }
+
+    /// Several metrics, each large enough to split, exported in one cycle.
+    ///
+    /// The exporter mutates one `ExportMetricsServiceRequest` in place as it
+    /// walks metrics, so this is the scenario where state left over from one
+    /// metric could leak into the next.
+    #[ignore]
+    #[test]
+    fn integration_test_multiple_metrics_each_split_without_cross_contamination() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 700;
+        const NAMES: [&str; 3] = ["counter_alpha", "counter_beta", "counter_gamma"];
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        for (index, name) in NAMES.iter().enumerate() {
+            let counter = meter.u64_counter(*name).build();
+            for i in 0..SERIES {
+                // A distinct value per metric makes misattribution detectable.
+                counter.add(
+                    index as u64 + 1,
+                    &[KeyValue::new("partition", format!("{name}-p{i:05}"))],
+                );
+            }
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(2048, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_one_metric_per_event(&decoded);
+
+        for (index, name) in NAMES.iter().enumerate() {
+            let points = test_utils::number_points(&decoded, name);
+            assert_eq!(
+                points.len(),
+                SERIES,
+                "{name} lost or duplicated data points"
+            );
+            for (attrs, value) in &points {
+                assert_eq!(
+                    *value,
+                    test_utils::Num::I(index as i64 + 1),
+                    "{name} carries a value belonging to another metric"
+                );
+                let partition = attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing");
+                assert!(
+                    partition.starts_with(name),
+                    "{name} carries a data point belonging to another metric: {partition}"
+                );
+            }
+        }
+    }
+
+    /// Several scopes, each with a metric large enough to split. Scope identity
+    /// is part of the envelope rebuilt for every event, so this checks that an
+    /// event is never attributed to the wrong meter.
+    #[ignore]
+    #[test]
+    fn integration_test_multiple_scopes_each_split() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 600;
+        const SCOPES: [&str; 3] = ["scope-alpha", "scope-beta", "scope-gamma"];
+
+        let provider = test_provider();
+        for scope in SCOPES {
+            let meter = provider.meter(scope);
+            let counter = meter.u64_counter(format!("counter_{scope}")).build();
+            for i in 0..SERIES {
+                counter.add(1, &[KeyValue::new("partition", format!("p{i:05}"))]);
+            }
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(2048, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_one_metric_per_event(&decoded);
+
+        // Every event must pair the right scope with the right metric.
+        for request in &decoded {
+            let sm = &request.resource_metrics[0].scope_metrics[0];
+            let scope_name = sm.scope.as_ref().expect("scope missing").name.clone();
+            let metric_name = sm.metrics[0].name.clone();
+            assert_eq!(
+                metric_name,
+                format!("counter_{scope_name}"),
+                "metric {metric_name} was attributed to scope {scope_name}"
+            );
+        }
+
+        for scope in SCOPES {
+            let points = test_utils::number_points(&decoded, &format!("counter_{scope}"));
+            assert_eq!(points.len(), SERIES, "{scope} lost or duplicated points");
+        }
+
+        let names = test_utils::scope_names(&decoded);
+        for scope in SCOPES {
+            assert!(
+                names.iter().any(|n| n == scope),
+                "no event was emitted for scope {scope}"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Size boundary behaviour.
+    // ---------------------------------------------------------------------
+
+    /// Sweeps the per-data-point size so that batches land on many different
+    /// alignments relative to `MAX_EVENT_SIZE`.
+    ///
+    /// The batching loop decides whether the next point fits using an
+    /// incrementally accumulated length plus `SIZE_SLACK`. An off-by-one there
+    /// would only show up at particular sizes, which a single fixed-size test
+    /// would very likely miss.
+    #[ignore]
+    #[test]
+    fn integration_test_batching_boundary_size_sweep() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        // Sizes chosen to straddle protobuf varint length boundaries (127/128
+        // and 16383/16384 are where the length delimiter grows).
+        const VALUE_SIZES: [usize; 10] = [1, 63, 126, 127, 128, 129, 255, 512, 1024, 4096];
+        const SERIES: usize = 40;
+
+        for size in VALUE_SIZES {
+            let provider = test_provider();
+            let meter = provider.meter("user-event-test");
+            let counter = meter.u64_counter("counter_sweep").build();
+            for i in 0..SERIES {
+                // The index keeps the series distinct; the padding sets the size.
+                let value = format!("{i:05}{}", "x".repeat(size));
+                counter.add(1, &[KeyValue::new("partition", value)]);
+            }
+
+            let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+                provider.shutdown().expect("shutdown failed");
+            });
+
+            test_utils::assert_all_events_within_size_limit(&decoded);
+            test_utils::assert_one_metric_per_event(&decoded);
+
+            let points = test_utils::number_points(&decoded, "counter_sweep");
+            assert_eq!(
+                points.len(),
+                SERIES,
+                "value size {size}: expected {SERIES} data points, got {} across {} events",
+                points.len(),
+                decoded.len()
+            );
+
+            let mut partitions: Vec<String> = points
+                .iter()
+                .map(|(attrs, _)| {
+                    attrs
+                        .iter()
+                        .find(|(k, _)| k == "partition")
+                        .map(|(_, v)| v.clone())
+                        .expect("partition attribute missing")
+                })
+                .collect();
+            partitions.sort();
+            partitions.dedup();
+            assert_eq!(
+                partitions.len(),
+                SERIES,
+                "value size {size}: data points were duplicated"
+            );
+        }
+    }
+
+    /// Walks a single data point up to and past the per-event limit.
+    ///
+    /// Delivery must be monotonic in size: once a point is too large it must
+    /// stay too large. A non-monotonic result would mean the size accounting
+    /// disagrees with what the kernel accepts, which is the failure mode that
+    /// loses data silently in production.
+    #[ignore]
+    #[test]
+    fn integration_test_single_data_point_size_limit_is_monotonic() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        // Around the 8168 byte budget, minus the resource/scope/metric envelope.
+        const SIZES: [usize; 9] = [4096, 6144, 7168, 7680, 7900, 8000, 8100, 8192, 16384];
+
+        let mut delivered = Vec::new();
+        for size in SIZES {
+            let provider = test_provider();
+            let meter = provider.meter("user-event-test");
+            let counter = meter.u64_counter("counter_single_large").build();
+            counter.add(1, &[KeyValue::new("payload", "x".repeat(size))]);
+
+            let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+                // Export returns an error when a data point cannot be encoded
+                // within the limit; that is expected for the larger sizes here,
+                // so the result is deliberately not unwrapped.
+                let _ = provider.shutdown();
+            });
+
+            test_utils::assert_all_events_within_size_limit(&decoded);
+            let points = test_utils::number_points(&decoded, "counter_single_large");
+            delivered.push((size, points.len()));
+        }
+
+        println!("single data point delivery by attribute size: {delivered:?}");
+
+        assert_eq!(
+            delivered[0].1, 1,
+            "a 4 KiB data point must fit in one event"
+        );
+        assert_eq!(
+            delivered.last().expect("sizes must not be empty").1,
+            0,
+            "a 16 KiB data point cannot fit and must be dropped rather than written"
+        );
+
+        let mut seen_drop = false;
+        for (size, count) in &delivered {
+            if *count == 0 {
+                seen_drop = true;
+            } else {
+                assert!(
+                    !seen_drop,
+                    "size {size} was delivered after a smaller size was dropped; \
+                     the size accounting is not monotonic"
+                );
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Value and attribute edge cases.
+    // ---------------------------------------------------------------------
+
+    /// Extreme numeric values must round-trip through the protobuf encoding.
+    #[ignore]
+    #[test]
+    fn integration_test_extreme_numeric_values() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        let big = meter.u64_counter("counter_u64_max").build();
+        big.add(u64::MAX, &[KeyValue::new("k", "max")]);
+
+        let small = meter.i64_up_down_counter("updown_i64_min").build();
+        small.add(i64::MIN, &[KeyValue::new("k", "min")]);
+
+        let gauge = meter.f64_gauge("gauge_special_floats").build();
+        gauge.record(f64::INFINITY, &[KeyValue::new("k", "inf")]);
+        gauge.record(f64::NEG_INFINITY, &[KeyValue::new("k", "neg_inf")]);
+        gauge.record(f64::NAN, &[KeyValue::new("k", "nan")]);
+        gauge.record(f64::MIN_POSITIVE, &[KeyValue::new("k", "min_positive")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+
+        // OTLP represents integral data points as a signed 64-bit value, so a
+        // u64 above i64::MAX arrives with the same bit pattern reinterpreted.
+        // This is a property of the wire format rather than of batching; the
+        // assertion pins the behaviour so a future encoding change is noticed.
+        let big_points = test_utils::number_points(&decoded, "counter_u64_max");
+        assert_eq!(big_points.len(), 1);
+        let test_utils::Num::I(raw) = big_points[0].1 else {
+            panic!("expected an integer data point");
+        };
+        assert_eq!(raw as u64, u64::MAX, "u64::MAX must round-trip bitwise");
+
+        let small_points = test_utils::number_points(&decoded, "updown_i64_min");
+        assert_eq!(small_points.len(), 1);
+        assert_eq!(small_points[0].1, test_utils::Num::I(i64::MIN));
+
+        let floats = test_utils::number_points(&decoded, "gauge_special_floats");
+        assert_eq!(floats.len(), 4, "every gauge series must be exported");
+        for (attrs, value) in &floats {
+            let key = attrs
+                .iter()
+                .find(|(k, _)| k == "k")
+                .map(|(_, v)| v.clone())
+                .expect("attribute k missing");
+            let test_utils::Num::D(d) = value else {
+                panic!("expected a double data point for {key}");
+            };
+            match key.as_str() {
+                "inf" => assert!(d.is_infinite() && d.is_sign_positive()),
+                "neg_inf" => assert!(d.is_infinite() && d.is_sign_negative()),
+                // NaN is never equal to itself, so this cannot be asserted with
+                // a plain comparison.
+                "nan" => assert!(d.is_nan(), "NaN must survive as NaN"),
+                "min_positive" => assert_eq!(*d, f64::MIN_POSITIVE),
+                other => panic!("unexpected series {other}"),
+            }
+        }
+    }
+
+    /// Attribute keys and values are copied verbatim into the payload, so
+    /// multi-byte and empty values must not be mangled or truncated.
+    #[ignore]
+    #[test]
+    fn integration_test_unicode_and_empty_attribute_values() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let cases: Vec<(&str, String)> = vec![
+            ("ascii", "plain".to_string()),
+            ("empty", String::new()),
+            ("cjk", "配置更新".to_string()),
+            ("emoji", "🚀🛰️".to_string()),
+            ("combining", "e\u{0301}".to_string()),
+            ("whitespace", " leading and trailing ".to_string()),
+            ("newline", "line1\nline2".to_string()),
+            ("quotes", "he said \"hi\"".to_string()),
+        ];
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_unicode").build();
+        for (name, value) in &cases {
+            counter.add(
+                1,
+                &[
+                    KeyValue::new("case", *name),
+                    KeyValue::new("value", value.clone()),
+                ],
+            );
+        }
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        let points = test_utils::number_points(&decoded, "counter_unicode");
+        assert_eq!(points.len(), cases.len(), "every series must be exported");
+
+        for (name, expected) in &cases {
+            let found = points
+                .iter()
+                .find(|(attrs, _)| attrs.iter().any(|(k, v)| k == "case" && v == name))
+                .unwrap_or_else(|| panic!("series {name} was not exported"));
+            let actual = found
+                .0
+                .iter()
+                .find(|(k, _)| k == "value")
+                .map(|(_, v)| v.clone())
+                .expect("value attribute missing");
+            assert_eq!(&actual, expected, "series {name} was mangled in transit");
+        }
+    }
+
+    /// A data point carrying many attributes. The attribute list is the bulk of
+    /// a data point's size, so this is the shape most likely to interact badly
+    /// with the per-point size accounting.
+    #[ignore]
+    #[test]
+    fn integration_test_many_attributes_per_data_point() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const ATTRS: usize = 32;
+        const SERIES: usize = 50;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_wide").build();
+        for i in 0..SERIES {
+            let mut kvs: Vec<KeyValue> = (0..ATTRS)
+                .map(|a| KeyValue::new(format!("dimension_{a:02}"), format!("value_{a:02}")))
+                .collect();
+            kvs.push(KeyValue::new("partition", format!("p{i:05}")));
+            counter.add(1, &kvs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_one_metric_per_event(&decoded);
+
+        let points = test_utils::number_points(&decoded, "counter_wide");
+        assert_eq!(
+            points.len(),
+            SERIES,
+            "every wide data point must be exported"
+        );
+        for (attrs, _) in &points {
+            assert_eq!(
+                attrs.len(),
+                ATTRS + 1,
+                "a wide data point lost attributes during batching"
+            );
+        }
+    }
+
+    /// Histograms must also report deltas rather than cumulative totals across
+    /// collection cycles, including the bucket counts.
+    #[ignore]
+    #[test]
+    fn integration_test_histogram_delta_across_cycles() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let hist = meter.f64_histogram("histogram_delta").build();
+        let attrs = [KeyValue::new("k", "a")];
+
+        hist.record(1.0, &attrs);
+        hist.record(2.0, &attrs);
+        let first = test_utils::collect_otlp_metrics(|| {
+            provider.force_flush().expect("first force_flush failed");
+        });
+        let first_points = test_utils::histogram_points(&first, "histogram_delta");
+        assert_eq!(first_points.len(), 1);
+        assert_eq!(
+            first_points[0].1.count, 2,
+            "first cycle recorded two values"
+        );
+        assert_eq!(first_points[0].1.sum, Some(3.0));
+
+        hist.record(10.0, &attrs);
+        let second = test_utils::collect_otlp_metrics(|| {
+            provider.force_flush().expect("second force_flush failed");
+        });
+        let second_points = test_utils::histogram_points(&second, "histogram_delta");
+        assert_eq!(second_points.len(), 1);
+        assert_eq!(
+            second_points[0].1.count, 1,
+            "delta temporality means the second cycle reports only the new measurement"
+        );
+        assert_eq!(second_points[0].1.sum, Some(10.0));
+        assert_eq!(
+            second_points[0].1.bucket_counts.iter().sum::<u64>(),
+            1,
+            "bucket counts must be deltas too"
+        );
+
+        provider.shutdown().expect("shutdown failed");
+    }
+
+    /// All four data point types in a single collection cycle, each large enough
+    /// to span multiple events. This is the closest thing to a production export
+    /// in the suite.
+    #[ignore]
+    #[test]
+    fn integration_test_mixed_instrument_types_in_one_cycle() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 400;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("mixed_counter").build();
+        let udc = meter.i64_up_down_counter("mixed_updown").build();
+        let hist = meter.f64_histogram("mixed_histogram").build();
+        meter
+            .u64_observable_gauge("mixed_gauge")
+            .with_callback(|obs| {
+                for i in 0..SERIES {
+                    obs.observe(i as u64, &[KeyValue::new("partition", format!("p{i:05}"))]);
+                }
+            })
+            .build();
+
+        for i in 0..SERIES {
+            let attrs = [KeyValue::new("partition", format!("p{i:05}"))];
+            counter.add(1, &attrs);
+            udc.add(-1, &attrs);
+            hist.record(i as f64, &attrs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(2048, || {
+            provider.shutdown().expect("shutdown failed");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        test_utils::assert_one_metric_per_event(&decoded);
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "mixed_counter").len(),
+            SERIES
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "mixed_updown").len(),
+            SERIES
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "mixed_gauge").len(),
+            SERIES
+        );
+        assert_eq!(
+            test_utils::histogram_points(&decoded, "mixed_histogram").len(),
+            SERIES
+        );
+
+        // Each metric must appear in at least one event, and no event may mix
+        // data points from two different metrics.
+        for name in [
+            "mixed_counter",
+            "mixed_updown",
+            "mixed_gauge",
+            "mixed_histogram",
+        ] {
+            assert!(
+                !test_utils::find_metrics(&decoded, name).is_empty(),
+                "{name} was never exported"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Motivation

The exporter currently emits one `user_events` tracepoint write per metric data point. Every write re-serializes the entire OTLP envelope — resource attributes, scope, metric name/unit/description, aggregation temporality — so a metric with N data points pays the envelope cost N times.

`user_events` ring buffers are per-CPU and finite, and the `PeriodicReader` exports from a single dedicated thread, so an agent's whole export cycle lands in one buffer. This has caused observed data loss in production deployments with high series counts.

## Changes

`export_resource_metrics` now packs as many data points as will fit into each event, up to `MAX_EVENT_SIZE`, instead of one per event. Batching is per-metric: the envelope is still repeated per event, but amortized across every point in that event rather than paid per point.

The packing is byte-aware and incremental. The envelope is encoded once with zero data points to learn the fixed cost, and each point's marginal cost is computed as `tag + varint_len(len) + len`. A `SIZE_SLACK` of 32 bytes covers the growth of the four enclosing length delimiters (`Sum`/`Gauge`/`Histogram` -> `Metric` -> `ScopeMetrics` -> `ResourceMetrics`), whose true worst-case combined growth is 8 bytes. Points are consumed from an iterator rather than collected, so only one batch is resident at a time and peak memory does not regress.

A single data point that cannot fit in an event even on its own is still dropped with the existing `EventSizeExceeded` diagnostic, unchanged from today.

The four near-identical `process_*` loops are collapsed onto a shared generic path, and an `EventWriter` trait is introduced so the encoding and packing logic can be exercised without a live tracepoint.

### Corrected maximum event size

`MAX_EVENT_SIZE` was 65360, chosen against the perf record length field. That value is wrong. A `user_events` tracepoint consumed through perf goes through `user_event_perf()`, which copies the record into a per-CPU scratch buffer from `perf_trace_buf_alloc()`. That buffer is `PERF_MAX_TRACE_SIZE`, or 8192 bytes. When the record does not fit, `perf_trace_buf_alloc()` returns NULL and `user_event_perf()` returns without submitting anything, so the write succeeds from userspace and the event simply never reaches the consumer.

This had no observable effect before this change, because one event carried one data point and never came close to 8KB. Batching immediately exposed it: the high-cardinality integration test received zero events until the limit was corrected.

Accounting for `struct trace_entry` (8), `u32 protocol` (4), `char[8] version` (8) and the `__rel_loc` descriptor (4), the payload budget is `8192 - 24 = 8168` bytes, which is the new value.

## Measured impact

Real OTLP wire bytes, 1000 series per scenario, 4 resource attributes and 2 scope attributes, envelope ~220 bytes:

| scenario | bytes written | writes | envelope waste eliminated |
|---|---|---|---|
| counter, 5 dims | 2.32x fewer | 48x fewer | 57.3% |
| counter, 2 dims | 3.50x fewer | 91x fewer | 71.9% |
| observable gauge, 4 dims | 2.51x fewer | 56x fewer | 60.5% |
| histogram, 3 dims | 1.52x fewer | 20x fewer | 35.7% |

Low-cardinality metrics benefit most, since the payload shrinks while the envelope does not. Histograms benefit least, since their data points are large enough that the envelope was never the dominant cost.

## Tests

Six platform-independent unit tests drive a real `SdkMeterProvider` + `PeriodicReader` through the exporter with a collecting `EventWriter`, asserting that every event stays within the size limit, that every data point survives exactly once, that metric metadata is repeated in each event, that an oversized single point is dropped without panicking, and that packing is maximal (for every non-final event, the next event's first point would not have fit). `varint_len` is cross-checked against `prost`.

The Linux integration suite, which reads the real perf ring buffer and runs under `sudo` on a real kernel in CI, grows from 4 tests to 17. The existing tests are updated to assert the batched shape rather than one event per data point, and the following are added:

- **High-cardinality round trip.** 2000 distinct series are exported and read back out of the kernel, checking that every data point survives exactly once with no duplication or loss, that no event exceeds the size limit, and that batching collapses them into far fewer events. This is the test that caught the `MAX_EVENT_SIZE` bug.
- **Packing to capacity.** 3000 data points, asserting that at most one event is under-filled, so a regression that flushes early cannot silently give back the byte savings. The assertion is order-independent, because records from one export can land in different per-CPU buffers if the exporter thread migrates.
- **Oversized data point.** A point too large to ever fit is dropped while the points recorded around it are still exported.
- **Multiple metrics in one cycle** and **multiple instrumentation scopes**, checking that batching stays per-metric and that scope name, version and schema URL are carried on every event.
- **Observable instruments**, checking monotonicity and Delta aggregation temporality survive batching.
- **f64 instruments**, checking values round-trip as `AsDouble` rather than being coerced.
- **Attribute value types**, covering string, bool, int, double and array values, since the batching path re-encodes data points individually.
- **Data point with no attributes.**
- **Delta semantics across `force_flush` cycles**, checking a second cycle reports only the increment.
- **Empty export cycle**, checking nothing is written when nothing was recorded.
- **Exponential histogram** via a view, exercising a distinct data point type.
- **Histogram batching** over 500 series, since histogram data points are the largest and most likely to overflow an event.

A criterion benchmark is added under `benches/metrics.rs`. It must be run on Linux with the tracepoint enabled, since the exporter short-circuits when no listener is attached.

## Follow-ups (not in this PR)

- `MAX_EVENT_SIZE` is now derived from a kernel constant rather than guessed, but it is still hardcoded. Making it configurable would let a consumer with a smaller budget lower it.
- Packing across metrics and scopes within one export cycle would amortize the envelope further. That is a larger change and belongs in its own PR.
