### PR TITLE
fix: [geneva-uploader] Fix Common Schema related fields

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+- Emit compatible Common Schema metadata for OTLP logs and spans, including `env_ver=4.0`, event-based `env_name`, uppercase `TIMESTAMP`, canonical log severity field casing, and a default Part B log name.
+
 ## [0.7.0] - 2026-09-03
 
 ### Changed
@@ -15,7 +18,6 @@
 - Native multi-moniker routing. `AccountRouting` defines one required default logical account group and optional exact final-event-name overrides. Encoded batches carry their resolved logical group, and uploads resolve that group through the current GCS snapshot to the corresponding primary physical moniker.
 
 ### Fixed
-- Emit AMACA-compatible Common Schema metadata for OTLP logs and spans, including `env_ver=4.0`, event-based `env_name`, uppercase `TIMESTAMP`, canonical log severity field casing, and a default Part B log name.
 - Corrected a misleading startup log message: when `logs.default_event_name` is set without an `event_name_mapping`, `GenevaClient::new` now logs `Configured logs event name routing [default_event_name=...]` instead of `Logs config not initialized; using default values for log events`. The default was always applied correctly; only the log line was wrong. This makes the logs message symmetric with the equivalent spans message.
 - Resolve every GCS logical account group to exactly one primary physical
   moniker instead of inspecting physical moniker names for `diag` or depending

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Native multi-moniker routing. `AccountRouting` defines one required default logical account group and optional exact final-event-name overrides. Encoded batches carry their resolved logical group, and uploads resolve that group through the current GCS snapshot to the corresponding primary physical moniker.
 
 ### Fixed
