### PR TITLE
chore(geneva-uploader): bump pdata views and prepare 0.7.0 release

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0] - 2026-09-03
+
+### Changed
+- Update `geneva-uploader`, `otel-arrow-dfe-pdata`, and
+  `otel-arrow-dfe-pdata-views` to 0.7.0, 0.54.1, and 0.54.1 respectively.
+
 ## [0.6.0] - 2026-09-03
 
 ### Added

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geneva-uploader-ffi"
 description = "FFI bindings for Geneva uploader"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
@@ -13,10 +13,10 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-geneva-uploader = { path = "../geneva-uploader", version = "0.6.0", default-features = false }
+geneva-uploader = { path = "../geneva-uploader", version = "0.7.0", default-features = false }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
-otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
-otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0", optional = true }
+otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.54.1" }
+otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.54.1", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 prost = "0.14"
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.0] - 2026-09-03
+
+### Changed
+- Update `otel-arrow-dfe-pdata` and `otel-arrow-dfe-pdata-views` to 0.54.1.
+
 ## [0.6.0] - 2026-09-03
 
 ### Added

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geneva-uploader"
 description = "Upload telemetry data to Geneva logs service"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
@@ -10,7 +10,7 @@ keywords = ["opentelemetry", "geneva", "logs", "uploader"]
 license = "Apache-2.0"
 
 [dependencies]
-otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
+otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.54.1" }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 base64 = "0.23"
 serde = { version = "1.0", features = ["derive"] }
@@ -76,7 +76,7 @@ default = ["tls-native"]
 
 [dev-dependencies]
 geneva-test-server = { path = "../geneva-test-server", features = ["testing"] }
-otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0" }
+otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.54.1" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 rcgen = "0.14"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.0] - 2026-09-03
+
+### Changed
+- Update `geneva-uploader` to 0.7.0 and `otel-arrow-dfe-pdata-views` to 0.54.1.
+
 ## [0.6.0] - 2026-09-03
 
 ### Added

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-exporter-geneva"
 description = "OpenTelemetry exporter for Geneva logs and traces"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
@@ -12,9 +12,9 @@ license = "Apache-2.0"
 [dependencies]
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
-geneva-uploader = { path = "../geneva-uploader", version = "0.6.0", default-features = false }
+geneva-uploader = { path = "../geneva-uploader", version = "0.7.0", default-features = false }
 futures = "0.3"
-otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.53.0" }
+otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.54.1" }
 
 [features]
 # TLS backend selection is forwarded to geneva-uploader. `tls-native` (default)

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/README.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/README.md
@@ -23,7 +23,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opentelemetry-exporter-geneva = "0.6.0"
+opentelemetry-exporter-geneva = "0.7.0"
 ```
 
 See `examples/basic.rs` for a logs example and `examples/trace_basic.rs` for

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -36,8 +36,8 @@ opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs" }
 opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
-geneva-uploader = { version = "0.6.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
-otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.53.0" }
+geneva-uploader = { version = "0.7.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
+otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.54.1" }
 prost = "0.14"
 
 [features]


### PR DESCRIPTION
## Changes

- bump `geneva-uploader`, `geneva-uploader-ffi`, and `opentelemetry-exporter-geneva` to 0.7.0
- update `otel-arrow-dfe-pdata` and `otel-arrow-dfe-pdata-views` to 0.54.1
- update internal Geneva and stress dependency versions
- add 0.7.0 changelog entries and update the exporter README example

The 0.7.0 minor release is required because the pdata view traits cross the public API boundary. This keeps consumers on a single compatible `otel-arrow-dfe-pdata-views` identity.

## Validation

- `cargo check -p geneva-uploader -p geneva-uploader-ffi -p opentelemetry-exporter-geneva -p stress --all-targets --all-features`
- `cargo package -p geneva-uploader --allow-dirty`
- `git diff --check`

No crates should be published or yanked until this PR is merged.
