### PR TITLE
[DO NOT MERGE] Demonstrate silent data loss for oversized user_events log records

### DIFF
--- a/.github/workflows/user-events-logs-size-limit.yml
+++ b/.github/workflows/user-events-logs-size-limit.yml
@@ -1,0 +1,57 @@
+name: user_events logs size limit
+
+# Demonstration, not a gate. Runs the oversized-log-record test across several
+# runner images so the per-event `user_events` delivery limit can be compared
+# across kernel versions and architectures. Every leg is expected to fail on a
+# kernel that enforces PERF_MAX_TRACE_SIZE; the failure is the finding.
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'opentelemetry-user-events-logs/**'
+      - '.github/workflows/user-events-logs-size-limit.yml'
+
+jobs:
+  size-limit:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      # Every leg must report, so one failing kernel does not hide the others.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            note: x86_64
+          - os: ubuntu-24.04
+            note: x86_64
+          - os: ubuntu-24.04-arm
+            note: aarch64
+    name: size-limit (${{ matrix.os }}, ${{ matrix.note }})
+    steps:
+      - uses: actions/checkout@v5
+      - name: Show kernel configuration
+        run: |
+          uname -a
+          echo -n "page size: "; getconf PAGESIZE
+          sudo mount -t tracefs nodev /sys/kernel/tracing 2>/dev/null || true
+          ls -l /sys/kernel/tracing/user_events_data \
+            || echo "user_events_data missing: kernel lacks CONFIG_USER_EVENTS"
+          for f in buffer_size_kb buffer_subbuf_size_kb; do
+            echo -n "$f: "; sudo cat /sys/kernel/tracing/$f 2>/dev/null || echo "<unavailable>"
+          done
+      - name: Emit oversized log records through the OpenTelemetry Logs API
+        run: |
+          sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
+            --lib --all-features size_limit -- --ignored --nocapture --test-threads=1
+      # perf_trace_buf_alloc() reports the refusal via WARN_ONCE, which names
+      # both the requested and the maximum size.
+      - name: Kernel log
+        if: always()
+        run: sudo dmesg | grep -iE "perf buffer|user_event" || echo "(no relevant kernel messages)"

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -195,20 +195,31 @@ mod size_limit {
 
     /// Emits one log record with a `message` attribute of `size` bytes while a
     /// perf session is attached, and returns how many records the consumer
-    /// actually received.
+    /// actually received along with the length of the last one.
+    ///
+    /// The record length is the total encoded event as the consumer sees it,
+    /// which is what the kernel limit actually applies to. It is always larger
+    /// than `size`: the difference is the EventHeader metadata, the event and
+    /// field names, the severity and timestamp fields, and the resource and
+    /// scope content. That overhead grows with the number of attributes, so a
+    /// body size that fits here will not necessarily fit for a richer record.
     ///
     /// A fresh session per size keeps attribution unambiguous: whatever arrives
     /// during the window belongs to this record.
-    fn emit_and_count(size: usize) -> usize {
+    fn emit_and_count(size: usize) -> (usize, Option<usize>) {
         let tracefs = TraceFS::open().expect("need root to open tracefs");
         let mut tp_event = tracefs
             .find_event("user_events", TRACEPOINT)
             .expect("tracepoint not registered; is the provider built?");
 
-        let count = Writable::<usize>::new(0);
+        let count = Writable::<(usize, Option<usize>)>::new((0, None));
         let sink = count.clone();
-        tp_event.add_callback(move |_data| {
-            sink.write(|c| *c += 1);
+        tp_event.add_callback(move |data| {
+            let len = data.event_data().len();
+            sink.write(|c| {
+                c.0 += 1;
+                c.1 = Some(len);
+            });
             Ok(())
         });
 
@@ -232,7 +243,7 @@ mod size_limit {
         session.disable().expect("failed to disable perf session");
         session.parse_all().expect("failed to drain ring buffer");
 
-        let mut received = 0;
+        let mut received = (0, None);
         count.read(|c| received = *c);
         received
     }
@@ -268,8 +279,8 @@ mod size_limit {
 
         let mut results = Vec::new();
         for &size in BODY_SIZES {
-            let delivered = emit_and_count(size);
-            results.push((size, delivered));
+            let (delivered, record_len) = emit_and_count(size);
+            results.push((size, delivered, record_len));
         }
 
         // Flushing reports success for every record above, including the ones
@@ -277,29 +288,77 @@ mod size_limit {
         let flush = provider.force_flush();
 
         println!("--- log records emitted via the OpenTelemetry Logs API ---");
-        println!("{:>10}  {:>9}  verdict", "body bytes", "delivered");
-        for (size, delivered) in &results {
+        println!(
+            "{:>10}  {:>11}  {:>8}  {:>9}  verdict",
+            "body bytes", "record bytes", "overhead", "delivered"
+        );
+        for (size, delivered, record_len) in &results {
             let verdict = if *delivered > 0 { "ok" } else { "LOST" };
-            println!("{size:>10}  {delivered:>9}  {verdict}");
+            match record_len {
+                Some(len) => println!(
+                    "{size:>10}  {len:>11}  {:>8}  {delivered:>9}  {verdict}",
+                    len - size
+                ),
+                None => println!(
+                    "{size:>10}  {:>11}  {:>8}  {delivered:>9}  {verdict}",
+                    "-", "-"
+                ),
+            }
         }
         println!("force_flush() result: {flush:?}");
 
         let lost: Vec<usize> = results
             .iter()
-            .filter(|(_, delivered)| *delivered == 0)
-            .map(|(size, _)| *size)
+            .filter(|(_, delivered, _)| *delivered == 0)
+            .map(|(size, _, _)| *size)
             .collect();
         println!("silently lost sizes: {lost:?}");
 
-        // Single greppable line, so results from different kernels can be
-        // compared at a glance when people paste them into the discussion.
         let largest_ok = results
             .iter()
-            .filter(|(_, delivered)| *delivered > 0)
-            .map(|(size, _)| *size)
+            .filter(|(_, delivered, _)| *delivered > 0)
+            .map(|(size, _, _)| *size)
             .max();
+
+        // The coarse sweep above only brackets the boundary. Bisect between the
+        // largest delivered and the smallest lost size to find the exact body
+        // size at which delivery stops, and the record length that corresponds
+        // to it. That record length -- not the body size -- is the quantity the
+        // kernel limit applies to, and it is what should be compared against
+        // PERF_MAX_TRACE_SIZE.
+        let mut cutoff: Option<(usize, Option<usize>)> = None;
+        if let (Some(mut lo), Some(hi)) = (largest_ok, lost.first().copied()) {
+            let mut hi = hi;
+            let mut lo_record = None;
+            while hi - lo > 1 {
+                let mid = lo + (hi - lo) / 2;
+                let (delivered, record_len) = emit_and_count(mid);
+                if delivered > 0 {
+                    lo = mid;
+                    lo_record = record_len;
+                } else {
+                    hi = mid;
+                }
+            }
+            if lo_record.is_none() {
+                lo_record = emit_and_count(lo).1;
+            }
+            cutoff = Some((lo, lo_record));
+            match lo_record {
+                Some(len) => println!(
+                    "exact boundary: body {lo} delivered (record {len} bytes, \
+                     {} bytes of non-body content); body {hi} lost",
+                    len - lo
+                ),
+                None => println!("exact boundary: body {lo} delivered; body {hi} lost"),
+            }
+        }
+
+        // Single greppable line, so results from different kernels can be
+        // compared at a glance when people paste them into the discussion.
         println!(
-            "SUMMARY arch={} page_size={} largest_delivered={:?} smallest_lost={:?}",
+            "SUMMARY arch={} page_size={} largest_delivered_body={:?} \
+             largest_delivered_record={:?} smallest_lost_body={:?}",
             std::env::consts::ARCH,
             unsafe {
                 unsafe extern "C" {
@@ -307,7 +366,8 @@ mod size_limit {
                 }
                 sysconf(30)
             },
-            largest_ok,
+            cutoff.map(|(body, _)| body).or(largest_ok),
+            cutoff.and_then(|(_, record)| record),
             lost.first().copied()
         );
 

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -291,6 +291,26 @@ mod size_limit {
             .collect();
         println!("silently lost sizes: {lost:?}");
 
+        // Single greppable line, so results from different kernels can be
+        // compared at a glance when people paste them into the discussion.
+        let largest_ok = results
+            .iter()
+            .filter(|(_, delivered)| *delivered > 0)
+            .map(|(size, _)| *size)
+            .max();
+        println!(
+            "SUMMARY arch={} page_size={} largest_delivered={:?} smallest_lost={:?}",
+            std::env::consts::ARCH,
+            unsafe {
+                unsafe extern "C" {
+                    fn sysconf(name: i32) -> i64;
+                }
+                sysconf(30)
+            },
+            largest_ok,
+            lost.first().copied()
+        );
+
         assert!(
             lost.is_empty(),
             "these log records were reported as successfully exported but never \

--- a/opentelemetry-user-events-logs/src/lib.rs
+++ b/opentelemetry-user-events-logs/src/lib.rs
@@ -138,6 +138,169 @@ pub use logs::ProcessorBuilder;
 #[cfg(feature = "experimental_eventname_callback")]
 pub use logs::EventNameCallback;
 
+/// Demonstrates that a log record larger than the kernel's per-event
+/// `user_events` limit is silently lost: the exporter reports success, no error
+/// surfaces through the OpenTelemetry API, and the record never reaches the
+/// consumer.
+///
+/// This exists to start a discussion and to gather data across kernels, not as
+/// a regression test. Everything here goes through the public OpenTelemetry
+/// Logs API, so it reflects what an application would actually experience.
+///
+/// Background: `user_event_perf()` in the kernel stages records through
+/// `perf_trace_buf_alloc()`, which refuses anything above `PERF_MAX_TRACE_SIZE`
+/// (8192) and returns without setting `*faulted`. The ftrace path fails the same
+/// silent way at a lower, page-sized bound. Because neither sets `*faulted`,
+/// `writev()` reports success, so `EventBuilder::write` returns 0 and the
+/// exporter treats the record as delivered. The exporter's only size check
+/// (`PAYLOAD_SIZE_EXCEEDED_ERROR`) fires above 64 KB, well past the real limit.
+///
+/// Run with:
+///   sudo -E cargo test --lib size_limit -- --ignored --nocapture --test-threads=1
+#[cfg(all(test, target_os = "linux"))]
+mod size_limit {
+    use crate::Processor;
+    use one_collect::perf_event::{RingBufBuilder, RingBufSessionBuilder};
+    use one_collect::tracefs::TraceFS;
+    use one_collect::Writable;
+    use opentelemetry_sdk::logs::{LoggerProviderBuilder, SdkLoggerProvider};
+    use opentelemetry_sdk::Resource;
+    use tracing::error;
+    use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
+
+    const PROVIDER_NAME: &str = "otelsizelimit";
+    /// `tracing::error!` maps to EventHeader level 2, so the registered
+    /// tracepoint is `otelsizelimit_L2K1`.
+    const TRACEPOINT: &str = "otelsizelimit_L2K1";
+
+    /// Sizes of the log record's `message` attribute, in bytes.
+    const BODY_SIZES: &[usize] = &[
+        512, 1024, 2048, 4096, 6144, 7168, 8192, 12288, 16384, 32768, 65536,
+    ];
+
+    fn build_provider() -> SdkLoggerProvider {
+        let processor = Processor::builder(PROVIDER_NAME)
+            .build()
+            .expect("failed to build user_events processor");
+
+        LoggerProviderBuilder::default()
+            .with_resource(
+                Resource::builder()
+                    .with_service_name("size-limit-demo")
+                    .build(),
+            )
+            .with_log_processor(processor)
+            .build()
+    }
+
+    /// Emits one log record with a `message` attribute of `size` bytes while a
+    /// perf session is attached, and returns how many records the consumer
+    /// actually received.
+    ///
+    /// A fresh session per size keeps attribution unambiguous: whatever arrives
+    /// during the window belongs to this record.
+    fn emit_and_count(size: usize) -> usize {
+        let tracefs = TraceFS::open().expect("need root to open tracefs");
+        let mut tp_event = tracefs
+            .find_event("user_events", TRACEPOINT)
+            .expect("tracepoint not registered; is the provider built?");
+
+        let count = Writable::<usize>::new(0);
+        let sink = count.clone();
+        tp_event.add_callback(move |_data| {
+            sink.write(|c| *c += 1);
+            Ok(())
+        });
+
+        // 8 MiB per CPU, so ring buffer capacity is never the constraint.
+        let mut session = RingBufSessionBuilder::new()
+            .with_page_count(2048)
+            .with_tracepoint_events(RingBufBuilder::for_tracepoint())
+            .with_target_pid(std::process::id() as i32)
+            .build()
+            .expect("need root to create a perf session");
+        session.add_event(tp_event).expect("failed to add event");
+        session.enable().expect("failed to enable perf session");
+
+        // The user_events processor writes synchronously on emit, so the write
+        // has already happened by the time this returns.
+        let message = "x".repeat(size);
+        error!(name: "SizeLimitDemo", target: "size-limit-demo", message = %message);
+
+        // The ring buffer is drained only after the session is disabled;
+        // draining a live session blocks.
+        session.disable().expect("failed to disable perf session");
+        session.parse_all().expect("failed to drain ring buffer");
+
+        let mut received = 0;
+        count.read(|c| received = *c);
+        received
+    }
+
+    /// Emits log records of increasing size through the OpenTelemetry Logs API
+    /// and reports which ones actually reached the consumer.
+    ///
+    /// Every emit below reports success. On a kernel that enforces
+    /// `PERF_MAX_TRACE_SIZE`, the larger records are nonetheless discarded, and
+    /// this test fails at the first such size. That failure is the point: it is
+    /// the data loss an application would suffer without any error, log, or
+    /// counter indicating it happened.
+    #[ignore]
+    #[test]
+    fn large_log_records_are_silently_dropped() {
+        if let Ok(version) = std::fs::read_to_string("/proc/version") {
+            println!("kernel: {}", version.trim());
+        }
+        println!("page_size: {}", unsafe {
+            unsafe extern "C" {
+                fn sysconf(name: i32) -> i64;
+            }
+            // _SC_PAGESIZE is 30 on Linux.
+            sysconf(30)
+        });
+
+        let provider = build_provider();
+        let otel_layer =
+            opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&provider)
+                .with_filter(EnvFilter::new("error"));
+        let subscriber = tracing_subscriber::registry().with(otel_layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let mut results = Vec::new();
+        for &size in BODY_SIZES {
+            let delivered = emit_and_count(size);
+            results.push((size, delivered));
+        }
+
+        // Flushing reports success for every record above, including the ones
+        // the kernel discarded.
+        let flush = provider.force_flush();
+
+        println!("--- log records emitted via the OpenTelemetry Logs API ---");
+        println!("{:>10}  {:>9}  verdict", "body bytes", "delivered");
+        for (size, delivered) in &results {
+            let verdict = if *delivered > 0 { "ok" } else { "LOST" };
+            println!("{size:>10}  {delivered:>9}  {verdict}");
+        }
+        println!("force_flush() result: {flush:?}");
+
+        let lost: Vec<usize> = results
+            .iter()
+            .filter(|(_, delivered)| *delivered == 0)
+            .map(|(size, _)| *size)
+            .collect();
+        println!("silently lost sizes: {lost:?}");
+
+        assert!(
+            lost.is_empty(),
+            "these log records were reported as successfully exported but never \
+             reached the consumer: {lost:?}. No error was returned to the caller, \
+             no internal log was emitted, and no dropped-event counter was \
+             incremented on either side."
+        );
+    }
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
 


### PR DESCRIPTION
**Do not merge.** This adds a failing test showing that oversized log records are silently dropped by the user_events logs exporter. CI is expected to fail; the failing test is the demonstration.

A log record emitted through the OpenTelemetry Logs API is reported as exported successfully but never reaches the consumer once it exceeds the kernel's per-event `user_events` limit. `force_flush()` returns `Ok(())`, no error is returned, and no counter is incremented.

| kernel | arch | page size | largest delivered body | smallest lost body |
| --- | --- | --- | --- | --- |
| 6.8.0-1064-azure | x86_64 | 4096 | 7980 | 7981 |
| 6.17.0-1022-azure | x86_64 | 4096 | 7980 | 7981 |
| 6.17.0-1022-azure | aarch64 | 4096 | 7980 | 7981 |

Body sizes here exclude ~212 bytes of per-record encoding overhead (EventHeader metadata, event and field names, severity, timestamps, resource and scope). Records with more attributes have less body budget.

Results from other kernels and distributions are welcome. Requires Linux with `CONFIG_USER_EVENTS` (check `ls /sys/kernel/tracing/user_events_data`) and root:

```bash
gh pr checkout 783
sudo -E $(which cargo) test --manifest-path opentelemetry-user-events-logs/Cargo.toml \
  --lib --all-features size_limit -- --ignored --nocapture --test-threads=1
uname -a; getconf PAGESIZE; sudo dmesg | grep -i "perf buffer"
```