+- Emit AMACA-compatible Common Schema metadata for OTLP logs and spans, including `env_ver=4.0`, event-based `env_name`, uppercase `TIMESTAMP`, canonical log severity field casing, and a default Part B log name.
 - Corrected a misleading startup log message: when `logs.default_event_name` is set without an `event_name_mapping`, `GenevaClient::new` now logs `Configured logs event name routing [default_event_name=...]` instead of `Logs config not initialized; using default values for log events`. The default was always applied correctly; only the log line was wrong. This makes the logs message symmetric with the equivalent spans message.
 - Resolve every GCS logical account group to exactly one primary physical
   moniker instead of inspecting physical moniker names for `diag` or depending

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [vNext]
+
 ### Fixed
 - Emit compatible Common Schema metadata for OTLP logs and spans, including `env_ver=4.0`, event-based `env_name`, uppercase `TIMESTAMP`, canonical log severity field casing, and a default Part B log name.
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/bench.rs
@@ -21,8 +21,6 @@ mod benchmarks {
 
     fn make_metadata(namespace: &str) -> MetadataFields {
         MetadataFields::new(
-            "BenchmarkEnv".to_string(),
-            "Ver1v0".to_string(),
             "BenchmarkTenant".to_string(),
             "BenchmarkRole".to_string(),
             "BenchmarkRoleInstance".to_string(),

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/client.rs
@@ -426,22 +426,21 @@ impl GenevaClient {
         );
         let config_version = format!("Ver{}v0", config_major_version);
 
-        // Metadata fields that will appear as Bond schema fields in Geneva.
+        // Common Schema metadata is independent of the Geneva transport
+        // environment and GCS configuration version.
         let metadata_fields = MetadataFields::new(
-            environment,
-            config_version.clone(),
             tenant,
             role_name,
             role_instance,
-            namespace,
-            config_version,
+            namespace.clone(),
+            config_version.clone(),
         );
 
         let uploader_config = GenevaUploaderConfig {
-            namespace: metadata_fields.namespace.clone(),
+            namespace,
             source_identity,
-            environment: metadata_fields.env_name.clone(),
-            config_version: metadata_fields.event_version.clone(),
+            environment,
+            config_version,
         };
 
         (
@@ -862,6 +861,17 @@ mod tests {
 
     fn build_client(logs: Option<&str>, spans: Option<&str>) -> GenevaClient {
         GenevaClient::new(build_config(logs, spans)).expect("client should initialize")
+    }
+
+    /// Scenario: Geneva transport uses a GCS environment and configuration version.
+    /// Guarantees: Deriving payload metadata does not alter the uploader routing values.
+    #[test]
+    fn derive_parts_preserves_transport_environment_and_version() {
+        let (uploader, metadata) = GenevaClient::derive_parts(build_config(None, None));
+
+        assert_eq!(uploader.environment, "Test");
+        assert_eq!(uploader.config_version, "Ver2v0");
+        assert_eq!(metadata.metadata_fields.event_version, "Ver2v0");
     }
 
     fn build_span_client(

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -1078,12 +1078,8 @@ impl OtlpEncoder {
             };
 
             // 4. Encode row
-            let row_buffer = self.write_span_row_data(
-                span,
-                &field_info,
-                metadata_fields,
-                table_name,
-            );
+            let row_buffer =
+                self.write_span_row_data(span, &field_info, metadata_fields, table_name);
             let level = 5; // Default level for spans (INFO equivalent)
 
             // 5. Create CentralEventEntry

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -172,6 +172,7 @@ struct LogEncodeContext<'a> {
 struct LogRecordParts<'a> {
     timestamp: u64,
     routing_event_name: Cow<'a, str>,
+    env_name: Option<Cow<'a, str>>,
     name: Option<Cow<'a, str>>,
     severity_number: i32,
     severity_text: Option<Cow<'a, str>>,
@@ -226,6 +227,9 @@ impl<'a> LogRecordParts<'a> {
         if let Some(routing_event_name) = routing_event_name {
             parts.routing_event_name = routing_event_name;
         }
+        if parts.env_name.is_none() {
+            parts.env_name = Some(parts.routing_event_name.clone());
+        }
         if parts.name.is_none() {
             parts.name = Some(parts.routing_event_name.clone());
         }
@@ -259,6 +263,7 @@ impl<'a> LogRecordParts<'a> {
         let mut parts = Self {
             timestamp: record_timestamp(record),
             routing_event_name,
+            env_name: None,
             name,
             severity_number: record.severity_number().unwrap_or(0),
             severity_text,
@@ -302,6 +307,7 @@ impl<'a> LogRecordParts<'a> {
         Self {
             timestamp: record_timestamp(record),
             routing_event_name: Cow::Borrowed(table_name),
+            env_name: None,
             name: None,
             severity_number: record.severity_number().unwrap_or(0),
             severity_text: record
@@ -424,7 +430,6 @@ impl<'a> LogRecordParts<'a> {
 
 struct CommonSchemaParts<'a> {
     parts: LogRecordParts<'a>,
-    part_a_name: Option<Cow<'a, str>>,
     part_b_name: Option<Cow<'a, str>>,
 }
 
@@ -437,7 +442,6 @@ impl<'a> CommonSchemaParts<'a> {
     ) -> Self {
         Self {
             parts: LogRecordParts::common_schema_base(record, role, role_instance, table_name),
-            part_a_name: None,
             part_b_name: None,
         }
     }
@@ -485,7 +489,7 @@ impl<'a> CommonSchemaParts<'a> {
             }
             "PartA.name" => {
                 if let Some(name) = value.and_then(value_as_utf8).filter(|s| !s.is_empty()) {
-                    self.part_a_name = Some(Cow::Owned(name.to_owned()));
+                    self.parts.env_name = Some(Cow::Owned(name.to_owned()));
                 }
             }
             "PartB.name" => {
@@ -584,7 +588,7 @@ impl<'a> CommonSchemaParts<'a> {
     }
 
     fn finish(mut self) -> LogRecordParts<'a> {
-        self.parts.name = self.part_b_name.or(self.part_a_name);
+        self.parts.name = self.part_b_name;
         self.parts
     }
 }
@@ -1232,7 +1236,13 @@ impl OtlpEncoder {
         let formatted_timestamp = Self::format_timestamp(parts.timestamp);
         for field in &parts.fields[..parts.dynamic_fields_start] {
             match field.name.as_ref() {
-                FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, &parts.routing_event_name),
+                FIELD_ENV_NAME => BondWriter::write_string(
+                    &mut buffer,
+                    parts
+                        .env_name
+                        .as_deref()
+                        .unwrap_or(&parts.routing_event_name),
+                ),
                 FIELD_ENV_VER => BondWriter::write_string(&mut buffer, CS_VERSION_4_DISPLAY),
                 FIELD_TENANT => BondWriter::write_string(&mut buffer, &metadata_fields.tenant),
                 FIELD_ROLE => BondWriter::write_string(&mut buffer, &parts.role),
@@ -1929,6 +1939,43 @@ mod tests {
         let parts = LogRecordParts::new(&record, &context);
 
         assert_eq!(parts.routing_event_name, "MappedLog");
+        assert_eq!(parts.env_name.as_deref(), Some("MappedLog"));
+        assert_eq!(parts.name.as_deref(), Some("MappedLog"));
+    }
+
+    /// Scenario: A Common Schema log supplies Part A name but no Part B name.
+    /// Guarantees: Part A controls `env_name` and does not replace the Part B `name` fallback.
+    #[test]
+    fn common_schema_part_a_name_does_not_populate_part_b_name() {
+        use otap_df_pdata::views::otlp::bytes::logs::RawLogRecord;
+        use prost::Message as _;
+
+        let log = LogRecord {
+            attributes: vec![
+                int_attr(KEY_CSVER, CS_VERSION_4),
+                string_attr(KEY_PARTB_TYPENAME, CS_LOG_TYPENAME),
+                string_attr("PartA.name", "ExplicitPartA"),
+            ],
+            ..Default::default()
+        };
+        let bytes = log.encode_to_vec();
+        let record = RawLogRecord::new(&bytes);
+        let metadata = make_metadata("testNamespace");
+        let role = RoleOverrides::default();
+        let scope_routing = LogScopeRouting::Fixed("MappedLog".to_string());
+        let context = LogEncodeContext {
+            metadata_fields: &metadata,
+            routing: LogRoutingContext {
+                table_name: "Log",
+                resource_role: &role,
+                scope_routing: &scope_routing,
+            },
+        };
+
+        let parts = LogRecordParts::new(&record, &context);
+
+        assert_eq!(parts.routing_event_name, "MappedLog");
+        assert_eq!(parts.env_name.as_deref(), Some("ExplicitPartA"));
         assert_eq!(parts.name.as_deref(), Some("MappedLog"));
     }
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -28,20 +28,21 @@ use std::sync::Arc;
 use tracing::{debug, error};
 
 const CS_VERSION_4: i64 = 0x400;
+const CS_VERSION_4_DISPLAY: &str = "4.0";
 const KEY_CSVER: &str = "__csver__";
 const KEY_PARTB_TYPENAME: &str = "PartB._typeName";
 const CS_LOG_TYPENAME: &str = "Log";
 
 const FIELD_ENV_NAME: &str = "env_name";
 const FIELD_ENV_VER: &str = "env_ver";
-const FIELD_TIMESTAMP: &str = "timestamp";
+const FIELD_TIMESTAMP: &str = "TIMESTAMP";
 const FIELD_ENV_TIME: &str = "env_time";
 const FIELD_TRACE_ID: &str = "env_dt_traceId";
 const FIELD_SPAN_ID: &str = "env_dt_spanId";
 const FIELD_TRACE_FLAGS: &str = "env_dt_traceFlags";
 const FIELD_NAME: &str = "name";
-const FIELD_SEVERITY_NUMBER: &str = "SeverityNumber";
-const FIELD_SEVERITY_TEXT: &str = "SeverityText";
+const FIELD_SEVERITY_NUMBER: &str = "severityNumber";
+const FIELD_SEVERITY_TEXT: &str = "severityText";
 const FIELD_BODY: &str = "body";
 
 // Tenant/Role/RoleInstance fields
@@ -224,6 +225,9 @@ impl<'a> LogRecordParts<'a> {
         };
         if let Some(routing_event_name) = routing_event_name {
             parts.routing_event_name = routing_event_name;
+        }
+        if parts.name.is_none() {
+            parts.name = Some(parts.routing_event_name.clone());
         }
 
         parts.finish_fields();
@@ -719,8 +723,6 @@ fn parse_hex_bytes<const N: usize>(value: &str) -> Option<[u8; N]> {
 /// Metadata fields that should appear as Bond schema fields (queryable in Geneva)
 #[derive(Clone, Debug)]
 pub(crate) struct MetadataFields {
-    pub env_name: String,
-    pub env_ver: String,
     pub tenant: String,
     pub role: String,
     pub role_instance: String,
@@ -731,8 +733,6 @@ pub(crate) struct MetadataFields {
 
 impl MetadataFields {
     pub fn new(
-        env_name: String,
-        env_ver: String,
         tenant: String,
         role: String,
         role_instance: String,
@@ -745,8 +745,6 @@ impl MetadataFields {
         );
 
         Self {
-            env_name,
-            env_ver,
             tenant,
             role,
             role_instance,
@@ -1080,7 +1078,12 @@ impl OtlpEncoder {
             };
 
             // 4. Encode row
-            let row_buffer = self.write_span_row_data(span, &field_info, metadata_fields);
+            let row_buffer = self.write_span_row_data(
+                span,
+                &field_info,
+                metadata_fields,
+                table_name,
+            );
             let level = 5; // Default level for spans (INFO equivalent)
 
             // 5. Create CentralEventEntry
@@ -1189,8 +1192,6 @@ impl OtlpEncoder {
             String::new(),
             String::new(),
             String::new(),
-            String::new(),
-            String::new(),
         );
         let role_overrides = RoleOverrides::default();
         let scope_routing = LogScopeRouting::None;
@@ -1235,8 +1236,8 @@ impl OtlpEncoder {
         let formatted_timestamp = Self::format_timestamp(parts.timestamp);
         for field in &parts.fields[..parts.dynamic_fields_start] {
             match field.name.as_ref() {
-                FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, &metadata_fields.env_name),
-                FIELD_ENV_VER => BondWriter::write_string(&mut buffer, &metadata_fields.env_ver),
+                FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, &parts.routing_event_name),
+                FIELD_ENV_VER => BondWriter::write_string(&mut buffer, CS_VERSION_4_DISPLAY),
                 FIELD_TENANT => BondWriter::write_string(&mut buffer, &metadata_fields.tenant),
                 FIELD_ROLE => BondWriter::write_string(&mut buffer, &parts.role),
                 FIELD_ROLE_INSTANCE => BondWriter::write_string(&mut buffer, &parts.role_instance),
@@ -1414,6 +1415,7 @@ impl OtlpEncoder {
         span: &Span,
         fields: &[FieldDef],
         metadata_fields: &MetadataFields,
+        event_name: &str,
     ) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(fields.len() * 50);
 
@@ -1422,8 +1424,8 @@ impl OtlpEncoder {
 
         for field in fields {
             match field.name.as_ref() {
-                FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, &metadata_fields.env_name),
-                FIELD_ENV_VER => BondWriter::write_string(&mut buffer, &metadata_fields.env_ver),
+                FIELD_ENV_NAME => BondWriter::write_string(&mut buffer, event_name),
+                FIELD_ENV_VER => BondWriter::write_string(&mut buffer, CS_VERSION_4_DISPLAY),
                 FIELD_TENANT => BondWriter::write_string(&mut buffer, &metadata_fields.tenant),
                 FIELD_ROLE => BondWriter::write_string(&mut buffer, &metadata_fields.role),
                 FIELD_ROLE_INSTANCE => {
@@ -1624,8 +1626,6 @@ mod tests {
 
     fn make_metadata(namespace: &str) -> MetadataFields {
         MetadataFields::new(
-            "TestEnv".to_string(),
-            "Ver1v0".to_string(),
             "TestTenant".to_string(),
             "TestRole".to_string(),
             "TestRoleInstance".to_string(),
@@ -1842,6 +1842,120 @@ mod tests {
         assert_eq!(lhs.metadata.end_time, rhs.metadata.end_time);
         assert_eq!(lhs.metadata.schema_ids, rhs.metadata.schema_ids);
         assert_eq!(lhs.row_count, rhs.row_count);
+    }
+
+    fn read_bond_string(row: &[u8], offset: &mut usize) -> String {
+        let length = u32::from_le_bytes(
+            row[*offset..*offset + 4]
+                .try_into()
+                .expect("string length should be present"),
+        ) as usize;
+        *offset += 4;
+        let value = std::str::from_utf8(&row[*offset..*offset + length])
+            .expect("encoded string should be UTF-8")
+            .to_owned();
+        *offset += length;
+        value
+    }
+
+    /// Scenario: A canonical OTLP log has no explicit event name.
+    /// Guarantees: The encoded row uses AMACA-compatible Common Schema fields and values.
+    #[test]
+    fn canonical_log_uses_common_schema_contract() {
+        use otap_df_pdata::views::otlp::bytes::logs::RawLogRecord;
+        use prost::Message as _;
+
+        let log = LogRecord {
+            observed_time_unix_nano: 1_700_000_000_000_000_000,
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            ..Default::default()
+        };
+        let bytes = log.encode_to_vec();
+        let record = RawLogRecord::new(&bytes);
+        let metadata = make_metadata("testNamespace");
+        let (fields, dynamic_fields_start) = OtlpEncoder::determine_fields(&record);
+        let field_names: Vec<&str> = fields.iter().map(|field| field.name.as_ref()).collect();
+
+        assert_eq!(
+            field_names,
+            vec![
+                "env_name",
+                "env_ver",
+                "TIMESTAMP",
+                "env_time",
+                "Tenant",
+                "Role",
+                "RoleInstance",
+                "name",
+                "severityNumber",
+                "severityText",
+            ]
+        );
+
+        let row = OtlpEncoder::write_row_data(&record, &fields, dynamic_fields_start, &metadata);
+        let mut offset = 0;
+        assert_eq!(read_bond_string(&row, &mut offset), "Log");
+        assert_eq!(read_bond_string(&row, &mut offset), "4.0");
+        let timestamp = read_bond_string(&row, &mut offset);
+        assert!(!timestamp.is_empty());
+        assert_eq!(read_bond_string(&row, &mut offset), timestamp);
+        assert_eq!(read_bond_string(&row, &mut offset), "TestTenant");
+        assert_eq!(read_bond_string(&row, &mut offset), "TestRole");
+        assert_eq!(read_bond_string(&row, &mut offset), "TestRoleInstance");
+        assert_eq!(read_bond_string(&row, &mut offset), "Log");
+        offset += std::mem::size_of::<i32>();
+        assert_eq!(read_bond_string(&row, &mut offset), "INFO");
+        assert_eq!(offset, row.len());
+    }
+
+    /// Scenario: A canonical OTLP log without an event name is routed to a mapped event.
+    /// Guarantees: Common Schema `env_name` and the default Part B `name` use the final event.
+    #[test]
+    fn routed_canonical_log_defaults_name_to_final_event() {
+        use otap_df_pdata::views::otlp::bytes::logs::RawLogRecord;
+        use prost::Message as _;
+
+        let bytes = LogRecord::default().encode_to_vec();
+        let record = RawLogRecord::new(&bytes);
+        let metadata = make_metadata("testNamespace");
+        let role = RoleOverrides::default();
+        let scope_routing = LogScopeRouting::Fixed("MappedLog".to_string());
+        let context = LogEncodeContext {
+            metadata_fields: &metadata,
+            routing: LogRoutingContext {
+                table_name: "Log",
+                resource_role: &role,
+                scope_routing: &scope_routing,
+                obo_event_map: None,
+            },
+        };
+
+        let parts = LogRecordParts::new(&record, &context);
+
+        assert_eq!(parts.routing_event_name, "MappedLog");
+        assert_eq!(parts.name.as_deref(), Some("MappedLog"));
+    }
+
+    /// Scenario: An OTLP span is encoded for the default Span event.
+    /// Guarantees: Span Part A metadata uses the Common Schema version and event identity.
+    #[test]
+    fn span_uses_common_schema_part_a_values() {
+        let encoder = OtlpEncoder::new();
+        let span = Span {
+            start_time_unix_nano: 1_700_000_000_000_000_000,
+            ..Default::default()
+        };
+        let metadata = make_metadata("testNamespace");
+        let fields = OtlpEncoder::determine_span_fields(&span, "Span", None);
+        let row = encoder.write_span_row_data(&span, &fields, &metadata, "Span");
+        let mut offset = 0;
+
+        assert_eq!(read_bond_string(&row, &mut offset), "Span");
+        assert_eq!(read_bond_string(&row, &mut offset), "4.0");
+        let timestamp = read_bond_string(&row, &mut offset);
+        assert!(!timestamp.is_empty());
+        assert_eq!(read_bond_string(&row, &mut offset), timestamp);
     }
 
     #[test]

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -1865,7 +1865,7 @@ mod tests {
     }
 
     /// Scenario: A canonical OTLP log has no explicit event name.
-    /// Guarantees: The encoded row uses AMACA-compatible Common Schema fields and values.
+    /// Guarantees: The encoded row uses compatible Common Schema fields and values.
     #[test]
     fn canonical_log_uses_common_schema_contract() {
         use otap_df_pdata::views::otlp::bytes::logs::RawLogRecord;

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -1923,7 +1923,6 @@ mod tests {
                 table_name: "Log",
                 resource_role: &role,
                 scope_routing: &scope_routing,
-                obo_event_map: None,
             },
         };
 
@@ -1943,7 +1942,7 @@ mod tests {
             ..Default::default()
         };
         let metadata = make_metadata("testNamespace");
-        let fields = OtlpEncoder::determine_span_fields(&span, "Span", None);
+        let fields = OtlpEncoder::determine_span_fields(&span, "Span");
         let row = encoder.write_span_row_data(&span, &fields, &metadata, "Span");
         let mut offset = 0;
 

--- a/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/src/payload_encoder/otlp_encoder.rs
@@ -227,12 +227,6 @@ impl<'a> LogRecordParts<'a> {
         if let Some(routing_event_name) = routing_event_name {
             parts.routing_event_name = routing_event_name;
         }
-        if parts.env_name.is_none() {
-            parts.env_name = Some(parts.routing_event_name.clone());
-        }
-        if parts.name.is_none() {
-            parts.name = Some(parts.routing_event_name.clone());
-        }
 
         parts.finish_fields();
         parts
@@ -401,9 +395,7 @@ impl<'a> LogRecordParts<'a> {
         if self.trace_flags.is_some() {
             self.push_field(FIELD_TRACE_FLAGS, BondDataType::BT_UINT32);
         }
-        if self.name.is_some() {
-            self.push_field(FIELD_NAME, BondDataType::BT_STRING);
-        }
+        self.push_field(FIELD_NAME, BondDataType::BT_STRING);
         self.push_field(FIELD_SEVERITY_NUMBER, BondDataType::BT_INT32);
         if self.severity_text.is_some() {
             self.push_field(FIELD_SEVERITY_TEXT, BondDataType::BT_STRING);
@@ -731,8 +723,9 @@ pub(crate) struct MetadataFields {
     pub role: String,
     pub role_instance: String,
     pub namespace: String,
-    pub event_version: String, // TODO - do we need both env_ver and event_version?
-    metadata_string: String,   // preformatted metadata string for central blob
+    // GCS transport event version; distinct from the Common Schema `env_ver`.
+    pub event_version: String,
+    metadata_string: String, // preformatted metadata string for central blob
 }
 
 impl MetadataFields {
@@ -1270,7 +1263,10 @@ impl OtlpEncoder {
                     BondWriter::write_numeric(&mut buffer, parts.trace_flags.unwrap_or(0));
                 }
                 FIELD_NAME => {
-                    BondWriter::write_string(&mut buffer, parts.name.as_deref().unwrap_or(""));
+                    BondWriter::write_string(
+                        &mut buffer,
+                        parts.name.as_deref().unwrap_or(&parts.routing_event_name),
+                    );
                 }
                 FIELD_SEVERITY_NUMBER => {
                     BondWriter::write_numeric(&mut buffer, parts.severity_number);
@@ -1939,8 +1935,16 @@ mod tests {
         let parts = LogRecordParts::new(&record, &context);
 
         assert_eq!(parts.routing_event_name, "MappedLog");
-        assert_eq!(parts.env_name.as_deref(), Some("MappedLog"));
-        assert_eq!(parts.name.as_deref(), Some("MappedLog"));
+        assert_eq!(parts.env_name, None);
+        assert_eq!(parts.name, None);
+
+        let row = OtlpEncoder::write_row_parts(&parts, &metadata);
+        let mut offset = 0;
+        assert_eq!(read_bond_string(&row, &mut offset), "MappedLog");
+        for _ in 0..6 {
+            read_bond_string(&row, &mut offset);
+        }
+        assert_eq!(read_bond_string(&row, &mut offset), "MappedLog");
     }
 
     /// Scenario: A Common Schema log supplies Part A name but no Part B name.
@@ -1976,7 +1980,15 @@ mod tests {
 
         assert_eq!(parts.routing_event_name, "MappedLog");
         assert_eq!(parts.env_name.as_deref(), Some("ExplicitPartA"));
-        assert_eq!(parts.name.as_deref(), Some("MappedLog"));
+        assert_eq!(parts.name, None);
+
+        let row = OtlpEncoder::write_row_parts(&parts, &metadata);
+        let mut offset = 0;
+        assert_eq!(read_bond_string(&row, &mut offset), "ExplicitPartA");
+        for _ in 0..6 {
+            read_bond_string(&row, &mut offset);
+        }
+        assert_eq!(read_bond_string(&row, &mut offset), "MappedLog");
     }
 
     /// Scenario: An OTLP span is encoded for the default Span event.

--- a/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
+++ b/opentelemetry-exporter-geneva/geneva-uploader/tests/geneva_test_server_integration.rs
@@ -73,6 +73,10 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     let payload = &records[0]["payload"];
     assert_eq!(payload["Role"], "checkout");
     assert_eq!(payload["RoleInstance"], "instance-1");
+    assert_eq!(payload["env_name"], "Log");
+    assert_eq!(payload["env_ver"], "4.0");
+    assert_eq!(payload["TIMESTAMP"], payload["env_time"]);
+    assert_eq!(payload["name"], "CheckoutEvent");
     assert_eq!(payload["body"], "checkout failed");
     assert_eq!(payload["operation"], "checkout");
     assert_eq!(payload["result"], 127);
@@ -127,9 +131,13 @@ async fn uploader_batch_is_accepted_and_decoded_by_test_server() {
     let payload = &records[0]["payload"];
     assert_eq!(payload["Role"], "checkout");
     assert_eq!(payload["RoleInstance"], "instance-1");
+    assert_eq!(payload["env_name"], "Log");
+    assert_eq!(payload["env_ver"], "4.0");
+    assert_eq!(payload["TIMESTAMP"], payload["env_time"]);
+    assert_eq!(payload["name"], "CommonSchemaCheckoutEvent");
     assert_eq!(payload["body"], "common schema checkout failed");
-    assert_eq!(payload["SeverityNumber"], 17);
-    assert_eq!(payload["SeverityText"], "ERROR");
+    assert_eq!(payload["severityNumber"], 17);
+    assert_eq!(payload["severityText"], "ERROR");
     assert_eq!(payload["operation"], "checkout");
     assert_eq!(payload["result"], 127);
 }


### PR DESCRIPTION
## Summary

Correct the Geneva uploader's OTLP log and span encoding to produce compatible Common Schema fields and values.

| Field | Expected | Observed |
|---|---|---|
| `env_name` | `Log` | `DiagnosticsProd` |
| `env_ver` | `4.0` | `Ver1v0` |
| `TIMESTAMP` | Current event time | Missing/default year 1 |
| `name` | `Log` | Missing when OTLP `event_name` was absent |
| Severity fields | `severityNumber`, `severityText` | `SeverityNumber`, `SeverityText` |


The underlying issue was that Geneva transport configuration was reused as Common Schema payload metadata. `DiagnosticsProd` and `Ver1v0` identify the GCS transport environment and event configuration version; they are not the
Common Schema `env_name` and `env_ver` values.

## Changes

- Keep Geneva transport metadata separate from Common Schema payload metadata.
- Preserve `DiagnosticsProd` and `Ver1v0` for GCS routing and upload metadata.
- Emit Common Schema version `4.0` as `env_ver`.
- Populate `env_name` from explicit `PartA.name` when present, otherwise from
  the final outgoing Geneva event/table name.
- Emit uppercase `TIMESTAMP` and give it the same event time as `env_time`.
- Emit canonical `severityNumber` and `severityText` field names.
- Populate Part B `name` from:
  1. explicit `PartB.name` for Common Schema records;
  2. OTLP `event_name` for canonical OTLP records;
  3. the final routed event/table name when no explicit name is supplied.
- Apply equivalent Part A metadata corrections to spans.
- Update the decoded-payload integration assertions and add regression coverage
  for canonical logs, routed logs, and spans.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
