### PR TITLE
[DO NOT MERGE] Experiment: measured maximum user_events event size on the perf and ftrace paths

### DIFF
--- a/.github/workflows/size-experiment.yml
+++ b/.github/workflows/size-experiment.yml
@@ -39,23 +39,6 @@ jobs:
       # WARN_ONCE, which fires at most once per boot per call site. Running the
       # probes in separate steps with a clear in between keeps the attribution
       # unambiguous.
-      - name: Probe perf delivery path (metrics)
-        run: |
-          sudo dmesg -C
-          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
-            --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1
-      - name: Kernel log after metrics perf probe
-        if: always()
-        run: sudo dmesg || true
-      - name: Probe ftrace delivery path (metrics)
-        if: always()
-        run: |
-          sudo dmesg -C
-          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
-            --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
-      - name: Kernel log after metrics ftrace probe
-        if: always()
-        run: sudo dmesg || true
       - name: Probe perf delivery path (logs)
         if: always()
         run: |
@@ -72,5 +55,23 @@ jobs:
           sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
             --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
       - name: Kernel log after logs ftrace probe
+        if: always()
+        run: sudo dmesg || true
+      - name: Probe perf delivery path (metrics)
+        if: always()
+        run: |
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
+            --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1
+      - name: Kernel log after metrics perf probe
+        if: always()
+        run: sudo dmesg || true
+      - name: Probe ftrace delivery path (metrics)
+        if: always()
+        run: |
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
+            --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
+      - name: Kernel log after metrics ftrace probe
         if: always()
         run: sudo dmesg || true

--- a/.github/workflows/size-experiment.yml
+++ b/.github/workflows/size-experiment.yml
@@ -18,8 +18,15 @@ on:
 
 jobs:
   size-experiment:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Several runner images, so the measured thresholds can be separated into
+    # those that are fixed by the kernel and those that depend on the
+    # environment (kernel version, architecture, page size, sub-buffer size).
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v5
       - name: Show kernel and tracefs configuration
@@ -75,3 +82,22 @@ jobs:
       - name: Kernel log after metrics ftrace probe
         if: always()
         run: sudo dmesg || true
+      # The perf ceiling is a compile-time constant (PERF_MAX_TRACE_SIZE), but
+      # the ftrace ceiling derives from the ring buffer sub-buffer size, which
+      # is writable at runtime. Raising it and re-probing shows which of the two
+      # thresholds is actually tunable.
+      - name: Probe ftrace delivery path with a 32 KB sub-buffer (logs)
+        if: always()
+        run: |
+          echo -n "buffer_subbuf_size_kb before: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
+          sudo sh -c 'echo 32 > /sys/kernel/tracing/buffer_subbuf_size_kb' || echo "not writable on this kernel"
+          echo -n "buffer_subbuf_size_kb after: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
+            --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
+      - name: Probe perf delivery path with a 32 KB sub-buffer (logs)
+        if: always()
+        run: |
+          echo -n "buffer_subbuf_size_kb: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
+            --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1

--- a/.github/workflows/size-experiment.yml
+++ b/.github/workflows/size-experiment.yml
@@ -31,25 +31,45 @@ jobs:
             echo -n "$f: "; sudo cat /sys/kernel/tracing/$f 2>/dev/null || echo "<unavailable>"
           done
       - name: Build test binary
-        run: cargo test --manifest-path opentelemetry-user-events-metrics/Cargo.toml --lib --no-run
+        run: |
+          cargo test --manifest-path opentelemetry-user-events-metrics/Cargo.toml --lib --no-run
+          cargo test --manifest-path opentelemetry-user-events-logs/Cargo.toml --lib --no-run
       # dmesg is cleared before each probe because perf_trace_buf_alloc() uses
       # WARN_ONCE, which fires at most once per boot per call site. Running the
       # probes in separate steps with a clear in between keeps the attribution
       # unambiguous.
-      - name: Probe perf delivery path
+      - name: Probe perf delivery path (metrics)
         run: |
           sudo dmesg -C
           sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
             --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1
-      - name: Kernel log after perf probe
+      - name: Kernel log after metrics perf probe
         if: always()
         run: sudo dmesg || true
-      - name: Probe ftrace delivery path
+      - name: Probe ftrace delivery path (metrics)
         if: always()
         run: |
           sudo dmesg -C
           sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
             --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
-      - name: Kernel log after ftrace probe
+      - name: Kernel log after metrics ftrace probe
+        if: always()
+        run: sudo dmesg || true
+      - name: Probe perf delivery path (logs)
+        if: always()
+        run: |
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
+            --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1
+      - name: Kernel log after logs perf probe
+        if: always()
+        run: sudo dmesg || true
+      - name: Probe ftrace delivery path (logs)
+        if: always()
+        run: |
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
+            --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
+      - name: Kernel log after logs ftrace probe
         if: always()
         run: sudo dmesg || true

--- a/.github/workflows/size-experiment.yml
+++ b/.github/workflows/size-experiment.yml
@@ -82,22 +82,22 @@ jobs:
       - name: Kernel log after metrics ftrace probe
         if: always()
         run: sudo dmesg || true
-      # The perf ceiling is a compile-time constant (PERF_MAX_TRACE_SIZE), but
-      # the ftrace ceiling derives from the ring buffer sub-buffer size, which
-      # is writable at runtime. Raising it and re-probing shows which of the two
-      # thresholds is actually tunable.
-      - name: Probe ftrace delivery path with a 32 KB sub-buffer (logs)
+      # The ftrace ceiling should derive from the ring buffer sub-buffer size
+      # (rb_subbuf_max_data_size), which is writable at runtime. Sweeping it
+      # shows whether the measured ftrace threshold actually tracks it, or
+      # whether something else is the binding constraint.
+      - name: Sweep ftrace sub-buffer size (logs)
         if: always()
         run: |
-          echo -n "buffer_subbuf_size_kb before: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
-          sudo sh -c 'echo 32 > /sys/kernel/tracing/buffer_subbuf_size_kb' || echo "not writable on this kernel"
-          echo -n "buffer_subbuf_size_kb after: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
-          sudo dmesg -C
-          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
-            --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
-      - name: Probe perf delivery path with a 32 KB sub-buffer (logs)
+          for kb in 4 8 16 32 64; do
+            echo "===================== buffer_subbuf_size_kb = $kb ====================="
+            sudo sh -c "echo $kb > /sys/kernel/tracing/buffer_subbuf_size_kb" \
+              || { echo "write failed for $kb"; continue; }
+            echo -n "readback: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
+            sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
+              --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1 \
+              2>&1 | grep -E "largest fully delivered|smallest fully dropped|subbuf"
+          done
+      - name: Kernel log after sub-buffer sweep
         if: always()
-        run: |
-          echo -n "buffer_subbuf_size_kb: "; sudo cat /sys/kernel/tracing/buffer_subbuf_size_kb
-          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
-            --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1
+        run: sudo dmesg || true

--- a/.github/workflows/size-experiment.yml
+++ b/.github/workflows/size-experiment.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   size-experiment:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - name: Show kernel and tracefs configuration

--- a/.github/workflows/size-experiment.yml
+++ b/.github/workflows/size-experiment.yml
@@ -1,0 +1,55 @@
+name: user_events size experiment
+
+# Fork-only experiment. Measures the largest user_events event that is actually
+# delivered, separately for the perf and ftrace paths, and captures any kernel
+# WARN_ONCE that explains a drop. Not intended to be merged.
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - cijothomas/user-events-size-experiment
+
+jobs:
+  size-experiment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Show kernel and tracefs configuration
+        run: |
+          uname -a
+          getconf PAGESIZE
+          sudo mount -t tracefs nodev /sys/kernel/tracing 2>/dev/null || true
+          ls -l /sys/kernel/tracing/user_events_data || true
+          for f in buffer_size_kb buffer_subbuf_size_kb; do
+            echo -n "$f: "; sudo cat /sys/kernel/tracing/$f 2>/dev/null || echo "<unavailable>"
+          done
+      - name: Build test binary
+        run: cargo test --manifest-path opentelemetry-user-events-metrics/Cargo.toml --lib --no-run
+      # dmesg is cleared before each probe because perf_trace_buf_alloc() uses
+      # WARN_ONCE, which fires at most once per boot per call site. Running the
+      # probes in separate steps with a clear in between keeps the attribution
+      # unambiguous.
+      - name: Probe perf delivery path
+        run: |
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
+            --lib size_experiment::size_experiment_perf -- --ignored --nocapture --test-threads=1
+      - name: Kernel log after perf probe
+        if: always()
+        run: sudo dmesg || true
+      - name: Probe ftrace delivery path
+        if: always()
+        run: |
+          sudo dmesg -C
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-metrics/Cargo.toml \
+            --lib size_experiment::size_experiment_ftrace -- --ignored --nocapture --test-threads=1
+      - name: Kernel log after ftrace probe
+        if: always()
+        run: sudo dmesg || true

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -240,6 +240,29 @@ mod size_experiment {
         eb.write(event_set, None, None)
     }
 
+    /// Sums the `entries` counter across every per-CPU ring buffer. This counts
+    /// records that the kernel actually committed, independent of whether the
+    /// `trace` text formatter can render them: an event larger than
+    /// `TRACE_SEQ_SIZE` (8192) renders as `[LINE TOO BIG]`, so counting lines in
+    /// `trace` measures the formatter rather than delivery.
+    fn ftrace_entries(root: &Path) -> usize {
+        let mut total = 0;
+        let per_cpu = root.join("per_cpu");
+        let dir = fs::read_dir(&per_cpu).expect("failed to list per_cpu directory");
+        for entry in dir.flatten() {
+            let stats = entry.path().join("stats");
+            let Ok(text) = fs::read_to_string(&stats) else {
+                continue;
+            };
+            for line in text.lines() {
+                if let Some(rest) = line.strip_prefix("entries:") {
+                    total += rest.trim().parse::<usize>().unwrap_or(0);
+                }
+            }
+        }
+        total
+    }
+
     fn report(label: &str, results: &[(usize, usize, usize, i32)]) {
         println!("--- {label} ---");
         println!(
@@ -443,12 +466,7 @@ mod size_experiment {
                 }
             }
 
-            let trace = fs::read_to_string(&trace_path).expect("failed to read trace buffer");
-            let delivered = trace
-                .lines()
-                .filter(|line| !line.trim_start().starts_with('#'))
-                .filter(|line| line.contains(TRACEPOINT))
-                .count();
+            let delivered = ftrace_entries(&root);
             results.push((size, delivered, written, errno));
         }
 

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -138,6 +138,278 @@ pub use logs::ProcessorBuilder;
 #[cfg(feature = "experimental_eventname_callback")]
 pub use logs::EventNameCallback;
 
