### PR TITLE
chore(geneva): prepare 0.6.0 release

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] - 2026-09-03
 
 ### Added
 - Forwarded `tls-native` (default) and `tls-rustls` feature flags from `geneva-uploader`. Build with `--no-default-features --features tls-rustls` to use the pure-Rust TLS backend (required for FIPS / OpenSSL-free deployments that install a custom `rustls::crypto::CryptoProvider`).

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geneva-uploader-ffi"
 description = "FFI bindings for Geneva uploader"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
+geneva-uploader = { path = "../geneva-uploader", version = "0.6.0", default-features = false }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
 otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0", optional = true }

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] - 2026-09-03
 
 ### Added
 - New `tls-rustls` feature flag enables a pure-Rust TLS backend as an alternative to the default `tls-native` (native-tls / OpenSSL) backend. The two flags are additive (so `--all-features` builds compile cleanly); if both are enabled simultaneously, `tls-rustls` takes precedence at runtime. No built-in crypto provider (e.g. ring) is compiled in; consumers **must** install a `rustls::crypto::CryptoProvider` (e.g. `rustls-symcrypt`) at process start. The uploader returns a clear error if no provider is found.

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geneva-uploader"
 description = "Upload telemetry data to Geneva logs service"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] - 2026-09-03
 
 ### Added
 - Forwarded `tls-native` (default) and `tls-rustls` feature flags from `geneva-uploader`. Build with `--no-default-features --features tls-rustls` to use the pure-Rust TLS backend (required for FIPS / OpenSSL-free deployments that install a custom `rustls::crypto::CryptoProvider`).

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-exporter-geneva"
 description = "OpenTelemetry exporter for Geneva logs and traces"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
-geneva-uploader = { path = "../geneva-uploader", version = "0.5.0", default-features = false }
+geneva-uploader = { path = "../geneva-uploader", version = "0.6.0", default-features = false }
 futures = "0.3"
 otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/README.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/README.md
@@ -23,7 +23,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opentelemetry-exporter-geneva = "0.5.0"
+opentelemetry-exporter-geneva = "0.6.0"
 ```
 
 See `examples/basic.rs` for a logs example and `examples/trace_basic.rs` for

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -36,7 +36,7 @@ opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs" }
 opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
-geneva-uploader = { version = "0.5.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
+geneva-uploader = { version = "0.6.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
 otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0" }
 prost = "0.14"
 


### PR DESCRIPTION
## Changes

- bump `geneva-uploader`, `geneva-uploader-ffi`, and `opentelemetry-exporter-geneva` to 0.6.0
- finalize the 0.6.0 changelog sections with the release date
- update internal `geneva-uploader` version requirements and the exporter README example
- update the stress crate to use `geneva-uploader` 0.6.0

## Validation

- `cargo check -p geneva-uploader -p geneva-uploader-ffi -p opentelemetry-exporter-geneva -p stress --all-targets --all-features`
- `cargo package -p geneva-uploader --allow-dirty`

The dependent exporter and FFI packages should be published after `geneva-uploader` 0.6.0 is available on crates.io.