+/// Empirical measurement of the largest EventHeader event that `user_events`
+/// actually delivers to a consumer, for both the perf and ftrace paths.
+///
+/// This is an experiment, not a regression test. The logs exporter currently
+/// assumes a 64 KB bound: `logs/exporter.rs` only reports
+/// `PAYLOAD_SIZE_EXCEEDED_ERROR` and, on success, treats the record as
+/// delivered. But `user_event_perf()` in the kernel stages records through
+/// `perf_trace_buf_alloc()`, which refuses anything above `PERF_MAX_TRACE_SIZE`
+/// (8192), and the ftrace path is bounded by the ring buffer sub-buffer size.
+/// If those bounds apply here, log records between the real limit and 64 KB are
+/// reported as written and silently discarded.
+///
+/// This probes the boundary directly, through the same `eventheader_dynamic`
+/// write path the exporter uses, so the measured overhead is the real one.
+///
+/// Run with:
+///   sudo -E cargo test --lib size_experiment -- --ignored --nocapture --test-threads=1
+#[cfg(all(test, target_os = "linux"))]
+mod size_experiment {
+    use eventheader::{FieldFormat, Level};
+    use eventheader_dynamic::{EventBuilder, EventSet, Provider};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    const PROVIDER_NAME: &str = "otelsizeexp";
+    const KEYWORD: u64 = 1;
+    /// `Level::Informational` is 4, so the registered tracepoint is
+    /// `otelsizeexp_L4K1`.
+    const TRACEPOINT: &str = "otelsizeexp_L4K1";
+
+    /// Sizes of the variable-length string field, in bytes. Chosen to bracket
+    /// the ftrace sub-buffer bound (~4 KiB), `PERF_MAX_TRACE_SIZE` (8192), and
+    /// the 64 KiB limit the exporter currently assumes.
+    const PROBE_SIZES: &[usize] = &[
+        512, 1024, 2048, 3072, 4000, 4048, 4072, 4096, 5120, 6144, 7500, 8000, 8100, 8140, 8168,
+        8192, 8300, 10240, 12288, 16384, 24576, 32768, 49152, 60000, 65000, 65400,
+    ];
+
+    /// Each size is written this many times so a single transient drop is not
+    /// mistaken for a hard limit.
+    const REPEATS: usize = 3;
+
+    fn tracefs_root() -> PathBuf {
+        for candidate in ["/sys/kernel/tracing", "/sys/kernel/debug/tracing"] {
+            if Path::new(candidate).join("events").is_dir() {
+                return PathBuf::from(candidate);
+            }
+        }
+        panic!("tracefs is not mounted; run as root on a kernel with tracefs available");
+    }
+
+    fn print_environment(root: &Path) {
+        println!("--- environment ---");
+        println!("page_size: {}", unsafe { sysconf_page_size() });
+        for file in ["buffer_subbuf_size_kb", "buffer_size_kb"] {
+            match fs::read_to_string(root.join(file)) {
+                Ok(v) => println!("{file}: {}", v.trim()),
+                Err(e) => println!("{file}: <unavailable: {e}>"),
+            }
+        }
+        if let Ok(v) = fs::read_to_string("/proc/version") {
+            println!("kernel: {}", v.trim());
+        }
+    }
+
+    /// `sysconf(_SC_PAGESIZE)` without adding a dependency on `libc`.
+    unsafe fn sysconf_page_size() -> i64 {
+        unsafe extern "C" {
+            fn sysconf(name: i32) -> i64;
+        }
+        // _SC_PAGESIZE is 30 on Linux.
+        unsafe { sysconf(30) }
+    }
+
+    fn register_provider() -> (Provider, Arc<EventSet>) {
+        let mut provider = Provider::new(PROVIDER_NAME, &Provider::new_options());
+        let event_set = provider.register_set(Level::Informational, KEYWORD);
+        assert_eq!(
+            event_set.errno(),
+            0,
+            "failed to register {PROVIDER_NAME} event set; run as root"
+        );
+        (provider, event_set)
+    }
+
+    /// Writes one event carrying a string field of `size` bytes, plus a `size`
+    /// field so a decoded event can be attributed back to its probe. Returns
+    /// the errno reported by `EventBuilder::write`, which is exactly what the
+    /// exporter inspects to decide whether the record was delivered.
+    fn write_probe(eb: &mut EventBuilder, event_set: &EventSet, size: usize) -> i32 {
+        let payload = "x".repeat(size);
+        eb.reset("SizeProbe", 0);
+        eb.add_value("size", size as u64, FieldFormat::UnsignedInt, 0);
+        eb.add_str("payload", payload.as_str(), FieldFormat::Default, 0);
+        eb.write(event_set, None, None)
+    }
+
+    fn report(label: &str, results: &[(usize, usize, usize, i32)]) {
+        println!("--- {label} ---");
+        println!(
+            "{:>8}  {:>9}  {:>7}  {:>6}  verdict",
+            "size", "delivered", "written", "errno"
+        );
+        let mut largest_ok = None;
+        let mut smallest_dropped = None;
+        let mut silent_loss = Vec::new();
+        for (size, delivered, written, errno) in results {
+            let verdict = if *delivered == *written {
+                // PROBE_SIZES is ascending, so the last match is the largest.
+                largest_ok = Some(*size);
+                "ok"
+            } else if *delivered == 0 {
+                if smallest_dropped.is_none() {
+                    smallest_dropped = Some(*size);
+                }
+                if *errno == 0 {
+                    silent_loss.push(*size);
+                }
+                "DROPPED"
+            } else {
+                "PARTIAL"
+            };
+            println!("{size:>8}  {delivered:>9}  {written:>7}  {errno:>6}  {verdict}");
+        }
+        println!(
+            "{label}: largest fully delivered = {largest_ok:?}, smallest fully dropped = {smallest_dropped:?}"
+        );
+        println!(
+            "{label}: sizes dropped while write() reported success (silent loss) = {silent_loss:?}"
+        );
+    }
+
+    /// Probes the perf delivery path, which is what a `one_collect`-based
+    /// consumer uses.
+    #[ignore]
+    #[test]
+    fn size_experiment_perf() {
+        use one_collect::perf_event::{RingBufBuilder, RingBufSessionBuilder};
+        use one_collect::tracefs::TraceFS;
+        use one_collect::Writable;
+
+        let root = tracefs_root();
+        print_environment(&root);
+
+        let (_provider, event_set) = register_provider();
+
+        let tracefs = TraceFS::open().expect("need root to open tracefs");
+        let mut tp_event = tracefs
+            .find_event("user_events", TRACEPOINT)
+            .expect("tracepoint not found after registration");
+
+        let count = Writable::<usize>::new(0);
+        let sink = count.clone();
+        tp_event.add_callback(move |_data| {
+            sink.write(|c| *c += 1);
+            Ok(())
+        });
+
+        // 8 MiB per CPU, far more than this test writes, so ring buffer
+        // capacity can never be mistaken for a per-event limit.
+        let mut session = RingBufSessionBuilder::new()
+            .with_page_count(2048)
+            .with_tracepoint_events(RingBufBuilder::for_tracepoint())
+            .with_target_pid(std::process::id() as i32)
+            .build()
+            .expect("need root to create a perf session");
+        session.add_event(tp_event).expect("failed to add event");
+        session.enable().expect("failed to enable perf session");
+
+        assert!(
+            event_set.enabled(),
+            "event set should be enabled once the perf session is attached"
+        );
+
+        let mut eb = EventBuilder::new();
+        let mut results = Vec::new();
+        let mut seen = 0usize;
+        for &size in PROBE_SIZES {
+            let mut written = 0;
+            let mut errno = 0;
+            for _ in 0..REPEATS {
+                let code = write_probe(&mut eb, &event_set, size);
+                if code == 0 {
+                    written += 1;
+                } else {
+                    errno = code;
+                }
+            }
+
+            // Drain after each size so deliveries are attributed to the probe
+            // that produced them without having to decode the payload.
+            session.parse_all().expect("failed to drain ring buffer");
+            let mut total = 0;
+            count.read(|c| total = *c);
+            results.push((size, total - seen, written, errno));
+            seen = total;
+        }
+
+        session.disable().expect("failed to disable perf session");
+        report("perf", &results);
+
+        // Guard against a broken capture setup reporting a bogus threshold: the
+        // smallest probe must always be delivered.
+        assert_eq!(
+            results[0].1, REPEATS,
+            "smallest probe was not delivered; the capture path itself is broken, \
+             so the reported threshold is meaningless"
+        );
+    }
+
+    /// Probes the ftrace delivery path, with no perf session attached. This is
+    /// bounded by the ring buffer sub-buffer size rather than by
+    /// `PERF_MAX_TRACE_SIZE`.
+    #[ignore]
+    #[test]
+    fn size_experiment_ftrace() {
+        let root = tracefs_root();
+        print_environment(&root);
+
+        let (_provider, event_set) = register_provider();
+
+        let enable_path = root.join(format!("events/user_events/{TRACEPOINT}/enable"));
+        fs::write(&enable_path, "1")
+            .unwrap_or_else(|e| panic!("failed to enable {}: {e}", enable_path.display()));
+        fs::write(root.join("tracing_on"), "1").expect("failed to set tracing_on");
+
+        assert!(
+            event_set.enabled(),
+            "event set should be enabled once the ftrace event is enabled"
+        );
+
+        let trace_path = root.join("trace");
+        let mut eb = EventBuilder::new();
+        let mut results = Vec::new();
+        for &size in PROBE_SIZES {
+            // Truncate the trace buffer so each probe is measured in isolation.
+            fs::write(&trace_path, "").expect("failed to clear trace buffer");
+
+            let mut written = 0;
+            let mut errno = 0;
+            for _ in 0..REPEATS {
+                let code = write_probe(&mut eb, &event_set, size);
+                if code == 0 {
+                    written += 1;
+                } else {
+                    errno = code;
+                }
+            }
+
+            let trace = fs::read_to_string(&trace_path).expect("failed to read trace buffer");
+            let delivered = trace
+                .lines()
+                .filter(|line| !line.trim_start().starts_with('#'))
+                .filter(|line| line.contains(TRACEPOINT))
+                .count();
+            results.push((size, delivered, written, errno));
+        }
+
+        let _ = fs::write(&enable_path, "0");
+        report("ftrace", &results);
+
+        // Guard against a broken capture setup reporting a bogus threshold: the
+        // smallest probe must always be delivered.
+        assert_eq!(
+            results[0].1, REPEATS,
+            "smallest probe was not delivered; the capture path itself is broken, \
+             so the reported threshold is meaningless"
+        );
+    }
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
 

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -290,10 +290,16 @@ mod size_experiment {
             .find_event("user_events", TRACEPOINT)
             .expect("tracepoint not found after registration");
 
-        let count = Writable::<usize>::new(0);
-        let sink = count.clone();
-        tp_event.add_callback(move |_data| {
-            sink.write(|c| *c += 1);
+        // Record the raw record length of every delivered event. The
+        // EventHeader overhead is identical across probes (same event name,
+        // same two fields), so record length differs from probe to probe by
+        // exactly the difference in payload size, which makes it a reliable
+        // attribution key without having to decode the payload.
+        let lengths = Writable::<Vec<usize>>::new(Vec::new());
+        let sink = lengths.clone();
+        tp_event.add_callback(move |data| {
+            let len = data.event_data().len();
+            sink.write(|v| v.push(len));
             Ok(())
         });
 
@@ -314,8 +320,7 @@ mod size_experiment {
         );
 
         let mut eb = EventBuilder::new();
-        let mut results = Vec::new();
-        let mut seen = 0usize;
+        let mut write_results = Vec::new();
         for &size in PROBE_SIZES {
             let mut written = 0;
             let mut errno = 0;
@@ -327,17 +332,47 @@ mod size_experiment {
                     errno = code;
                 }
             }
-
-            // Drain after each size so deliveries are attributed to the probe
-            // that produced them without having to decode the payload.
-            session.parse_all().expect("failed to drain ring buffer");
-            let mut total = 0;
-            count.read(|c| total = *c);
-            results.push((size, total - seen, written, errno));
-            seen = total;
+            write_results.push((size, written, errno));
         }
 
+        // The ring buffer is drained only after the session is disabled;
+        // draining a live session blocks.
         session.disable().expect("failed to disable perf session");
+        session.parse_all().expect("failed to drain ring buffer");
+
+        let mut received = Vec::new();
+        lengths.read(|v| received = v.clone());
+
+        // Derive the fixed per-record overhead from the smallest probe, which
+        // is far below every candidate limit and so is always delivered.
+        let smallest = PROBE_SIZES[0];
+        let overhead = received
+            .iter()
+            .min()
+            .map(|min_len| min_len.saturating_sub(smallest))
+            .unwrap_or(0);
+        println!("derived per-record overhead: {overhead} bytes");
+
+        let results: Vec<(usize, usize, usize, i32)> = write_results
+            .iter()
+            .map(|&(size, written, errno)| {
+                let delivered = received
+                    .iter()
+                    .filter(|&&len| len.saturating_sub(overhead) == size)
+                    .count();
+                (size, delivered, written, errno)
+            })
+            .collect();
+
+        let attributed: usize = results.iter().map(|r| r.1).sum();
+        if attributed != received.len() {
+            println!(
+                "warning: {} of {} received records could not be attributed to a probe size",
+                received.len() - attributed,
+                received.len()
+            );
+        }
+
         report("perf", &results);
 
         // Guard against a broken capture setup reporting a bogus threshold: the

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -172,9 +172,13 @@ mod size_experiment {
     /// Sizes of the variable-length string field, in bytes. Chosen to bracket
     /// the ftrace sub-buffer bound (~4 KiB), `PERF_MAX_TRACE_SIZE` (8192), and
     /// the 64 KiB limit the exporter currently assumes.
+    /// All values are multiples of 8 so that record-length attribution on the
+    /// perf path is unambiguous, and the spacing is 8 bytes around each
+    /// candidate boundary so the threshold is pinned exactly.
     const PROBE_SIZES: &[usize] = &[
-        512, 1024, 2048, 3072, 4000, 4048, 4072, 4096, 5120, 6144, 7500, 8000, 8100, 8140, 8168,
-        8192, 8300, 10240, 12288, 16384, 24576, 32768, 49152, 60000, 65000, 65400,
+        512, 1024, 2048, 3072, 3968, 3976, 3984, 3992, 4000, 4008, 4016, 4024, 4032, 4040, 4048,
+        4056, 4064, 4072, 4096, 5120, 6144, 7168, 8000, 8016, 8032, 8048, 8064, 8080, 8088, 8096,
+        8104, 8112, 8120, 8128, 8136, 8144, 8168, 8192, 10240, 16384, 32768, 65400,
     ];
 
     /// Each size is written this many times so a single transient drop is not
@@ -353,12 +357,28 @@ mod size_experiment {
             .unwrap_or(0);
         println!("derived per-record overhead: {overhead} bytes");
 
+        // Print the raw length histogram so the attribution below can be
+        // checked against the unprocessed measurement.
+        let mut sorted = received.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        println!("--- received record lengths (length, count, length - overhead) ---");
+        for len in &sorted {
+            let count = received.iter().filter(|&l| l == len).count();
+            println!("{len:>8}  {count:>3}  {}", len.saturating_sub(overhead));
+        }
+
+        // Attribute with a tolerance of one 8-byte alignment unit. Probe sizes
+        // are 8 bytes apart at their closest, so the mapping stays unique.
         let results: Vec<(usize, usize, usize, i32)> = write_results
             .iter()
             .map(|&(size, written, errno)| {
                 let delivered = received
                     .iter()
-                    .filter(|&&len| len.saturating_sub(overhead) == size)
+                    .filter(|&&len| {
+                        let payload = len.saturating_sub(overhead);
+                        payload >= size && payload - size < 8
+                    })
                     .count();
                 (size, delivered, written, errno)
             })

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 - Pack multiple metric data points into each `user_events` write instead of
   emitting one event per data point. The resource/scope/metric envelope is now
-  amortized across every data point that fits within the 64KB tracepoint limit,
-  which substantially reduces both the bytes written to the per-CPU perf ring
-  buffer and the number of writes per export cycle. Batching is per-metric: a
-  single event never mixes data points from different metrics or scopes.
+  amortized across every data point that fits within a single event, which
+  substantially reduces both the bytes written to the per-CPU perf ring buffer
+  and the number of writes per export cycle. Batching is per-metric: a single
+  event never mixes data points from different metrics or scopes.
+- Fixed the maximum tracepoint event size, which was previously set to 64KB.
+  When a `user_events` tracepoint is consumed through perf, the kernel copies
+  the record into a `PERF_MAX_TRACE_SIZE` (8192 byte) per-CPU buffer, and an
+  event that does not fit is dropped without any error being reported to the
+  writer. The limit is now derived from that bound. This had no effect before
+  batching, because a single data point never approached 64KB.
 
 ## v0.13.0
 

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+- Pack multiple metric data points into each `user_events` write instead of
+  emitting one event per data point. The resource/scope/metric envelope is now
+  amortized across every data point that fits within the 64KB tracepoint limit,
+  which substantially reduces both the bytes written to the per-CPU perf ring
+  buffer and the number of writes per export cycle. Batching is per-metric: a
+  single event never mixes data points from different metrics or scopes.
+
 ## v0.13.0
 
 Released 2026-May-13

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -20,6 +20,7 @@ prost = "0.14"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter","registry", "std", "fmt"] }
+criterion = "0.8"
 
 # Linux-only: in-process user_events consumer used by the integration tests to
 # read the `otlp_metrics` tracepoint directly from the perf ring buffer instead
@@ -30,6 +31,10 @@ one_collect = "0.1.34532"
 [features]
 internal-logs = ["opentelemetry/internal-logs", "opentelemetry_sdk/internal-logs", "opentelemetry-proto/internal-logs"]
 default = ["internal-logs"]
+
+[[bench]]
+name = "metrics"
+harness = false
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]

--- a/opentelemetry-user-events-metrics/benches/metrics.rs
+++ b/opentelemetry-user-events-metrics/benches/metrics.rs
@@ -1,0 +1,121 @@
+/*
+    Benchmarks a full collect + export cycle for the user_events metrics
+    exporter.
+
+    Each iteration records `series` data points and then forces a flush, so the
+    measurement covers aggregation, OTLP serialization and the tracepoint
+    writes. Recording cost is identical across implementations, so the numbers
+    are meaningful when comparing two revisions of the exporter (for example
+    one-event-per-data-point versus batched writes).
+
+    IMPORTANT: the exporter short-circuits when the tracepoint has no listener,
+    in which case nothing is serialized and the numbers only reflect collection.
+    Run on Linux with the tracepoint enabled to measure the export path:
+
+      sudo -E ~/.cargo/bin/cargo bench --bench metrics
+      # in another shell, once the tracepoint is registered:
+      echo 1 | sudo tee /sys/kernel/tracing/events/user_events/otlp_metrics/enable
+
+    To compare against another revision:
+
+      git checkout main     && cargo bench --bench metrics -- --save-baseline before
+      git checkout <branch> && cargo bench --bench metrics -- --baseline before
+*/
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::Resource;
+use opentelemetry_user_events_metrics::MetricsExporter;
+
+/// A deliberately small resource, matching what production agents carry. The
+/// envelope it produces is what batching amortizes away.
+fn resource() -> Resource {
+    Resource::builder_empty()
+        .with_attributes([
+            KeyValue::new("service.name", "bench-ingest"),
+            KeyValue::new(
+                "service.instance.id",
+                "9f1c2b7e-4a3d-4c11-9b02-7e5f8a1d3c44",
+            ),
+            KeyValue::new("cloud.region", "eastus2"),
+            KeyValue::new("host.name", "node-bench-0731"),
+        ])
+        .build()
+}
+
+/// Attribute sets for `count` dimensions. The high-cardinality `partition` key
+/// comes first so every dimension count still yields distinct series.
+fn dims(i: usize, count: usize) -> Vec<KeyValue> {
+    let all = [
+        KeyValue::new("partition", format!("p{i:04}")),
+        KeyValue::new("operation", "GetBlobProperties"),
+        KeyValue::new("status_code", "200"),
+        KeyValue::new("client_version", "2024-11-04"),
+        KeyValue::new("protocol", "https"),
+    ];
+    all.into_iter().take(count).collect()
+}
+
+fn provider() -> SdkMeterProvider {
+    SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(MetricsExporter::new()).build())
+        .with_resource(resource())
+        .build()
+}
+
+fn bench_counter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("export_cycle_counter");
+    for series in [100usize, 1000] {
+        for n_dims in [2usize, 5] {
+            group.throughput(Throughput::Elements(series as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("{n_dims}_dims"), series),
+                &series,
+                |b, &series| {
+                    let provider = provider();
+                    let counter = provider
+                        .meter("bench")
+                        .u64_counter("bench.requests")
+                        .build();
+                    let attrs: Vec<Vec<KeyValue>> = (0..series).map(|i| dims(i, n_dims)).collect();
+                    b.iter(|| {
+                        for a in &attrs {
+                            counter.add(1, a);
+                        }
+                        let _ = provider.force_flush();
+                    });
+                    let _ = provider.shutdown();
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_histogram(c: &mut Criterion) {
+    let mut group = c.benchmark_group("export_cycle_histogram");
+    for series in [100usize, 1000] {
+        group.throughput(Throughput::Elements(series as u64));
+        group.bench_with_input(BenchmarkId::new("3_dims", series), &series, |b, &series| {
+            let provider = provider();
+            let hist = provider
+                .meter("bench")
+                .f64_histogram("bench.latency")
+                .build();
+            let attrs: Vec<Vec<KeyValue>> = (0..series).map(|i| dims(i, 3)).collect();
+            b.iter(|| {
+                for a in &attrs {
+                    hist.record(12.5, a);
+                }
+                let _ = provider.force_flush();
+            });
+            let _ = provider.shutdown();
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_counter, bench_histogram);
+criterion_main!(benches);

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -16,7 +16,14 @@ use prost::Message;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
-const MAX_EVENT_SIZE: usize = 65360;
+/// Upper bound on the encoded size of a single tracepoint event.
+///
+/// A perf ring buffer record carries its length in a `__u16`, so a record can
+/// never exceed 65535 bytes in total. The payload budget is set slightly below
+/// that to leave room for the perf record header and the tracepoint's own
+/// fields, so a maximally packed event is still guaranteed to be representable
+/// (and therefore readable) by a perf consumer.
+pub(crate) const MAX_EVENT_SIZE: usize = 65360;
 
 /// Safety margin, in bytes, reserved when deciding whether another data point
 /// fits into the current batch.
@@ -26,7 +33,7 @@ const MAX_EVENT_SIZE: usize = 65360;
 /// `ResourceMetrics`. Each of those four varints grows by at most 2 bytes as
 /// the payload approaches `MAX_EVENT_SIZE`, so 8 bytes is the true bound; 32
 /// gives ample headroom while costing nothing measurable in packing density.
-const SIZE_SLACK: usize = 32;
+pub(crate) const SIZE_SLACK: usize = 32;
 
 /// Abstracts the destination of an encoded OTLP payload.
 ///

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -1,5 +1,6 @@
 use opentelemetry::{otel_debug, otel_info};
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::metrics::v1::metric::Data as ProtoData;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::metrics::data::AggregatedMetrics;
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
@@ -16,6 +17,69 @@ use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
 const MAX_EVENT_SIZE: usize = 65360;
+
+/// Safety margin, in bytes, reserved when deciding whether another data point
+/// fits into the current batch.
+///
+/// Adding data points grows the protobuf length-delimiter of every enclosing
+/// message: `Sum`/`Gauge`/`Histogram` -> `Metric` -> `ScopeMetrics` ->
+/// `ResourceMetrics`. Each of those four varints grows by at most 2 bytes as
+/// the payload approaches `MAX_EVENT_SIZE`, so 8 bytes is the true bound; 32
+/// gives ample headroom while costing nothing measurable in packing density.
+const SIZE_SLACK: usize = 32;
+
+/// Abstracts the destination of an encoded OTLP payload.
+///
+/// Production uses [`TracepointWriter`]. Tests substitute an in-memory writer so
+/// the encoding and batching logic can be exercised on any platform, not just
+/// Linux hosts with `user_events` available.
+trait EventWriter: Send + Sync {
+    fn enabled(&self) -> bool;
+    fn write(&self, buffer: &[u8]) -> i32;
+}
+
+struct TracepointWriter {
+    trace_point: Pin<Box<ehi::TracepointState>>,
+}
+
+impl TracepointWriter {
+    fn new() -> Self {
+        let trace_point = Box::pin(ehi::TracepointState::new(0));
+        // This is unsafe because if the code is used in a shared object,
+        // the event MUST be unregistered before the shared object unloads.
+        unsafe {
+            let _result = tracepoint::register(trace_point.as_ref());
+        }
+        TracepointWriter { trace_point }
+    }
+}
+
+impl EventWriter for TracepointWriter {
+    fn enabled(&self) -> bool {
+        self.trace_point.enabled()
+    }
+
+    fn write(&self, buffer: &[u8]) -> i32 {
+        tracepoint::write(&self.trace_point, buffer)
+    }
+}
+
+/// Number of bytes a single data point contributes to its enclosing
+/// `repeated` field: a 1-byte tag (all four data-point fields are field 1),
+/// the length varint, and the encoded body.
+fn data_point_cost<P: Message>(point: &P) -> usize {
+    let len = point.encoded_len();
+    1 + varint_len(len) + len
+}
+
+fn varint_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
 
 trait Numeric: Copy {
     // lossy at large values for u64 and i64 but otlp histograms only handle float values
@@ -62,18 +126,16 @@ impl Numeric for f64 {
 }
 
 pub struct MetricsExporter {
-    trace_point: Pin<Box<ehi::TracepointState>>,
+    writer: Box<dyn EventWriter>,
+    max_event_size: usize,
 }
 
 impl MetricsExporter {
     pub fn new() -> MetricsExporter {
-        let trace_point = Box::pin(ehi::TracepointState::new(0));
-        // This is unsafe because if the code is used in a shared object,
-        // the event MUST be unregistered before the shared object unloads.
-        unsafe {
-            let _result = tracepoint::register(trace_point.as_ref());
+        MetricsExporter {
+            writer: Box::new(TracepointWriter::new()),
+            max_event_size: MAX_EVENT_SIZE,
         }
-        MetricsExporter { trace_point }
     }
 }
 
@@ -98,339 +160,295 @@ fn to_nanos(time: SystemTime) -> u64 {
 impl MetricsExporter {
     fn process_numeric_metrics<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         data: &MetricData<T>,
     ) -> usize {
         match data {
-            MetricData::Gauge(gauge) => self.process_gauge(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                gauge,
-            ),
-            MetricData::Sum(sum) => self.process_sum(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                sum,
-            ),
-            MetricData::Histogram(hist) => self.process_histogram(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                hist,
-            ),
-            MetricData::ExponentialHistogram(hist) => self.process_exponential_histogram(
-                export_metric_service_request_common,
-                byte_array,
-                metric,
-                hist,
-            ),
+            MetricData::Gauge(gauge) => self.process_gauge(request, byte_array, metric, gauge),
+            MetricData::Sum(sum) => self.process_sum(request, byte_array, metric, sum),
+            MetricData::Histogram(hist) => {
+                self.process_histogram(request, byte_array, metric, hist)
+            }
+            MetricData::ExponentialHistogram(hist) => {
+                self.process_exponential_histogram(request, byte_array, metric, hist)
+            }
+        }
+    }
+
+    /// Installs a `Metric` shell (name/description/unit, no data) as the single
+    /// metric of the single scope in `request`.
+    fn set_metric_shell(
+        request: &mut ExportMetricsServiceRequest,
+        metric: &opentelemetry_sdk::metrics::data::Metric,
+    ) {
+        request.resource_metrics[0].scope_metrics[0].metrics =
+            vec![opentelemetry_proto::tonic::metrics::v1::Metric {
+                name: metric.name().to_string(),
+                description: metric.description().to_string(),
+                unit: metric.unit().to_string(),
+                metadata: vec![],
+                data: None,
+            }];
+    }
+
+    /// Packs `points` into as few tracepoint events as possible.
+    ///
+    /// Data points are accumulated until adding one more would push the encoded
+    /// `ExportMetricsServiceRequest` past `max_event_size`, at which point the
+    /// batch is flushed and a new one is started with the remaining points. The
+    /// resource, scope and metric metadata (the "envelope") is therefore written
+    /// once per event rather than once per data point.
+    ///
+    /// Returns the number of data points that could not be exported.
+    fn emit_batched<P, F>(
+        &self,
+        request: &mut ExportMetricsServiceRequest,
+        byte_array: &mut Vec<u8>,
+        metric: &opentelemetry_sdk::metrics::data::Metric,
+        points: impl Iterator<Item = P>,
+        make_data: F,
+    ) -> usize
+    where
+        P: Message,
+        F: Fn(Vec<P>) -> ProtoData,
+    {
+        // Encode the envelope once (metric present, zero data points) to learn
+        // the fixed per-event cost.
+        request.resource_metrics[0].scope_metrics[0].metrics[0].data = Some(make_data(Vec::new()));
+        let envelope_len = request.encoded_len();
+
+        let mut batch: Vec<P> = Vec::new();
+        let mut batch_len = 0usize;
+        let mut failed_count = 0usize;
+
+        for point in points {
+            let cost = data_point_cost(&point);
+
+            if !batch.is_empty()
+                && envelope_len + batch_len + cost + SIZE_SLACK > self.max_event_size
+            {
+                failed_count +=
+                    self.flush_batch(request, byte_array, metric, &mut batch, &make_data);
+                batch_len = 0;
+            }
+
+            batch_len += cost;
+            batch.push(point);
+        }
+
+        if !batch.is_empty() {
+            failed_count += self.flush_batch(request, byte_array, metric, &mut batch, &make_data);
+        }
+
+        failed_count
+    }
+
+    /// Encodes and writes the accumulated batch, leaving `batch` empty.
+    fn flush_batch<P, F>(
+        &self,
+        request: &mut ExportMetricsServiceRequest,
+        byte_array: &mut Vec<u8>,
+        metric: &opentelemetry_sdk::metrics::data::Metric,
+        batch: &mut Vec<P>,
+        make_data: &F,
+    ) -> usize
+    where
+        P: Message,
+        F: Fn(Vec<P>) -> ProtoData,
+    {
+        let point_count = batch.len();
+        request.resource_metrics[0].scope_metrics[0].metrics[0].data =
+            Some(make_data(std::mem::take(batch)));
+
+        byte_array.clear();
+        if self
+            .encode_and_emit_metric(request, byte_array, metric)
+            .is_err()
+        {
+            point_count
+        } else {
+            0
         }
     }
 
     fn process_gauge<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         gauge: &opentelemetry_sdk::metrics::data::Gauge<T>,
     ) -> usize {
-        // Store and reuse common values for all data points in this gauge
-        let gauge_start_time = gauge.start_time().map(to_nanos).unwrap_or_default();
-        let gauge_time = to_nanos(gauge.time());
+        let start_time = gauge.start_time().map(to_nanos).unwrap_or_default();
+        let time = to_nanos(gauge.time());
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this gauge metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + value).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in gauge.data_points() {
-            let number_data_point = opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+        let points = gauge.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
                 attributes: dp.attributes().map(Into::into).collect(),
-                start_time_unix_nano: gauge_start_time,
-                time_unix_nano: gauge_time,
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
                 exemplars: Vec::new(), // No support for exemplars
                 flags: default_flags,
                 value: Some(dp.value().into_number_data_point_value()),
-            };
-
-            let gauge_point_proto = opentelemetry_proto::tonic::metrics::v1::Gauge {
-                data_points: vec![number_data_point],
-            };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(
-                opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(gauge_point_proto),
-            );
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::Gauge(opentelemetry_proto::tonic::metrics::v1::Gauge { data_points })
+        })
     }
 
     fn process_sum<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         sum: &opentelemetry_sdk::metrics::data::Sum<T>,
     ) -> usize {
-        // Pre-compute common values for all data points in this sum
-        let sum_start_time = to_nanos(sum.start_time());
-        let sum_time = to_nanos(sum.time());
-        let sum_is_monotonic = sum.is_monotonic();
+        let start_time = to_nanos(sum.start_time());
+        let time = to_nanos(sum.time());
+        let is_monotonic = sum.is_monotonic();
+        let temporality = sum.temporality() as i32;
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this sum metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + value).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in sum.data_points() {
-            let number_data_point = opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+        let points = sum.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
                 attributes: dp.attributes().map(Into::into).collect(),
-                start_time_unix_nano: sum_start_time,
-                time_unix_nano: sum_time,
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
                 exemplars: Vec::new(), // No support for exemplars
                 flags: default_flags,
                 value: Some(dp.value().into_number_data_point_value()),
-            };
-
-            let sum_point_proto = opentelemetry_proto::tonic::metrics::v1::Sum {
-                aggregation_temporality: sum.temporality() as i32,
-                is_monotonic: sum_is_monotonic,
-                data_points: vec![number_data_point],
-            };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
-                sum_point_proto,
-            ));
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::Sum(opentelemetry_proto::tonic::metrics::v1::Sum {
+                aggregation_temporality: temporality,
+                is_monotonic,
+                data_points,
+            })
+        })
     }
 
     fn process_histogram<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         hist: &opentelemetry_sdk::metrics::data::Histogram<T>,
     ) -> usize {
-        // Pre-compute common values for all data points in this histogram
-        let hist_start_time = to_nanos(hist.start_time());
-        let hist_time = to_nanos(hist.time());
+        let start_time = to_nanos(hist.start_time());
+        let time = to_nanos(hist.time());
+        let temporality = hist.temporality() as i32;
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this histogram metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + buckets).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in hist.data_points() {
-            let histogram_data_point =
-                opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint {
-                    attributes: dp.attributes().map(Into::into).collect(),
-                    start_time_unix_nano: hist_start_time,
-                    time_unix_nano: hist_time,
-                    count: dp.count(),
-                    sum: Some(dp.sum().into_f64()),
-                    bucket_counts: dp.bucket_counts().collect(),
-                    explicit_bounds: dp.bounds().collect(),
-                    exemplars: Vec::new(), // No support for exemplars
-                    flags: default_flags,
-                    min: dp.min().map(|v| v.into_f64()),
-                    max: dp.max().map(|v| v.into_f64()),
-                };
-
-            let histogram_point_proto = opentelemetry_proto::tonic::metrics::v1::Histogram {
-                aggregation_temporality: hist.temporality() as i32,
-                data_points: vec![histogram_data_point],
-            };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(
-                opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(
-                    histogram_point_proto,
-                ),
-            );
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
+        let points = hist.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint {
+                attributes: dp.attributes().map(Into::into).collect(),
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
+                count: dp.count(),
+                sum: Some(dp.sum().into_f64()),
+                bucket_counts: dp.bucket_counts().collect(),
+                explicit_bounds: dp.bounds().collect(),
+                exemplars: Vec::new(), // No support for exemplars
+                flags: default_flags,
+                min: dp.min().map(|v| v.into_f64()),
+                max: dp.max().map(|v| v.into_f64()),
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::Histogram(opentelemetry_proto::tonic::metrics::v1::Histogram {
+                aggregation_temporality: temporality,
+                data_points,
+            })
+        })
     }
 
     fn process_exponential_histogram<T: Numeric>(
         &self,
-        export_metric_service_request_common: &mut ExportMetricsServiceRequest,
+        request: &mut ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
         hist: &opentelemetry_sdk::metrics::data::ExponentialHistogram<T>,
     ) -> usize {
-        // Pre-compute common values for all data points in this histogram
-        let hist_start_time = to_nanos(hist.start_time());
-        let hist_time = to_nanos(hist.time());
+        let start_time = to_nanos(hist.start_time());
+        let time = to_nanos(hist.time());
+        let temporality = hist.temporality() as i32;
         let default_flags =
             opentelemetry_proto::tonic::metrics::v1::DataPointFlags::default() as u32;
 
-        // Create metric_proto template outside the loop to reuse name, description, unit
-        let metric_proto = opentelemetry_proto::tonic::metrics::v1::Metric {
-            name: metric.name().to_string(),
-            description: metric.description().to_string(),
-            unit: metric.unit().to_string(),
-            metadata: vec![],
-            data: None,
-        };
+        Self::set_metric_shell(request, metric);
 
-        export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics =
-            vec![metric_proto];
-
-        let mut failed_count = 0;
-
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 3: METRIC → DATA POINTS (Individual measurements)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each data point within this exponential histogram metric.
-        // Each data point = unique combination of (metric + attributes + timestamp + buckets).
-        // SERIALIZATION: Each data point is individually encoded and emitted to tracepoint.
-        for dp in hist.data_points() {
-            let histogram_data_point = opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint {
+        let points = hist.data_points().map(|dp| {
+            opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint {
                 attributes: dp.attributes().map(Into::into).collect(),
-                start_time_unix_nano: hist_start_time,
-                time_unix_nano: hist_time,
+                start_time_unix_nano: start_time,
+                time_unix_nano: time,
                 count: dp.count() as u64,
                 sum: Some(dp.sum().into_f64()),
                 scale: dp.scale().into(),
                 zero_count: dp.zero_count(),
-                positive: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
-                    offset: dp.positive_bucket().offset(),
-                    bucket_counts: dp.positive_bucket().counts().collect(),
-                }),
-                negative: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
-                    offset: dp.negative_bucket().offset(),
-                    bucket_counts: dp.negative_bucket().counts().collect(),
-                }),
+                positive: Some(
+                    opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
+                        offset: dp.positive_bucket().offset(),
+                        bucket_counts: dp.positive_bucket().counts().collect(),
+                    },
+                ),
+                negative: Some(
+                    opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
+                        offset: dp.negative_bucket().offset(),
+                        bucket_counts: dp.negative_bucket().counts().collect(),
+                    },
+                ),
                 exemplars: Vec::new(), // No support for exemplars
                 flags: default_flags,
                 min: dp.min().map(|v| v.into_f64()),
                 max: dp.max().map(|v| v.into_f64()),
                 zero_threshold: dp.zero_threshold(),
-            };
-
-            let histogram_point_proto =
-                opentelemetry_proto::tonic::metrics::v1::ExponentialHistogram {
-                    aggregation_temporality: hist.temporality() as i32,
-                    data_points: vec![histogram_data_point],
-                };
-
-            // Update the data field for this data point
-            export_metric_service_request_common.resource_metrics[0].scope_metrics[0].metrics[0]
-                .data = Some(
-                opentelemetry_proto::tonic::metrics::v1::metric::Data::ExponentialHistogram(
-                    histogram_point_proto,
-                ),
-            );
-
-            byte_array.clear(); // Clear contents but retain capacity for performance
-            if self
-                .encode_and_emit_metric(export_metric_service_request_common, byte_array, metric)
-                .is_err()
-            {
-                failed_count += 1;
             }
-        }
-        failed_count
+        });
+
+        self.emit_batched(request, byte_array, metric, points, |data_points| {
+            ProtoData::ExponentialHistogram(
+                opentelemetry_proto::tonic::metrics::v1::ExponentialHistogram {
+                    aggregation_temporality: temporality,
+                    data_points,
+                },
+            )
+        })
     }
 
     fn encode_and_emit_metric(
         &self,
-        export_metric_service_request_common: &ExportMetricsServiceRequest,
+        request: &ExportMetricsServiceRequest,
         byte_array: &mut Vec<u8>,
         metric: &opentelemetry_sdk::metrics::data::Metric,
     ) -> Result<(), String> {
-        match export_metric_service_request_common.encode(byte_array) {
+        match request.encode(byte_array) {
             Ok(_) => {
-                otel_debug!(name: "SerializationSucceeded", 
+                otel_debug!(name: "SerializationSucceeded",
                     metric_name = metric.name(),
                     size = byte_array.len());
 
-                if byte_array.len() > MAX_EVENT_SIZE {
-                    let error_msg = format!("Encoded event size exceeds maximum allowed limit of {MAX_EVENT_SIZE} bytes. Event will be dropped.");
+                if byte_array.len() > self.max_event_size {
+                    let error_msg = format!(
+                        "Encoded event size exceeds maximum allowed limit of {} bytes. Event will be dropped.",
+                        self.max_event_size
+                    );
                     otel_debug!(
                         name: "EventSizeExceeded",
                         reason = &error_msg,
@@ -440,7 +458,7 @@ impl MetricsExporter {
                     Err(error_msg)
                 } else {
                     // Write to the tracepoint
-                    let result = tracepoint::write(&self.trace_point, byte_array);
+                    let result = self.writer.write(byte_array);
                     if result == 0 {
                         otel_debug!(name: "TracepointWriteSucceeded", message = "Encoded data successfully written to tracepoint", size = byte_array.len(), metric_name = metric.name());
                         Ok(())
@@ -464,46 +482,17 @@ impl MetricsExporter {
 
     fn export_resource_metrics(&self, resource_metric: &ResourceMetrics) -> OTelSdkResult {
         // Custom transformation to protobuf structs is used instead of upstream
-        // transforms because tracepoint has a 64kB size limit. Encoding each
-        // data point separately ensures we stay within this limit and avoid
-        // data loss. Some upstream transforms are reused where appropriate for
-        // consistency. TODO: Optimize by batching multiple data points until
-        // the size limit is reached, rather than writing one data point at a
-        // time.
-
-        // OVERALL EXPORT FLOW: This method implements a 3-level nested loop
-        // structure:
+        // transforms because the tracepoint has a 64kB size limit. Data points
+        // are packed into as few events as possible while respecting that limit,
+        // so the resource/scope/metric envelope is amortized across many data
+        // points instead of being repeated for every one.
         //
-        // LOOP 1: Resource → Scopes (Instrumentation Libraries)
-        //   - Iterate through each scope/instrumentation library in the
-        //     resource
-        //   - Each scope contains multiple metrics from the same library
-        //
-        // LOOP 2: Scope → Metrics
-        //   - For each scope, iterate through all metrics (counters, gauges,
-        //     histograms)
-        //   - Each metric contains multiple data points with different
-        //     attribute combinations
-        //
-        // LOOP 3: Metric → Data Points
-        //   - For each metric, iterate through individual data points
-        //   - Each data point represents a unique combination of metric +
-        //     attributes + timestamp
-        //   - SERIALIZATION HAPPENS HERE: Each data point is encoded and
-        //     emitted individually
-        //
-        // PERFORMANCE OPTIMIZATIONS:
-        // - Reuse protobuf structure templates at each level to avoid repeated
-        //   allocations
-        // - Single byte_array is reused throughout: cleared between uses but
-        //   capacity retained
-        // - Common values (timestamps, flags, metadata) pre-computed (but not
-        //   pre-serialized) per metric to avoid duplication
-        // - Only the innermost data varies between serializations, parent
-        //   structures stay constant
+        // Batching is currently per-metric: a single event never mixes data
+        // points from different metrics or scopes. Packing across metrics would
+        // amortize the envelope further and is left as a follow-up.
         let mut byte_array = Vec::new();
         let mut has_failures = false;
-        let mut export_metric_service_request_common = ExportMetricsServiceRequest {
+        let mut request = ExportMetricsServiceRequest {
             resource_metrics: vec![opentelemetry_proto::tonic::metrics::v1::ResourceMetrics {
                 resource: Some((resource_metric.resource()).into()),
                 scope_metrics: vec![],
@@ -515,56 +504,29 @@ impl MetricsExporter {
             }],
         };
 
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // LOOP 1: RESOURCE → SCOPES (Instrumentation Libraries)
-        // ═══════════════════════════════════════════════════════════════════════════════════
-        // Iterate through each scope (instrumentation library) within this resource.
-        // Each scope groups metrics that originate from the same library/component.
         for scope_metric in resource_metric.scope_metrics() {
-            // Create reusable scope_metric_proto template with empty metrics
-            let scope_metric_proto = opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
-                scope: Some((scope_metric.scope(), None).into()),
-                metrics: vec![],
-                schema_url: scope_metric
-                    .scope()
-                    .schema_url()
-                    .unwrap_or_default()
-                    .to_string(),
-            };
+            request.resource_metrics[0].scope_metrics =
+                vec![opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
+                    scope: Some((scope_metric.scope(), None).into()),
+                    metrics: vec![],
+                    schema_url: scope_metric
+                        .scope()
+                        .schema_url()
+                        .unwrap_or_default()
+                        .to_string(),
+                }];
 
-            export_metric_service_request_common.resource_metrics[0].scope_metrics =
-                vec![scope_metric_proto];
-
-            // ═══════════════════════════════════════════════════════════════════════════════════
-            // LOOP 2: SCOPE → METRICS (Counters, Gauges, Histograms, etc.)
-            // ═══════════════════════════════════════════════════════════════════════════════════
-            // For each scope, iterate through all metrics of different types.
-            // Each metric will be processed by type-specific handlers that implement LOOP 3.
             for metric in scope_metric.metrics() {
                 let failed_count = match metric.data() {
                     AggregatedMetrics::F64(data) => {
-                        // → DELEGATES TO LOOP 3: process_* methods iterate through data points
-                        // → SERIALIZATION: Each data point encoded & emitted individually
-                        // → REUSE: Same byte_array cleared & reused for performance
-                        self.process_numeric_metrics(
-                            &mut export_metric_service_request_common,
-                            &mut byte_array,
-                            metric,
-                            data,
-                        )
+                        self.process_numeric_metrics(&mut request, &mut byte_array, metric, data)
                     }
-                    AggregatedMetrics::U64(data) => self.process_numeric_metrics(
-                        &mut export_metric_service_request_common,
-                        &mut byte_array,
-                        metric,
-                        data,
-                    ),
-                    AggregatedMetrics::I64(data) => self.process_numeric_metrics(
-                        &mut export_metric_service_request_common,
-                        &mut byte_array,
-                        metric,
-                        data,
-                    ),
+                    AggregatedMetrics::U64(data) => {
+                        self.process_numeric_metrics(&mut request, &mut byte_array, metric, data)
+                    }
+                    AggregatedMetrics::I64(data) => {
+                        self.process_numeric_metrics(&mut request, &mut byte_array, metric, data)
+                    }
                 };
 
                 // Log failure counts if any data points failed to export
@@ -590,7 +552,7 @@ impl MetricsExporter {
 impl PushMetricExporter for MetricsExporter {
     async fn export(&self, resource_metrics: &ResourceMetrics) -> OTelSdkResult {
         otel_debug!(name: "ExportStarted", message = "Starting metrics export");
-        if !self.trace_point.enabled() {
+        if !self.writer.enabled() {
             // TODO - This can flood the logs if the tracepoint is disabled for long periods of time
             otel_info!(name: "TracepointDisabled", message = "Tracepoint is disabled, skipping export");
             Ok(())
@@ -615,5 +577,430 @@ impl PushMetricExporter for MetricsExporter {
 
     fn shutdown(&self) -> OTelSdkResult {
         self.shutdown_with_timeout(Duration::from_secs(5))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry::KeyValue;
+    use opentelemetry_proto::tonic::metrics::v1::metric::Data as PData;
+    use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+    use opentelemetry_sdk::Resource;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct CollectingWriter {
+        events: Arc<Mutex<Vec<Vec<u8>>>>,
+    }
+
+    impl CollectingWriter {
+        fn take(&self) -> Vec<Vec<u8>> {
+            std::mem::take(&mut *self.events.lock().unwrap())
+        }
+    }
+
+    impl EventWriter for CollectingWriter {
+        fn enabled(&self) -> bool {
+            true
+        }
+
+        fn write(&self, buffer: &[u8]) -> i32 {
+            self.events.lock().unwrap().push(buffer.to_vec());
+            0
+        }
+    }
+
+    impl MetricsExporter {
+        fn for_test(writer: CollectingWriter, max_event_size: usize) -> Self {
+            MetricsExporter {
+                writer: Box::new(writer),
+                max_event_size,
+            }
+        }
+    }
+
+    /// Replaces the data points of `request` with `data_points`, preserving the
+    /// metric type and its type-specific fields.
+    fn with_data_points(
+        request: &ExportMetricsServiceRequest,
+        indices: &[usize],
+    ) -> ExportMetricsServiceRequest {
+        let mut out = request.clone();
+        let data = out.resource_metrics[0].scope_metrics[0].metrics[0]
+            .data
+            .as_mut()
+            .expect("metric has data");
+        fn keep<T: Clone>(points: &mut Vec<T>, indices: &[usize]) {
+            let all = std::mem::take(points);
+            *points = indices.iter().map(|&i| all[i].clone()).collect();
+        }
+        match data {
+            PData::Gauge(g) => keep(&mut g.data_points, indices),
+            PData::Sum(s) => keep(&mut s.data_points, indices),
+            PData::Histogram(h) => keep(&mut h.data_points, indices),
+            PData::ExponentialHistogram(h) => keep(&mut h.data_points, indices),
+            PData::Summary(s) => keep(&mut s.data_points, indices),
+        }
+        out
+    }
+
+    /// Encoded cost of the first data point of `request`, as charged by the
+    /// batching accounting in the exporter.
+    fn first_point_cost(request: &ExportMetricsServiceRequest) -> usize {
+        match request.resource_metrics[0].scope_metrics[0].metrics[0]
+            .data
+            .as_ref()
+            .expect("metric has data")
+        {
+            PData::Gauge(g) => data_point_cost(&g.data_points[0]),
+            PData::Sum(s) => data_point_cost(&s.data_points[0]),
+            PData::Histogram(h) => data_point_cost(&h.data_points[0]),
+            PData::ExponentialHistogram(h) => data_point_cost(&h.data_points[0]),
+            PData::Summary(s) => data_point_cost(&s.data_points[0]),
+        }
+    }
+
+    fn data_point_count(request: &ExportMetricsServiceRequest) -> usize {
+        match request.resource_metrics[0].scope_metrics[0].metrics[0]
+            .data
+            .as_ref()
+            .expect("metric has data")
+        {
+            PData::Gauge(g) => g.data_points.len(),
+            PData::Sum(s) => s.data_points.len(),
+            PData::Histogram(h) => h.data_points.len(),
+            PData::ExponentialHistogram(h) => h.data_points.len(),
+            PData::Summary(s) => s.data_points.len(),
+        }
+    }
+
+    #[derive(Debug)]
+    struct Stats {
+        batched_events: usize,
+        batched_bytes: usize,
+        baseline_events: usize,
+        baseline_bytes: usize,
+        data_points: usize,
+        envelope_bytes: usize,
+    }
+
+    impl Stats {
+        fn byte_ratio(&self) -> f64 {
+            self.baseline_bytes as f64 / self.batched_bytes as f64
+        }
+        fn write_ratio(&self) -> f64 {
+            self.baseline_events as f64 / self.batched_events as f64
+        }
+        /// Share of the unbatched payload that is pure repeated envelope.
+        fn baseline_waste_pct(&self) -> f64 {
+            (self.envelope_bytes * self.baseline_events) as f64 / self.baseline_bytes as f64 * 100.0
+        }
+    }
+
+    /// Measures what the exporter actually wrote, and what the same data would
+    /// have cost under the previous one-event-per-data-point scheme.
+    fn measure(events: &[Vec<u8>]) -> Stats {
+        let mut stats = Stats {
+            batched_events: events.len(),
+            batched_bytes: events.iter().map(|e| e.len()).sum(),
+            baseline_events: 0,
+            baseline_bytes: 0,
+            data_points: 0,
+            envelope_bytes: 0,
+        };
+
+        for raw in events {
+            let request =
+                ExportMetricsServiceRequest::decode(raw.as_slice()).expect("decodes as OTLP");
+            let count = data_point_count(&request);
+            stats.data_points += count;
+            stats.baseline_events += count;
+            for i in 0..count {
+                stats.baseline_bytes += with_data_points(&request, &[i]).encoded_len();
+            }
+            // Envelope = the same event with zero data points. Recorded from the
+            // first event only; it is identical across events of a metric.
+            if stats.envelope_bytes == 0 {
+                stats.envelope_bytes = with_data_points(&request, &[]).encoded_len();
+            }
+        }
+
+        stats
+    }
+
+    fn report(label: &str, stats: &Stats, expected_dps: usize) {
+        assert_eq!(
+            stats.data_points, expected_dps,
+            "{label}: scenario did not produce the expected number of series"
+        );
+        println!(
+            "{label:<44} | {:>7} | {:>6} | {:>10} | {:>10} | {:>5.2}x | {:>5.0}x | {:>5.1}%",
+            stats.data_points,
+            stats.envelope_bytes,
+            stats.baseline_bytes,
+            stats.batched_bytes,
+            stats.byte_ratio(),
+            stats.write_ratio(),
+            stats.baseline_waste_pct(),
+        );
+    }
+
+    fn header() {
+        println!(
+            "\n{:<44} | {:>7} | {:>6} | {:>10} | {:>10} | {:>6} | {:>6} | {:>6}",
+            "scenario", "dps", "envlp", "unbatched", "batched", "bytes", "writes", "waste"
+        );
+        println!("{}", "-".repeat(120));
+    }
+
+    /// Runs `record` against a meter provider wired to a collecting exporter and
+    /// returns the raw events the exporter produced.
+    fn run_scenario<F>(max_event_size: usize, record: F) -> Vec<Vec<u8>>
+    where
+        F: FnOnce(&opentelemetry::metrics::Meter),
+    {
+        let writer = CollectingWriter::default();
+        let exporter = MetricsExporter::for_test(writer.clone(), max_event_size);
+        let reader = PeriodicReader::builder(exporter).build();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes([
+                        KeyValue::new("service.name", "contoso-ingest"),
+                        KeyValue::new(
+                            "service.instance.id",
+                            "9f1c2b7e-4a3d-4c11-9b02-7e5f8a1d3c44",
+                        ),
+                        KeyValue::new("cloud.region", "eastus2"),
+                        KeyValue::new("host.name", "node-prod-0731"),
+                    ])
+                    .build(),
+            )
+            .build();
+
+        record(&provider.meter("contoso.ingest.meter"));
+        // Flush may legitimately report failure when a scenario deliberately
+        // configures a size limit that some data point cannot satisfy; callers
+        // assert on the emitted events instead.
+        let _ = provider.force_flush();
+        // Collect before shutdown: shutdown performs another collection, which
+        // would invoke observable callbacks a second time and double-count.
+        let events = writer.take();
+        let _ = provider.shutdown();
+        events
+    }
+
+    /// Attribute sets for `count` dimensions. The high-cardinality `partition`
+    /// key comes first so that every dimension count still yields distinct
+    /// series.
+    fn dims(i: usize, count: usize) -> Vec<KeyValue> {
+        let all = [
+            KeyValue::new("partition", format!("p{i:04}")),
+            KeyValue::new("operation", "GetBlobProperties"),
+            KeyValue::new("status_code", "200"),
+            KeyValue::new("client_version", "2024-11-04"),
+            KeyValue::new("protocol", "https"),
+        ];
+        all.into_iter().take(count).collect()
+    }
+
+    const SERIES: usize = 1000;
+
+    #[test]
+    fn batching_savings_report() {
+        header();
+
+        // Counter, 5 dimensions.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(1, &dims(i, 5));
+            }
+        });
+        let stats = measure(&events);
+        report("counter, 5 dims", &stats, SERIES);
+
+        // Counter, 2 dimensions: smaller payload against the same envelope, so
+        // the relative waste is worse.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(1, &dims(i, 2));
+            }
+        });
+        let stats = measure(&events);
+        report("counter, 2 dims", &stats, SERIES);
+
+        // Observable gauge.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            meter
+                .u64_observable_gauge("contoso.ingest.queue_depth")
+                .with_callback(|obs| {
+                    for i in 0..SERIES {
+                        obs.observe(i as u64, &dims(i, 4));
+                    }
+                })
+                .build();
+        });
+        let stats = measure(&events);
+        report("observable gauge, 4 dims", &stats, SERIES);
+
+        // Histogram: much larger data points (bucket counts + bounds), so the
+        // envelope is proportionally less significant.
+        let events = run_scenario(MAX_EVENT_SIZE, |meter| {
+            let h = meter.f64_histogram("contoso.ingest.latency").build();
+            for i in 0..SERIES {
+                h.record(12.5, &dims(i, 3));
+            }
+        });
+        let stats = measure(&events);
+        report("histogram, 3 dims", &stats, SERIES);
+
+        println!();
+    }
+
+    #[test]
+    fn every_event_is_within_the_size_limit() {
+        for max in [MAX_EVENT_SIZE, 8192, 2048, 512] {
+            let events = run_scenario(max, |meter| {
+                let c = meter.u64_counter("contoso.ingest.requests").build();
+                for i in 0..SERIES {
+                    c.add(1, &dims(i, 5));
+                }
+            });
+            assert!(!events.is_empty(), "max={max} produced no events");
+            for event in &events {
+                assert!(
+                    event.len() <= max,
+                    "event of {} bytes exceeds max_event_size {max}",
+                    event.len()
+                );
+            }
+            let stats = measure(&events);
+            assert_eq!(
+                stats.data_points, SERIES,
+                "max={max} lost or duplicated data points"
+            );
+
+            // Every event except the last must have been flushed because the
+            // next data point genuinely did not fit, not because the size
+            // accounting gave up early.
+            for i in 0..events.len().saturating_sub(1) {
+                let next = ExportMetricsServiceRequest::decode(events[i + 1].as_slice()).unwrap();
+                let next_cost = first_point_cost(&next);
+                let remaining = max - events[i].len();
+                assert!(
+                    remaining < next_cost + SIZE_SLACK,
+                    "event left {remaining} bytes unused but the next data point \
+                     needs only {next_cost} (max={max}); accounting is too conservative"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn batching_preserves_every_data_point_exactly_once() {
+        let events = run_scenario(4096, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(i as u64, &dims(i, 5));
+            }
+        });
+
+        let mut seen: Vec<(String, u64)> = Vec::new();
+        for raw in &events {
+            let request = ExportMetricsServiceRequest::decode(raw.as_slice()).unwrap();
+            let PData::Sum(sum) = request.resource_metrics[0].scope_metrics[0].metrics[0]
+                .data
+                .as_ref()
+                .unwrap()
+            else {
+                panic!("counter should encode as Sum");
+            };
+            for dp in &sum.data_points {
+                let partition = dp
+                    .attributes
+                    .iter()
+                    .find(|kv| kv.key == "partition")
+                    .and_then(|kv| kv.value.as_ref())
+                    .and_then(|v| match v.value.as_ref() {
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                s,
+                            ),
+                        ) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .expect("partition attribute present");
+                let value = match dp.value.as_ref().unwrap() {
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => {
+                        *v as u64
+                    }
+                    _ => panic!("counter should encode as int"),
+                };
+                seen.push((partition, value));
+            }
+        }
+
+        assert_eq!(seen.len(), SERIES, "wrong number of data points");
+        seen.sort();
+        seen.dedup_by(|a, b| a.0 == b.0);
+        assert_eq!(seen.len(), SERIES, "duplicate series across batches");
+        for (partition, value) in &seen {
+            let i: usize = partition.trim_start_matches('p').parse().unwrap();
+            assert_eq!(*value, i as u64, "value mismatch for {partition}");
+        }
+    }
+
+    #[test]
+    fn metric_metadata_is_repeated_in_every_event() {
+        // Each event must be independently decodable: resource, scope and metric
+        // identity are required in all of them, not just the first.
+        let events = run_scenario(2048, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..SERIES {
+                c.add(1, &dims(i, 5));
+            }
+        });
+        assert!(
+            events.len() > 1,
+            "expected the batch to span several events"
+        );
+        for raw in &events {
+            let request = ExportMetricsServiceRequest::decode(raw.as_slice()).unwrap();
+            let rm = &request.resource_metrics[0];
+            assert_eq!(rm.resource.as_ref().unwrap().attributes.len(), 4);
+            let sm = &rm.scope_metrics[0];
+            assert_eq!(sm.scope.as_ref().unwrap().name, "contoso.ingest.meter");
+            assert_eq!(sm.metrics[0].name, "contoso.ingest.requests");
+        }
+    }
+
+    #[test]
+    fn oversized_single_data_point_is_dropped_without_panicking() {
+        // A max_event_size below the envelope size means no data point can ever
+        // fit. The exporter must drop them and stay alive.
+        let events = run_scenario(64, |meter| {
+            let c = meter.u64_counter("contoso.ingest.requests").build();
+            for i in 0..10 {
+                c.add(1, &dims(i, 5));
+            }
+        });
+        assert!(
+            events.is_empty(),
+            "nothing should be written when no data point fits"
+        );
+    }
+
+    #[test]
+    fn varint_len_matches_prost() {
+        for len in [0usize, 1, 127, 128, 16_383, 16_384, 65_360, 2_097_151] {
+            let mut buf = Vec::new();
+            prost::encoding::encode_varint(len as u64, &mut buf);
+            assert_eq!(varint_len(len), buf.len(), "varint_len({len})");
+        }
     }
 }

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -16,14 +16,35 @@ use prost::Message;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
-/// Upper bound on the encoded size of a single tracepoint event.
+/// Maximum number of protobuf payload bytes that may be written in a single
+/// tracepoint event.
 ///
-/// A perf ring buffer record carries its length in a `__u16`, so a record can
-/// never exceed 65535 bytes in total. The payload budget is set slightly below
-/// that to leave room for the perf record header and the tracepoint's own
-/// fields, so a maximally packed event is still guaranteed to be representable
-/// (and therefore readable) by a perf consumer.
-pub(crate) const MAX_EVENT_SIZE: usize = 65360;
+/// A `user_events` tracepoint consumed through perf goes through
+/// `user_event_perf()`, which copies the record into a per-CPU scratch buffer
+/// obtained from `perf_trace_buf_alloc()`. That buffer is `PERF_MAX_TRACE_SIZE`
+/// (8192) bytes. If the record does not fit, `perf_trace_buf_alloc()` returns
+/// NULL and `user_event_perf()` returns without submitting anything, so the
+/// write silently succeeds from userspace while the event never reaches the
+/// consumer.
+///
+/// The size the kernel accounts for is
+/// `ALIGN(sizeof(struct trace_entry) + bytes_written_after_the_write_index, 8)`:
+///
+/// | component                         | bytes |
+/// |-----------------------------------|-------|
+/// | `struct trace_entry`              | 8     |
+/// | `u32 protocol`                    | 4     |
+/// | `char[8] version`                 | 8     |
+/// | `__rel_loc` descriptor for buffer | 4     |
+/// | **fixed overhead**                | 24    |
+///
+/// which leaves `8192 - 24 = 8168` bytes for the payload itself. See
+/// `src/tracepoint/mod.rs` for the field layout this is derived from.
+///
+/// Note that a consumer reading the same tracepoint through ftrace rather than
+/// perf is bounded by the trace ring buffer's per-event limit (roughly one
+/// page) instead, which is smaller still.
+pub(crate) const MAX_EVENT_SIZE: usize = 8168;
 
 /// Safety margin, in bytes, reserved when deciding whether another data point
 /// fits into the current batch.
@@ -489,7 +510,8 @@ impl MetricsExporter {
 
     fn export_resource_metrics(&self, resource_metric: &ResourceMetrics) -> OTelSdkResult {
         // Custom transformation to protobuf structs is used instead of upstream
-        // transforms because the tracepoint has a 64kB size limit. Data points
+        // transforms because a tracepoint event has a hard size limit (see
+        // MAX_EVENT_SIZE). Data points
         // are packed into as few events as possible while respecting that limit,
         // so the resource/scope/metric envelope is amortized across many data
         // points instead of being repeated for every one.

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -45,6 +45,17 @@ mod tests {
         /// pipeline with a self-contained, in-process consumer (no external tools,
         /// no temp files, no `sudo` shell-outs).
         pub fn collect_otlp_metrics<F: FnOnce()>(emit: F) -> Vec<ExportMetricsServiceRequest> {
+            collect_otlp_metrics_with_pages(32, emit)
+        }
+
+        /// Same as [`collect_otlp_metrics`], but with a configurable per-CPU ring
+        /// buffer size. High-cardinality scenarios emit several hundred kilobytes
+        /// in a single export cycle and will silently lose records if the ring
+        /// buffer is left at the default 32 pages (128 KiB).
+        pub fn collect_otlp_metrics_with_pages<F: FnOnce()>(
+            page_count: usize,
+            emit: F,
+        ) -> Vec<ExportMetricsServiceRequest> {
             let need_permission = "Need permission to access tracefs/perf_events (run via sudo?)";
 
             let tracefs = TraceFS::open().expect(need_permission);
@@ -70,7 +81,7 @@ mod tests {
             });
 
             let mut session = RingBufSessionBuilder::new()
-                .with_page_count(32)
+                .with_page_count(page_count)
                 .with_tracepoint_events(RingBufBuilder::for_tracepoint())
                 .with_target_pid(std::process::id() as i32)
                 .build()
@@ -189,6 +200,172 @@ mod tests {
                     actual_attributes
                 })
                 .collect()
+        }
+
+        /// A decoded numeric data point value.
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub enum Num {
+            I(i64),
+            D(f64),
+        }
+
+        /// Renders an OTLP `AnyValue` into a stable string form so tests can
+        /// assert on attribute values of any type without a match arm per type.
+        pub fn render_value(value: &opentelemetry_proto::tonic::common::v1::AnyValue) -> String {
+            use opentelemetry_proto::tonic::common::v1::any_value::Value;
+            match value.value.as_ref() {
+                Some(Value::StringValue(s)) => s.clone(),
+                Some(Value::BoolValue(b)) => b.to_string(),
+                Some(Value::IntValue(i)) => i.to_string(),
+                Some(Value::DoubleValue(d)) => d.to_string(),
+                Some(Value::ArrayValue(a)) => {
+                    let rendered: Vec<String> = a.values.iter().map(render_value).collect();
+                    format!("[{}]", rendered.join(","))
+                }
+                Some(Value::BytesValue(b)) => format!("{b:?}"),
+                Some(Value::KvlistValue(_)) => "<kvlist>".to_string(),
+                Some(other) => format!("{other:?}"),
+                None => "<empty>".to_string(),
+            }
+        }
+
+        /// Extracts a data point's attributes as sorted `(key, rendered value)`
+        /// pairs.
+        pub fn attrs_of(
+            attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+        ) -> Vec<(String, String)> {
+            let mut out: Vec<(String, String)> = attributes
+                .iter()
+                .map(|a| {
+                    let rendered = a.value.as_ref().map(render_value).unwrap_or_default();
+                    (a.key.clone(), rendered)
+                })
+                .collect();
+            out.sort();
+            out
+        }
+
+        /// Returns every occurrence of `name` across all events. A metric appears
+        /// once per event it was batched into, so this legitimately returns more
+        /// than one entry for a high-cardinality metric.
+        pub fn find_metrics<'a>(
+            requests: &'a [ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<&'a opentelemetry_proto::tonic::metrics::v1::Metric> {
+            requests
+                .iter()
+                .flat_map(|r| &r.resource_metrics)
+                .flat_map(|rm| &rm.scope_metrics)
+                .flat_map(|sm| &sm.metrics)
+                .filter(|m| m.name == name)
+                .collect()
+        }
+
+        /// Flattens every `NumberDataPoint` of `name` across all events into
+        /// `(sorted attributes, value)` pairs.
+        pub fn number_points(
+            requests: &[ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<(Vec<(String, String)>, Num)> {
+            use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+            use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
+
+            let mut out = Vec::new();
+            for metric in find_metrics(requests, name) {
+                let points = match metric.data.as_ref().expect("metric data missing") {
+                    Data::Sum(s) => &s.data_points,
+                    Data::Gauge(g) => &g.data_points,
+                    other => panic!("metric {name} is not a Sum or Gauge: {other:?}"),
+                };
+                for dp in points {
+                    let value = match dp.value.as_ref().expect("data point value missing") {
+                        Value::AsInt(i) => Num::I(*i),
+                        Value::AsDouble(d) => Num::D(*d),
+                    };
+                    out.push((attrs_of(&dp.attributes), value));
+                }
+            }
+            out
+        }
+
+        /// Flattens every `HistogramDataPoint` of `name` across all events.
+        pub fn histogram_points(
+            requests: &[ExportMetricsServiceRequest],
+            name: &str,
+        ) -> Vec<(
+            Vec<(String, String)>,
+            opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint,
+        )> {
+            use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+
+            let mut out = Vec::new();
+            for metric in find_metrics(requests, name) {
+                let Data::Histogram(h) = metric.data.as_ref().expect("metric data missing") else {
+                    panic!("metric {name} is not a Histogram");
+                };
+                for dp in &h.data_points {
+                    out.push((attrs_of(&dp.attributes), dp.clone()));
+                }
+            }
+            out
+        }
+
+        /// Asserts that no event exceeds the exporter's per-event size budget.
+        ///
+        /// This is the invariant the whole batching scheme rests on: a perf ring
+        /// buffer record length is a `__u16`, so an event that overshoots would be
+        /// silently unreadable rather than merely large. Because these payloads
+        /// came back out of the kernel, this also proves the bound end to end.
+        pub fn assert_all_events_within_size_limit(requests: &[ExportMetricsServiceRequest]) {
+            for (index, request) in requests.iter().enumerate() {
+                let len = request.encoded_len();
+                assert!(
+                    len <= crate::exporter::MAX_EVENT_SIZE,
+                    "event {} is {} bytes, over the {} byte limit",
+                    index,
+                    len,
+                    crate::exporter::MAX_EVENT_SIZE
+                );
+            }
+        }
+
+        /// Asserts that every event repeats the full resource and scope envelope.
+        ///
+        /// Batching amortizes the envelope across the data points inside one
+        /// event, but each event must remain independently decodable, so the
+        /// envelope must still be present in all of them.
+        pub fn assert_envelope_repeated(
+            requests: &[ExportMetricsServiceRequest],
+            expected_resource_attrs: &[(&str, &str)],
+            expected_scope_name: &str,
+        ) {
+            assert!(!requests.is_empty(), "expected at least one event");
+            for (index, request) in requests.iter().enumerate() {
+                assert_eq!(
+                    request.resource_metrics.len(),
+                    1,
+                    "event {index} should carry exactly one resource_metrics"
+                );
+                let rm = &request.resource_metrics[0];
+                let resource = rm.resource.as_ref().expect("resource missing");
+                let actual = attrs_of(&resource.attributes);
+                for (key, value) in expected_resource_attrs {
+                    assert!(
+                        actual.contains(&((*key).to_string(), (*value).to_string())),
+                        "event {index} is missing resource attribute {key}={value}, got {actual:?}"
+                    );
+                }
+                assert_eq!(
+                    rm.scope_metrics.len(),
+                    1,
+                    "event {index} should carry exactly one scope_metrics"
+                );
+                let scope = rm.scope_metrics[0].scope.as_ref().expect("scope missing");
+                assert_eq!(
+                    scope.name, expected_scope_name,
+                    "event {index} has the wrong scope name"
+                );
+            }
         }
     }
 
@@ -644,5 +821,804 @@ mod tests {
             .collect();
         actual_attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
         assert_eq!(actual_attrs, vec![KeyValue::new("mykey1", "myvalue1")]);
+    }
+
+    /// Builds a provider whose resource carries a few attributes, mirroring a
+    /// realistic (small) Overlake-style resource.
+    fn test_provider() -> SdkMeterProvider {
+        SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![
+                        KeyValue::new("service.name", "metric-demo"),
+                        KeyValue::new("service.namespace", "demo-ns"),
+                        KeyValue::new("host.name", "test-host"),
+                    ])
+                    .build(),
+            )
+            .with_periodic_exporter(MetricsExporter::new())
+            .build()
+    }
+
+    const RESOURCE_ATTRS: &[(&str, &str)] = &[
+        ("service.name", "metric-demo"),
+        ("service.namespace", "demo-ns"),
+        ("host.name", "test-host"),
+    ];
+
+    /// High-cardinality end-to-end batching test.
+    ///
+    /// This is the test that actually proves the batching change against the
+    /// kernel rather than against a mock: 2000 distinct series are exported,
+    /// read back out of the perf ring buffer, and checked for exact
+    /// preservation. It also proves that a maximally packed event survives the
+    /// `__u16` perf record length limit, which is the reason `MAX_EVENT_SIZE`
+    /// exists at all.
+    #[ignore]
+    #[test]
+    fn integration_test_batching_high_cardinality() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 2000;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_high_cardinality").build();
+
+        for i in 0..SERIES {
+            counter.add(
+                1,
+                &[
+                    KeyValue::new("partition", format!("p{i}")),
+                    KeyValue::new("region", "westus2"),
+                    KeyValue::new("cluster", "cluster-a"),
+                ],
+            );
+        }
+
+        // 2000 series is a few hundred KiB; the default 32-page ring buffer
+        // would drop records and make this test flaky.
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+
+        // Batching must collapse many data points into far fewer events. With
+        // ~60 byte data points and a 65360 byte budget this should be a ~1000x
+        // reduction; assert a very loose 10x so the test is about the behaviour,
+        // not about a particular encoding size.
+        assert!(
+            decoded.len() * 10 < SERIES,
+            "expected batching to produce far fewer than {} events, got {}",
+            SERIES,
+            decoded.len()
+        );
+
+        let points = test_utils::number_points(&decoded, "counter_high_cardinality");
+        assert_eq!(
+            points.len(),
+            SERIES,
+            "every data point must be exported exactly once"
+        );
+
+        let mut partitions: Vec<String> = points
+            .iter()
+            .map(|(attrs, value)| {
+                assert_eq!(*value, test_utils::Num::I(1), "unexpected counter value");
+                assert!(
+                    attrs.contains(&("region".to_string(), "westus2".to_string())),
+                    "data point lost its constant attributes: {attrs:?}"
+                );
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing")
+            })
+            .collect();
+        partitions.sort();
+        partitions.dedup();
+        assert_eq!(
+            partitions.len(),
+            SERIES,
+            "data points were duplicated or dropped"
+        );
+    }
+
+    /// Every event except the last must be packed until the next data point no
+    /// longer fits. This guards against a regression that silently flushes early
+    /// and gives back the byte savings.
+    #[ignore]
+    #[test]
+    fn integration_test_batching_packs_events_to_capacity() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use prost::Message;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_packing").build();
+
+        for i in 0..3000 {
+            counter.add(1, &[KeyValue::new("partition", format!("p{i:05}"))]);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        assert!(
+            decoded.len() > 1,
+            "test needs enough data points to fill more than one event, got {} events",
+            decoded.len()
+        );
+        test_utils::assert_all_events_within_size_limit(&decoded);
+
+        // The most expensive data point anywhere in the export. If an event has
+        // at least this much room left over, the batcher could have fitted
+        // another point into it and flushed too early.
+        let point_cost = |dp: &opentelemetry_proto::tonic::metrics::v1::NumberDataPoint| {
+            let len = dp.encoded_len();
+            // field tag (1 byte, field number 1) + length delimiter + payload
+            1 + prost::length_delimiter_len(len) + len
+        };
+        let max_point_cost = decoded
+            .iter()
+            .flat_map(|r| &r.resource_metrics)
+            .flat_map(|rm| &rm.scope_metrics)
+            .flat_map(|sm| &sm.metrics)
+            .map(|m| {
+                let Data::Sum(sum) = m.data.as_ref().expect("metric data missing") else {
+                    panic!("expected Sum data");
+                };
+                sum.data_points.iter().map(point_cost).max().unwrap_or(0)
+            })
+            .max()
+            .expect("no data points were exported");
+
+        // Records from a single export can land in different per-CPU ring
+        // buffers if the exporter thread migrates, so the order they are read
+        // back in is not guaranteed. Assert an order-independent property
+        // instead: only the final (partial) event may be under-filled.
+        let underfilled = decoded
+            .iter()
+            .filter(|request| {
+                crate::exporter::MAX_EVENT_SIZE - request.encoded_len()
+                    >= max_point_cost + crate::exporter::SIZE_SLACK
+            })
+            .count();
+        assert!(
+            underfilled <= 1,
+            "{} of {} events had room for another data point; only the final partial event may be \
+             under-filled (largest data point costs {} bytes)",
+            underfilled,
+            decoded.len(),
+            max_point_cost
+        );
+    }
+
+    /// A single data point too large to ever fit in one event is dropped, and
+    /// crucially the surrounding data points are still exported.
+    #[ignore]
+    #[test]
+    fn integration_test_oversized_data_point_is_dropped_but_others_survive() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_oversized").build();
+
+        counter.add(1, &[KeyValue::new("partition", "small-a")]);
+        // Comfortably larger than MAX_EVENT_SIZE on its own.
+        counter.add(1, &[KeyValue::new("partition", "X".repeat(70_000))]);
+        counter.add(1, &[KeyValue::new("partition", "small-b")]);
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            // The dropped data point surfaces as an export error, which is the
+            // documented behaviour; the test asserts on what was exported.
+            let _ = provider.shutdown();
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+
+        let points = test_utils::number_points(&decoded, "counter_oversized");
+        let partitions: Vec<String> = points
+            .iter()
+            .map(|(attrs, _)| {
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing")
+            })
+            .collect();
+
+        assert!(
+            partitions.iter().any(|p| p == "small-a"),
+            "small data point before the oversized one was lost: {partitions:?}"
+        );
+        assert!(
+            partitions.iter().any(|p| p == "small-b"),
+            "small data point after the oversized one was lost: {partitions:?}"
+        );
+        assert!(
+            !partitions.iter().any(|p| p.len() > 1000),
+            "oversized data point should have been dropped"
+        );
+    }
+
+    /// Batching is per-metric, so three instruments in one export cycle produce
+    /// three independent events, each carrying its own full envelope.
+    #[ignore]
+    #[test]
+    fn integration_test_multiple_metrics_in_one_cycle() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        meter
+            .u64_counter("multi_counter")
+            .build()
+            .add(7, &[KeyValue::new("k", "v")]);
+        meter
+            .u64_gauge("multi_gauge")
+            .build()
+            .record(11, &[KeyValue::new("k", "v")]);
+        meter
+            .f64_histogram("multi_histogram")
+            .build()
+            .record(2.5, &[KeyValue::new("k", "v")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+
+        assert_eq!(
+            decoded.len(),
+            3,
+            "expected one event per metric, got {}",
+            decoded.len()
+        );
+        for request in &decoded {
+            assert_eq!(
+                request.resource_metrics[0].scope_metrics[0].metrics.len(),
+                1,
+                "each event should carry exactly one metric"
+            );
+        }
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "multi_counter"),
+            vec![(
+                vec![("k".to_string(), "v".to_string())],
+                test_utils::Num::I(7)
+            )]
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "multi_gauge"),
+            vec![(
+                vec![("k".to_string(), "v".to_string())],
+                test_utils::Num::I(11)
+            )]
+        );
+        let hist = test_utils::histogram_points(&decoded, "multi_histogram");
+        assert_eq!(hist.len(), 1);
+        assert_eq!(hist[0].1.count, 1);
+        assert_eq!(hist[0].1.sum, Some(2.5));
+    }
+
+    /// Each instrumentation scope must be emitted in its own event with its own
+    /// scope metadata (name, version, schema URL).
+    #[ignore]
+    #[test]
+    fn integration_test_multiple_meters_keep_scope_metadata() {
+        use opentelemetry::InstrumentationScope;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+
+        let meter_a = provider.meter_with_scope(
+            InstrumentationScope::builder("scope.a")
+                .with_version("1.2.3")
+                .with_schema_url("https://example.com/schema/a")
+                .build(),
+        );
+        let meter_b = provider.meter_with_scope(
+            InstrumentationScope::builder("scope.b")
+                .with_version("4.5.6")
+                .build(),
+        );
+
+        meter_a
+            .u64_counter("scoped_counter_a")
+            .build()
+            .add(1, &[KeyValue::new("k", "v")]);
+        meter_b
+            .u64_counter("scoped_counter_b")
+            .build()
+            .add(2, &[KeyValue::new("k", "v")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert_eq!(decoded.len(), 2, "expected one event per scope");
+
+        let mut scopes: Vec<(String, String, String)> = decoded
+            .iter()
+            .map(|r| {
+                let sm = &r.resource_metrics[0].scope_metrics[0];
+                let scope = sm.scope.as_ref().expect("scope missing");
+                (
+                    scope.name.clone(),
+                    scope.version.clone(),
+                    sm.schema_url.clone(),
+                )
+            })
+            .collect();
+        scopes.sort();
+
+        assert_eq!(
+            scopes,
+            vec![
+                (
+                    "scope.a".to_string(),
+                    "1.2.3".to_string(),
+                    "https://example.com/schema/a".to_string()
+                ),
+                ("scope.b".to_string(), "4.5.6".to_string(), String::new()),
+            ]
+        );
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "scoped_counter_a")[0].1,
+            test_utils::Num::I(1)
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "scoped_counter_b")[0].1,
+            test_utils::Num::I(2)
+        );
+    }
+
+    /// Asynchronous instruments go through the same batching path as synchronous
+    /// ones, and must preserve monotonicity and aggregation temporality.
+    #[ignore]
+    #[test]
+    fn integration_test_observable_instruments() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use opentelemetry_proto::tonic::metrics::v1::AggregationTemporality;
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        let _obs_counter = meter
+            .u64_observable_counter("obs_counter")
+            .with_callback(|o| {
+                o.observe(100, &[KeyValue::new("k", "a")]);
+                o.observe(200, &[KeyValue::new("k", "b")]);
+            })
+            .build();
+        let _obs_udc = meter
+            .i64_observable_up_down_counter("obs_updowncounter")
+            .with_callback(|o| o.observe(-5, &[KeyValue::new("k", "a")]))
+            .build();
+        let _obs_gauge = meter
+            .u64_observable_gauge("obs_gauge")
+            .with_callback(|o| o.observe(42, &[KeyValue::new("k", "a")]))
+            .build();
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+
+        let mut counter_points = test_utils::number_points(&decoded, "obs_counter");
+        counter_points.sort_by_key(|(attrs, _)| attrs.clone());
+        assert_eq!(
+            counter_points,
+            vec![
+                (
+                    vec![("k".to_string(), "a".to_string())],
+                    test_utils::Num::I(100)
+                ),
+                (
+                    vec![("k".to_string(), "b".to_string())],
+                    test_utils::Num::I(200)
+                ),
+            ]
+        );
+
+        assert_eq!(
+            test_utils::number_points(&decoded, "obs_updowncounter"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(-5)
+            )]
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "obs_gauge"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(42)
+            )]
+        );
+
+        // Monotonicity and temporality must survive batching.
+        for metric in test_utils::find_metrics(&decoded, "obs_counter") {
+            let Data::Sum(sum) = metric.data.as_ref().unwrap() else {
+                panic!("obs_counter should be a Sum");
+            };
+            assert!(sum.is_monotonic, "observable counter must be monotonic");
+            assert_eq!(
+                sum.aggregation_temporality,
+                AggregationTemporality::Delta as i32,
+                "exporter declares Delta temporality"
+            );
+        }
+        for metric in test_utils::find_metrics(&decoded, "obs_updowncounter") {
+            let Data::Sum(sum) = metric.data.as_ref().unwrap() else {
+                panic!("obs_updowncounter should be a Sum");
+            };
+            assert!(
+                !sum.is_monotonic,
+                "observable updowncounter must be non-monotonic"
+            );
+        }
+        for metric in test_utils::find_metrics(&decoded, "obs_gauge") {
+            assert!(
+                matches!(metric.data.as_ref().unwrap(), Data::Gauge(_)),
+                "obs_gauge should be a Gauge"
+            );
+        }
+    }
+
+    /// Floating point instruments must round-trip as `AsDouble`, not be coerced
+    /// to integers.
+    #[ignore]
+    #[test]
+    fn integration_test_f64_instruments() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+
+        let counter = meter.f64_counter("counter_f64").build();
+        counter.add(1.5, &[KeyValue::new("k", "a")]);
+        counter.add(2.25, &[KeyValue::new("k", "a")]);
+
+        let udc = meter.f64_up_down_counter("updown_f64").build();
+        udc.add(-0.5, &[KeyValue::new("k", "a")]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert_eq!(
+            test_utils::number_points(&decoded, "counter_f64"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::D(3.75)
+            )]
+        );
+        assert_eq!(
+            test_utils::number_points(&decoded, "updown_f64"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::D(-0.5)
+            )]
+        );
+    }
+
+    /// Attribute values of every supported type must survive encoding. The
+    /// batching path re-encodes data points individually, so this guards against
+    /// a type being lost or coerced during that step.
+    #[ignore]
+    #[test]
+    fn integration_test_attribute_value_types() {
+        use opentelemetry::{Array, StringValue, Value};
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_attr_types").build();
+
+        counter.add(
+            1,
+            &[
+                KeyValue::new("str", "text"),
+                KeyValue::new("bool", true),
+                KeyValue::new("int", 42i64),
+                KeyValue::new("double", 1.5f64),
+                KeyValue::new(
+                    "str_array",
+                    Value::Array(Array::String(vec![
+                        StringValue::from("a"),
+                        StringValue::from("b"),
+                    ])),
+                ),
+            ],
+        );
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        let points = test_utils::number_points(&decoded, "counter_attr_types");
+        assert_eq!(points.len(), 1);
+
+        let expected = vec![
+            ("bool".to_string(), "true".to_string()),
+            ("double".to_string(), "1.5".to_string()),
+            ("int".to_string(), "42".to_string()),
+            ("str".to_string(), "text".to_string()),
+            ("str_array".to_string(), "[a,b]".to_string()),
+        ];
+        assert_eq!(points[0].0, expected);
+    }
+
+    /// A data point with no attributes at all must still be exported.
+    #[ignore]
+    #[test]
+    fn integration_test_no_attributes() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        meter.u64_counter("counter_no_attrs").build().add(9, &[]);
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        assert_eq!(
+            test_utils::number_points(&decoded, "counter_no_attrs"),
+            vec![(Vec::new(), test_utils::Num::I(9))]
+        );
+    }
+
+    /// `force_flush` must export the current cycle, and because the exporter
+    /// declares Delta temporality a subsequent cycle must carry only what was
+    /// recorded since the previous export.
+    #[ignore]
+    #[test]
+    fn integration_test_force_flush_across_cycles_is_delta() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let counter = meter.u64_counter("counter_delta").build();
+
+        counter.add(3, &[KeyValue::new("k", "a")]);
+        let first = test_utils::collect_otlp_metrics(|| {
+            provider.force_flush().expect("first force_flush failed");
+        });
+        assert_eq!(
+            test_utils::number_points(&first, "counter_delta"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(3)
+            )]
+        );
+
+        counter.add(4, &[KeyValue::new("k", "a")]);
+        let second = test_utils::collect_otlp_metrics(|| {
+            provider.force_flush().expect("second force_flush failed");
+        });
+        assert_eq!(
+            test_utils::number_points(&second, "counter_delta"),
+            vec![(
+                vec![("k".to_string(), "a".to_string())],
+                test_utils::Num::I(4)
+            )],
+            "Delta temporality means the second cycle reports only the increment"
+        );
+
+        provider.shutdown().expect("shutdown failed");
+    }
+
+    /// An export cycle with nothing recorded must not emit any event.
+    #[ignore]
+    #[test]
+    fn integration_test_no_metrics_emits_no_events() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let provider = test_provider();
+        let _meter = provider.meter("user-event-test");
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        assert!(
+            decoded.is_empty(),
+            "expected no events when nothing was recorded, got {}",
+            decoded.len()
+        );
+    }
+
+    /// Exponential histograms use a different data point type than every other
+    /// instrument, so they exercise a distinct arm of the batching code.
+    #[ignore]
+    #[test]
+    fn integration_test_exponential_histogram() {
+        use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+        use opentelemetry_sdk::metrics::{Aggregation, Instrument, Stream};
+
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        let view = |i: &Instrument| {
+            if i.name() == "exp_histogram" {
+                Some(
+                    Stream::builder()
+                        .with_aggregation(Aggregation::Base2ExponentialHistogram {
+                            max_size: 160,
+                            max_scale: 20,
+                            record_min_max: true,
+                        })
+                        .build()
+                        .unwrap(),
+                )
+            } else {
+                None
+            }
+        };
+
+        let provider = SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![
+                        KeyValue::new("service.name", "metric-demo"),
+                        KeyValue::new("service.namespace", "demo-ns"),
+                        KeyValue::new("host.name", "test-host"),
+                    ])
+                    .build(),
+            )
+            .with_periodic_exporter(MetricsExporter::new())
+            .with_view(view)
+            .build();
+
+        let meter = provider.meter("user-event-test");
+        let hist = meter.f64_histogram("exp_histogram").build();
+        for attr in ["a", "b"] {
+            let attrs = [KeyValue::new("k", attr)];
+            hist.record(1.0, &attrs);
+            hist.record(4.0, &attrs);
+            hist.record(16.0, &attrs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics(|| {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        assert_eq!(
+            decoded.len(),
+            1,
+            "both attribute sets should be packed into one event"
+        );
+
+        let metrics = test_utils::find_metrics(&decoded, "exp_histogram");
+        assert_eq!(metrics.len(), 1);
+        let Data::ExponentialHistogram(exp) = metrics[0].data.as_ref().unwrap() else {
+            panic!("expected ExponentialHistogram data");
+        };
+        assert_eq!(
+            exp.data_points.len(),
+            2,
+            "both attribute sets must be batched into the same event"
+        );
+        for dp in &exp.data_points {
+            assert_eq!(dp.count, 3);
+            assert_eq!(dp.sum, Some(21.0));
+            assert_eq!(dp.min, Some(1.0));
+            assert_eq!(dp.max, Some(16.0));
+        }
+    }
+
+    /// Histogram data points are much larger than number data points, so this
+    /// checks that batching stays correct (and within the size limit) for the
+    /// data point type most likely to overflow an event.
+    #[ignore]
+    #[test]
+    fn integration_test_histogram_batching_many_attribute_sets() {
+        test_utils::check_user_events_available().expect("Kernel does not support user_events.");
+
+        const SERIES: usize = 500;
+
+        let provider = test_provider();
+        let meter = provider.meter("user-event-test");
+        let hist = meter.f64_histogram("histogram_batched").build();
+
+        for i in 0..SERIES {
+            let attrs = [KeyValue::new("partition", format!("p{i:04}"))];
+            hist.record(1.0, &attrs);
+            hist.record(3.0, &attrs);
+        }
+
+        let decoded = test_utils::collect_otlp_metrics_with_pages(1024, || {
+            provider
+                .shutdown()
+                .expect("Failed to shutdown meter provider");
+        });
+
+        test_utils::assert_all_events_within_size_limit(&decoded);
+        test_utils::assert_envelope_repeated(&decoded, RESOURCE_ATTRS, "user-event-test");
+        assert!(
+            decoded.len() > 1,
+            "histogram data points are large enough that 500 series should span several events"
+        );
+
+        let points = test_utils::histogram_points(&decoded, "histogram_batched");
+        assert_eq!(
+            points.len(),
+            SERIES,
+            "every histogram data point must survive"
+        );
+
+        let mut partitions: Vec<String> = points
+            .iter()
+            .map(|(attrs, dp)| {
+                assert_eq!(dp.count, 2);
+                assert_eq!(dp.sum, Some(4.0));
+                assert_eq!(dp.min, Some(1.0));
+                assert_eq!(dp.max, Some(3.0));
+                assert_eq!(
+                    dp.bucket_counts.len(),
+                    dp.explicit_bounds.len() + 1,
+                    "bucket layout must survive batching"
+                );
+                assert_eq!(dp.bucket_counts.iter().sum::<u64>(), dp.count);
+                attrs
+                    .iter()
+                    .find(|(k, _)| k == "partition")
+                    .map(|(_, v)| v.clone())
+                    .expect("partition attribute missing")
+            })
+            .collect();
+        partitions.sort();
+        partitions.dedup();
+        assert_eq!(
+            partitions.len(),
+            SERIES,
+            "histogram data points were duplicated or dropped"
+        );
     }
 }

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -132,61 +132,63 @@ mod tests {
             }
         }
 
-        /// Extract and validate data point from metric data (supports Sum and Gauge types)
-        /// Returns the attributes from the single data point after validation
+        /// Extracts the sorted attribute set of every data point in `metric`,
+        /// validating each value against `expected_value`.
+        ///
+        /// The exporter packs as many data points as fit into one event, so a
+        /// single payload legitimately carries several data points.
         pub fn extract_and_validate_metric_data(
             metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
             expected_value: u64,
             request_index: usize,
-        ) -> Vec<opentelemetry::KeyValue> {
-            if let Some(data) = &metric.data {
-                // Use helper method to extract data points based on metric type
-                let data_points = extract_metric_data(data, request_index);
+        ) -> Vec<Vec<opentelemetry::KeyValue>> {
+            let Some(data) = &metric.data else {
+                panic!("Metric data is missing in request {}", request_index + 1);
+            };
 
-                // Validate exactly one data point
-                assert_eq!(
-                    data_points.len(),
-                    1,
-                    "Request {} should have exactly one data point",
-                    request_index + 1
-                );
+            let data_points = extract_metric_data(data, request_index);
+            assert!(
+                !data_points.is_empty(),
+                "Request {} should carry at least one data point",
+                request_index + 1
+            );
 
-                let data_point = &data_points[0];
-
-                // Validate counter value
-                if let Some(value) = &data_point.value {
-                    match value {
-                        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(int_val) => {
-                            assert_eq!(*int_val as u64, expected_value,
-                                "Counter value should match expected value in request {}", request_index + 1);
+            data_points
+                .iter()
+                .map(|data_point| {
+                    // Validate counter value
+                    if let Some(value) = &data_point.value {
+                        match value {
+                            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(int_val) => {
+                                assert_eq!(*int_val as u64, expected_value,
+                                    "Counter value should match expected value in request {}", request_index + 1);
+                            }
+                            _ => panic!("Expected integer value for u64 counter in request {}", request_index + 1),
                         }
-                        _ => panic!("Expected integer value for u64 counter in request {}", request_index + 1),
                     }
-                }
 
-                // Extract attributes from data point
-                let mut actual_attributes: Vec<opentelemetry::KeyValue> = Vec::new();
-                for attr in &data_point.attributes {
-                    if let Some(value) = &attr.value {
-                        if let Some(string_value) = &value.value {
-                            match string_value {
-                                opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
-                                    actual_attributes.push(opentelemetry::KeyValue::new(attr.key.clone(), s.clone()));
-                                }
-                                _ => {
-                                    panic!("Unsupported attribute value type for key: {} in request {}", attr.key, request_index + 1);
+                    // Extract attributes from data point
+                    let mut actual_attributes: Vec<opentelemetry::KeyValue> = Vec::new();
+                    for attr in &data_point.attributes {
+                        if let Some(value) = &attr.value {
+                            if let Some(string_value) = &value.value {
+                                match string_value {
+                                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
+                                        actual_attributes.push(opentelemetry::KeyValue::new(attr.key.clone(), s.clone()));
+                                    }
+                                    _ => {
+                                        panic!("Unsupported attribute value type for key: {} in request {}", attr.key, request_index + 1);
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                // Sort attributes for consistent comparison
-                actual_attributes.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
-                actual_attributes
-            } else {
-                panic!("Metric data is missing in request {}", request_index + 1);
-            }
+                    // Sort attributes for consistent comparison
+                    actual_attributes.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+                    actual_attributes
+                })
+                .collect()
         }
     }
 
@@ -258,11 +260,12 @@ mod tests {
         let expected_service_name = "metric-demo";
         let expected_meter_name = "user-event-test";
 
-        // STEP 1: Validate upfront that we have exactly 2 entries
+        // STEP 1: Both data points are small and share one metric, so the
+        // exporter must pack them into a single event.
         assert_eq!(
             decoded_metrics.len(),
-            2,
-            "Expected exactly 2 metrics payloads (one per data point)"
+            1,
+            "Expected a single batched payload carrying both data points"
         );
 
         // STEP 2: Do common validation on both entries (resource, scope, metric metadata)
@@ -339,7 +342,7 @@ mod tests {
             }
         }
 
-        // STEP 3: Validate that each entry has exactly one data point and collect attributes
+        // STEP 3: Collect the attribute set of every data point across all events
         let mut actual_attribute_sets = Vec::new();
 
         for (index, metrics_request) in decoded_metrics.iter().enumerate() {
@@ -350,12 +353,13 @@ mod tests {
                     for metric in &scope_metric.metrics {
                         if metric.name == expected_counter_name {
                             // Use helper method to extract and validate metric data
-                            let actual_attributes = test_utils::extract_and_validate_metric_data(
-                                metric,
-                                expected_value,
-                                index,
+                            actual_attribute_sets.extend(
+                                test_utils::extract_and_validate_metric_data(
+                                    metric,
+                                    expected_value,
+                                    index,
+                                ),
                             );
-                            actual_attribute_sets.push(actual_attributes);
                         }
                     }
                 }
@@ -429,8 +433,8 @@ mod tests {
 
         assert_eq!(
             decoded.len(),
-            2,
-            "Expected one event per data point (2 attribute sets)"
+            1,
+            "Expected both attribute sets to be packed into a single event"
         );
 
         let mut values: Vec<(u64, Vec<KeyValue>)> = Vec::new();
@@ -441,25 +445,25 @@ mod tests {
                         assert_eq!(m.name, "gauge_u64_test");
                         let data = m.data.as_ref().expect("metric data missing");
                         let dps = test_utils::extract_metric_data(data, 0);
-                        assert_eq!(dps.len(), 1, "expected 1 data point per event");
-                        let dp = &dps[0];
-                        let value = match dp.value.as_ref().expect("value missing") {
-                            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v as u64,
-                            _ => panic!("expected integer value for u64 gauge"),
-                        };
-                        let mut attrs: Vec<KeyValue> = dp
-                            .attributes
-                            .iter()
-                            .map(|a| {
-                                let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
-                                    Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
-                                    _ => panic!("unexpected attribute value type"),
-                                };
-                                KeyValue::new(a.key.clone(), v)
-                            })
-                            .collect();
-                        attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
-                        values.push((value, attrs));
+                        for dp in dps {
+                            let value = match dp.value.as_ref().expect("value missing") {
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v as u64,
+                                _ => panic!("expected integer value for u64 gauge"),
+                            };
+                            let mut attrs: Vec<KeyValue> = dp
+                                .attributes
+                                .iter()
+                                .map(|a| {
+                                    let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
+                                        _ => panic!("unexpected attribute value type"),
+                                    };
+                                    KeyValue::new(a.key.clone(), v)
+                                })
+                                .collect();
+                            attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+                            values.push((value, attrs));
+                        }
                     }
                 }
             }
@@ -510,7 +514,11 @@ mod tests {
                 .expect("Failed to shutdown meter provider");
         });
 
-        assert_eq!(decoded.len(), 2, "Expected one event per attribute set");
+        assert_eq!(
+            decoded.len(),
+            1,
+            "Expected both attribute sets to be packed into a single event"
+        );
 
         let mut results: Vec<(i64, Vec<KeyValue>, bool)> = Vec::new();
         for req in &decoded {
@@ -524,25 +532,25 @@ mod tests {
                             _ => panic!("expected Sum data for updowncounter"),
                         };
                         assert!(!sum.is_monotonic, "updowncounter sum must be non-monotonic");
-                        assert_eq!(sum.data_points.len(), 1);
-                        let dp = &sum.data_points[0];
-                        let value = match dp.value.as_ref().expect("value missing") {
-                            opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v,
-                            _ => panic!("expected integer value for i64 updowncounter"),
-                        };
-                        let mut attrs: Vec<KeyValue> = dp
-                            .attributes
-                            .iter()
-                            .map(|a| {
-                                let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
-                                    Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
-                                    _ => panic!("unexpected attribute value type"),
-                                };
-                                KeyValue::new(a.key.clone(), v)
-                            })
-                            .collect();
-                        attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
-                        results.push((value, attrs, sum.is_monotonic));
+                        for dp in &sum.data_points {
+                            let value = match dp.value.as_ref().expect("value missing") {
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(v) => *v,
+                                _ => panic!("expected integer value for i64 updowncounter"),
+                            };
+                            let mut attrs: Vec<KeyValue> = dp
+                                .attributes
+                                .iter()
+                                .map(|a| {
+                                    let v = match a.value.as_ref().and_then(|v| v.value.as_ref()) {
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
+                                        _ => panic!("unexpected attribute value type"),
+                                    };
+                                    KeyValue::new(a.key.clone(), v)
+                                })
+                                .collect();
+                            attrs.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+                            results.push((value, attrs, sum.is_monotonic));
+                        }
                     }
                 }
             }

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -101,19 +101,41 @@ mod size_experiment {
         trace_point
     }
 
+    /// Sums the `entries` counter across every per-CPU ring buffer. This counts
+    /// records that the kernel actually committed, independent of whether the
+    /// `trace` text formatter can render them: an event larger than
+    /// `TRACE_SEQ_SIZE` (8192) renders as `[LINE TOO BIG]`, so counting lines in
+    /// `trace` measures the formatter rather than delivery.
+    fn ftrace_entries(root: &Path) -> usize {
+        let mut total = 0;
+        let per_cpu = root.join("per_cpu");
+        let dir = fs::read_dir(&per_cpu).expect("failed to list per_cpu directory");
+        for entry in dir.flatten() {
+            let stats = entry.path().join("stats");
+            let Ok(text) = fs::read_to_string(&stats) else {
+                continue;
+            };
+            for line in text.lines() {
+                if let Some(rest) = line.strip_prefix("entries:") {
+                    total += rest.trim().parse::<usize>().unwrap_or(0);
+                }
+            }
+        }
+        total
+    }
+
     fn report(label: &str, results: &[(usize, usize, usize)]) {
         println!("--- {label} ---");
         println!(
-            "{:>8}  {:>9}  {:>8}  {}",
-            "size", "delivered", "written", ""
+            "{:>8}  {:>9}  {:>8}  verdict",
+            "size", "delivered", "written"
         );
         let mut largest_ok = None;
         let mut smallest_dropped = None;
         for (size, delivered, written) in results {
             let verdict = if *delivered == *written {
-                if largest_ok.is_none_or(|s| s < *size) {
-                    largest_ok = Some(*size);
-                }
+                // PROBE_SIZES is ascending, so the last match is the largest.
+                largest_ok = Some(*size);
                 "ok"
             } else if *delivered == 0 {
                 if smallest_dropped.is_none() {
@@ -256,12 +278,7 @@ mod size_experiment {
                 }
             }
 
-            let trace = fs::read_to_string(&trace_path).expect("failed to read trace buffer");
-            let delivered = trace
-                .lines()
-                .filter(|line| !line.trim_start().starts_with('#'))
-                .filter(|line| line.contains("otlp_metrics"))
-                .count();
+            let delivered = ftrace_entries(&root);
             results.push((size, delivered, written));
         }
 

--- a/opentelemetry-user-events-metrics/src/lib.rs
+++ b/opentelemetry-user-events-metrics/src/lib.rs
@@ -3,6 +3,273 @@ mod tracepoint;
 
 pub use exporter::MetricsExporter;
 
+/// Empirical measurement of the maximum `user_events` event size that is
+/// actually delivered to a consumer, for both the perf and ftrace paths.
+///
+/// This module is an experiment, not a regression test. It exists to answer a
+/// specific question: the `eventheader` crate documents that "the system will
+/// ignore any event that is larger than 64KB", but `user_event_perf()` in the
+/// kernel stages records through `perf_trace_buf_alloc()`, which refuses
+/// anything above `PERF_MAX_TRACE_SIZE` (8192). Those two claims imply very
+/// different budgets for a batching exporter, so this measures the boundary
+/// directly instead of arguing from source.
+///
+/// Run with:
+///   sudo -E cargo test --lib size_experiment -- --ignored --nocapture --test-threads=1
+#[cfg(all(test, target_os = "linux"))]
+mod size_experiment {
+    use eventheader::_internal as ehi;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    /// Payload sizes to probe, in bytes. Chosen to bracket both candidate
+    /// bounds: the ftrace sub-buffer (~4 KiB), `PERF_MAX_TRACE_SIZE` (8192),
+    /// and the 64 KiB perf record / ABI ceiling.
+    const PROBE_SIZES: &[usize] = &[
+        512, 1024, 2048, 3072, 4000, 4048, 4072, 4096, 5120, 6144, 8000, 8144, 8168, 8176, 8192,
+        8208, 10240, 12288, 16384, 24576, 32768, 49152, 60000, 65000, 65360, 65500,
+    ];
+
+    /// Number of times each size is written, so a single transient drop is not
+    /// mistaken for a hard limit.
+    const REPEATS: usize = 3;
+
+    fn tracefs_root() -> PathBuf {
+        for candidate in ["/sys/kernel/tracing", "/sys/kernel/debug/tracing"] {
+            if Path::new(candidate).join("events").is_dir() {
+                return PathBuf::from(candidate);
+            }
+        }
+        panic!("tracefs is not mounted; run as root on a kernel with tracefs available");
+    }
+
+    /// Builds a payload of `size` bytes whose first 8 bytes encode `size`, so a
+    /// received event can be attributed back to the probe that produced it.
+    fn payload(size: usize) -> Vec<u8> {
+        let mut buffer = vec![0xABu8; size];
+        let tag = (size as u64).to_le_bytes();
+        let n = tag.len().min(size);
+        buffer[..n].copy_from_slice(&tag[..n]);
+        buffer
+    }
+
+    fn print_environment(root: &Path) {
+        println!("--- environment ---");
+        println!("page_size: {}", unsafe {
+            libc_sysconf_page_size().unwrap_or(0)
+        });
+        for file in ["buffer_subbuf_size_kb", "buffer_size_kb"] {
+            let path = root.join(file);
+            match fs::read_to_string(&path) {
+                Ok(v) => println!("{file}: {}", v.trim()),
+                Err(e) => println!("{file}: <unavailable: {e}>"),
+            }
+        }
+        match fs::read_to_string("/proc/sys/kernel/perf_event_paranoid") {
+            Ok(v) => println!("perf_event_paranoid: {}", v.trim()),
+            Err(e) => println!("perf_event_paranoid: <unavailable: {e}>"),
+        }
+        if let Ok(v) = fs::read_to_string("/proc/version") {
+            println!("kernel: {}", v.trim());
+        }
+    }
+
+    /// `sysconf(_SC_PAGESIZE)` without pulling in a new dependency.
+    unsafe fn libc_sysconf_page_size() -> Option<i64> {
+        unsafe extern "C" {
+            fn sysconf(name: i32) -> i64;
+        }
+        // _SC_PAGESIZE is 30 on Linux.
+        let value = unsafe { sysconf(30) };
+        if value > 0 {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Registers the `otlp_metrics` tracepoint and returns it. Registration is
+    /// what makes the event visible in tracefs, which both probes depend on.
+    fn register_tracepoint() -> std::pin::Pin<Box<ehi::TracepointState>> {
+        let trace_point = Box::pin(ehi::TracepointState::new(0));
+        // Safety: the tracepoint lives for the rest of the test process and is
+        // unregistered when dropped.
+        unsafe {
+            let result = crate::tracepoint::register(trace_point.as_ref());
+            assert_eq!(result, 0, "failed to register otlp_metrics tracepoint");
+        }
+        trace_point
+    }
+
+    fn report(label: &str, results: &[(usize, usize, usize)]) {
+        println!("--- {label} ---");
+        println!(
+            "{:>8}  {:>9}  {:>8}  {}",
+            "size", "delivered", "written", ""
+        );
+        let mut largest_ok = None;
+        let mut smallest_dropped = None;
+        for (size, delivered, written) in results {
+            let verdict = if *delivered == *written {
+                if largest_ok.is_none_or(|s| s < *size) {
+                    largest_ok = Some(*size);
+                }
+                "ok"
+            } else if *delivered == 0 {
+                if smallest_dropped.is_none() {
+                    smallest_dropped = Some(*size);
+                }
+                "DROPPED"
+            } else {
+                "PARTIAL"
+            };
+            println!("{size:>8}  {delivered:>9}  {written:>8}  {verdict}");
+        }
+        println!(
+            "{label}: largest fully delivered = {:?}, smallest fully dropped = {:?}",
+            largest_ok, smallest_dropped
+        );
+    }
+
+    /// Probes the perf delivery path using a one_collect perf ring buffer
+    /// session, which is how this crate's integration tests (and, as far as we
+    /// know, production consumers built on one_collect) read the tracepoint.
+    #[ignore]
+    #[test]
+    fn size_experiment_perf() {
+        use one_collect::perf_event::{RingBufBuilder, RingBufSessionBuilder};
+        use one_collect::tracefs::TraceFS;
+        use one_collect::Writable;
+
+        let root = tracefs_root();
+        print_environment(&root);
+
+        let trace_point = register_tracepoint();
+
+        let tracefs = TraceFS::open().expect("need root to open tracefs");
+        let mut event = tracefs
+            .find_event("user_events", "otlp_metrics")
+            .expect("otlp_metrics tracepoint not found after registration");
+        let buffer_ref = event.format().get_field_ref_unchecked("buffer");
+
+        let received = Writable::<Vec<usize>>::new(Vec::new());
+        let sink = received.clone();
+        event.add_callback(move |data| {
+            let buffer = data.format().get_data(buffer_ref, data.event_data());
+            // First 8 bytes carry the size the producer intended to write.
+            if buffer.len() >= 8 {
+                let mut tag = [0u8; 8];
+                tag.copy_from_slice(&buffer[..8]);
+                sink.write(|out| out.push(u64::from_le_bytes(tag) as usize));
+            }
+            Ok(())
+        });
+
+        // 8 MiB per CPU, far larger than the ~1 MiB this test writes, so ring
+        // buffer capacity cannot be confused for a per-event limit.
+        let mut session = RingBufSessionBuilder::new()
+            .with_page_count(2048)
+            .with_tracepoint_events(RingBufBuilder::for_tracepoint())
+            .with_target_pid(std::process::id() as i32)
+            .build()
+            .expect("need root to create a perf session");
+        session.add_event(event).expect("failed to add event");
+        session.enable().expect("failed to enable perf session");
+
+        assert!(
+            trace_point.enabled(),
+            "tracepoint should be enabled once the perf session is attached"
+        );
+
+        let mut write_codes = Vec::new();
+        for &size in PROBE_SIZES {
+            let buffer = payload(size);
+            for _ in 0..REPEATS {
+                let code = crate::tracepoint::write(&trace_point, &buffer);
+                write_codes.push((size, code));
+            }
+        }
+
+        session.disable().expect("failed to disable perf session");
+        session
+            .parse_all()
+            .expect("failed to drain perf ring buffer");
+
+        let mut delivered = Vec::new();
+        received.read(|v| delivered = v.clone());
+
+        println!("--- userspace write() return codes (0 == success) ---");
+        for (size, code) in &write_codes {
+            if *code != 0 {
+                println!("size {size}: write returned {code}");
+            }
+        }
+        println!("(only non-zero codes shown)");
+
+        let results: Vec<(usize, usize, usize)> = PROBE_SIZES
+            .iter()
+            .map(|&size| {
+                let count = delivered.iter().filter(|&&s| s == size).count();
+                (size, count, REPEATS)
+            })
+            .collect();
+        report("perf", &results);
+    }
+
+    /// Probes the ftrace delivery path by enabling the event through tracefs
+    /// and reading back the textual trace buffer. This is the path a consumer
+    /// that does not use perf would be on, and it is bounded by the ring buffer
+    /// sub-buffer size rather than by `PERF_MAX_TRACE_SIZE`.
+    #[ignore]
+    #[test]
+    fn size_experiment_ftrace() {
+        let root = tracefs_root();
+        print_environment(&root);
+
+        let trace_point = register_tracepoint();
+
+        let enable_path = root.join("events/user_events/otlp_metrics/enable");
+        fs::write(&enable_path, "1").unwrap_or_else(|e| {
+            panic!("failed to enable {}: {e}", enable_path.display());
+        });
+        fs::write(root.join("tracing_on"), "1").expect("failed to set tracing_on");
+
+        assert!(
+            trace_point.enabled(),
+            "tracepoint should be enabled once the ftrace event is enabled"
+        );
+
+        let trace_path = root.join("trace");
+        let mut results = Vec::new();
+        for &size in PROBE_SIZES {
+            let buffer = payload(size);
+            // Truncate the trace buffer so each probe is measured in isolation.
+            fs::write(&trace_path, "").expect("failed to clear trace buffer");
+
+            let mut written = 0;
+            for _ in 0..REPEATS {
+                let code = crate::tracepoint::write(&trace_point, &buffer);
+                if code == 0 {
+                    written += 1;
+                } else {
+                    println!("size {size}: write returned {code}");
+                }
+            }
+
+            let trace = fs::read_to_string(&trace_path).expect("failed to read trace buffer");
+            let delivered = trace
+                .lines()
+                .filter(|line| !line.trim_start().starts_with('#'))
+                .filter(|line| line.contains("otlp_metrics"))
+                .count();
+            results.push((size, delivered, written));
+        }
+
+        let _ = fs::write(&enable_path, "0");
+        report("ftrace", &results);
+    }
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use crate::MetricsExporter;


### PR DESCRIPTION
**Do not merge.** This is a measurement harness, opened as a discussion artifact for the question of what the real maximum `user_events` event size is on Linux.

## Why

`opentelemetry-user-events-metrics` currently writes one tracepoint event per metric data point, repeating the full resource/scope/metric envelope every time. #780 batches data points into a single write, which requires knowing how large an event may be.

Two sources disagree. The `eventheader` crate documents "The system will ignore any event that is larger than 64KB" and "the event will not be delivered to any sessions". But `user_event_perf()` in `kernel/trace/trace_events_user.c` stages records through `perf_trace_buf_alloc()`, which refuses anything above `PERF_MAX_TRACE_SIZE` (8192). Rather than argue from source, this branch measures the boundary directly on both delivery paths, for both the metrics and logs tracepoint encodings.

## Method

The probes register a tracepoint, write payloads at sizes bracketing every candidate bound, and count what a consumer actually receives. Each size is written three times so a single transient drop is not mistaken for a hard limit, and the userspace `write()` return code is recorded per size.

The perf probe attaches a `one_collect` ring-buffer session with 2048 pages (8 MiB per CPU), so buffer capacity can never be confused for a per-event limit.

The ftrace probe runs with no perf session attached and counts committed records via the `entries` counter in `per_cpu/*/stats`. Counting lines in the `trace` file does **not** work: `TRACE_SEQ_SIZE` is 8192 and a `u8[]` payload renders as roughly three characters per byte, so any event over ~2.7 KB renders as `[LINE TOO BIG]`. An earlier revision of this branch made that mistake and measured the text formatter instead of delivery.

`dmesg` is cleared before each probe, because `perf_trace_buf_alloc()` reports via `WARN_ONCE`, which fires at most once per boot per call site.

## Results

Largest fully delivered payload, in bytes:

| kernel | arch | metrics perf | metrics ftrace | logs perf | logs ftrace |
| --- | --- | --- | --- | --- | --- |
| 6.8.0-1064-azure | x86_64 | 8168 | 4048 | 8136 | 4016 |
| 6.17.0-1022-azure | x86_64 | 8168 | 4048 | 8136 | 4016 |
| 6.17.0-1022-azure | aarch64 | 8168 | 4048 | 8136 | 4016 |

`write()` returned 0 (success) for every size, including every dropped one, on both paths. The loss is silent: userspace gets no indication the event was discarded.

`dmesg` on the first dropped perf probe:

```
perf buffer not large enough, wanted 8200, have 8192
WARNING: CPU: 0 PID: 4813 at kernel/trace/trace_event_perf.c:405 perf_trace_buf_alloc+0xcd/0x110
```

`wanted 8200` is `ALIGN(8176 + 24, 8)`, where 24 is the metrics tracepoint's fixed overhead (`struct trace_entry` 8 + `u32 protocol` 4 + `char[8] version` 8 + `__rel_loc` 4). So the perf payload budget is exactly `8192 - 24 = 8168`. The logs figures are lower by the EventHeader per-record overhead.

### The perf limit is fixed; the ftrace limit is lower

The perf threshold is byte-identical across two kernel versions and two architectures, consistent with `PERF_MAX_TRACE_SIZE` being an unconditional `#define` in `include/linux/trace_events.h` with no Kconfig guard, no sysctl, and no page-size dependence.

I originally attributed the ftrace bound to `rb_subbuf_max_data_size()`, which would make it tunable at runtime via `buffer_subbuf_size_kb`. **That is wrong, and the sweep refutes it:**

| `buffer_subbuf_size_kb` | 4 | 8 | 16 | 32 | 64 |
| --- | --- | --- | --- | --- | --- |
| largest delivered (logs) | 4016 | 4016 | 4016 | 4016 | 4016 |

Completely flat, with the resize confirmed applied (the tracefs read handler derives its value from `ring_buffer_subbuf_order_get`, so it is not merely echoing the write back). The ftrace ceiling is a total event size just under `PAGE_SIZE`, matching the kernel comment in `trace.c` that "the ring buffer currently only allows events less than a page". I have not identified the exact line that enforces it, and I would rather flag that than invent an explanation. No `WARN` is emitted on this path, so there is no dmesg breadcrumb.

## What I take from this

The 64 KB figure appears to be the encoding/ABI limit — `eventheader` and this crate's `__rel_loc` both carry lengths in 16 bits — rather than the delivery limit on the Linux `user_events` transport. It may also be carried over from ETW, where 64 KB genuinely is the delivery bound. A writer library must cap at 64 KB either way, and it cannot enforce the delivery limit, which depends on the attached consumer.

Consequences:

1. `MAX_EVENT_SIZE = 8168` in #780 is exactly right for the perf path, not a conservative guess.
2. But batching is what makes the limit reachable at all. Today each event is one data point of a few hundred bytes, so the ceiling is unreachable. #780 deliberately grows events toward it. If a consumer reads via ftrace, every batched 8 KB event would exceed the ~4 KB ftrace ceiling and be silently discarded, turning partial loss into total loss. That makes the ftrace-safe budget a safety requirement rather than a 3% optimization, and argues for defaulting to ~4048 with an opt-in to raise it.
3. `opentelemetry-user-events-logs` has a live instance of this bug today, with no batching involved: its only size check fires above 64 KB, so log records between roughly 8 KB and 64 KB are reported as exported and silently dropped. Demonstrated through the public OpenTelemetry Logs API in #783.

## Open question for the kernel side

`user_event_perf()` and `user_event_ftrace()` both return early on reserve failure **without setting `*faulted`**, unlike the copy-fault path immediately below them. Is that intentional? For a transient "not enabled" case, reporting success is reasonable; for an event that is structurally too large to ever be delivered, an errno would let every writer library handle this correctly without hardcoding a kernel constant.
