### PR TITLE
fix(tower): emit the missing HTTP server span attributes

### DIFF
--- a/.github/workflows/weaver-live-check-tower.yml
+++ b/.github/workflows/weaver-live-check-tower.yml
@@ -103,6 +103,17 @@ jobs:
           echo "::group::Drive traffic"
           c "http://127.0.0.1:5000/"
           c "http://127.0.0.1:5000/users/1"
+          # A query component makes `url.query` applicable.
+          c "http://127.0.0.1:5000/users/1?fields=name&verbose=true"
+          # The forwarding headers make the request look like it came through a
+          # reverse proxy, so `client.address`, `server.address` and
+          # `url.scheme` describe the original client request.
+          c -H 'Forwarded: for=203.0.113.7;host=public.example.com:8443;proto=https' \
+            "http://127.0.0.1:5000/users/2"
+          c -H 'X-Forwarded-For: 203.0.113.8' \
+            -H 'X-Forwarded-Host: public.example.com' \
+            -H 'X-Forwarded-Proto: https' \
+            "http://127.0.0.1:5000/users/3?fields=name"
           c "http://127.0.0.1:5000/files/a/b/c/1.txt"
           c -X POST   "http://127.0.0.1:5000/items"
           c -X PUT    "http://127.0.0.1:5000/items/1"

--- a/opentelemetry-instrumentation-tower/CHANGELOG.md
+++ b/opentelemetry-instrumentation-tower/CHANGELOG.md
@@ -13,6 +13,22 @@
 * The instrumentation scope now carries the OpenTelemetry semantic conventions
   schema URL.
   [#679](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/679)
+* The server span now carries the HTTP server span attributes that it missed:
+  `url.query`, `network.protocol.version`, `client.address`, `server.address`,
+  `server.port`, `network.peer.address`, `network.peer.port`, and `error.type`.
+  The middleware reads the attributes of the original client request from the
+  `Forwarded` header, then from the `X-Forwarded-For`, `X-Forwarded-Host`, and
+  `X-Forwarded-Proto` headers, and falls back to the connection. With the `axum`
+  feature, the peer address comes from `ConnectInfo`, so an application that
+  wants `client.address` and `network.peer.address` without a proxy must serve
+  with `Router::into_make_service_with_connect_info`.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* The `http.server.request.duration` metric now carries `error.type` for a
+  failed request, so users can derive an error rate from it.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* The README now lists the specification documents that the middleware
+  implements, and the attributes that a Tower service cannot know.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
 
 ### Changed
 
@@ -22,6 +38,33 @@
   `HTTPLayerBuilder` / `ResponseFuture` types introduced in v0.18.0 are replaced
   by `http::server::{Layer, Service, ResponseFuture, LayerBuilder}`.
   [#717](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/717)
+* **BREAKING**: The server span no longer carries `url.full`. The attribute
+  belongs to the HTTP client span, and a server receives a request target that
+  is no absolute URL. `url.path` and `url.query` describe the target instead.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* **BREAKING**: The `http.server.*` metrics no longer carry
+  `network.protocol.name`. The conventions ask for the attribute only when the
+  protocol is not `http`, which an `http::Version` cannot express.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* **BREAKING**: `network.protocol.version` now reports `2` and `3` for HTTP/2
+  and HTTP/3, in place of `2.0` and `3.0`, and stays unset for a version the
+  middleware does not know, in place of an empty value.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* **BREAKING**: `url.scheme` now reports the scheme of the original client
+  request. It read the request target before, which carries no scheme on a
+  server, so every request reported an empty value.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* **BREAKING**: A request method that the conventions do not list now reports
+  `http.request.method` as `_OTHER`, keeps the value from the request line in
+  `http.request.method_original`, and produces a span name of `HTTP` or
+  `HTTP {route}`. This keeps the method and the span name low cardinality.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* The span status description of a 5xx response is now empty, because
+  `error.type` already holds the status code.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
+* The `axum` feature now enables the `tokio` feature of `axum`, which carries
+  `ConnectInfo`.
+  [#777](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/777)
 
 ### Migration Guide
 

--- a/opentelemetry-instrumentation-tower/Cargo.toml
+++ b/opentelemetry-instrumentation-tower/Cargo.toml
@@ -17,7 +17,9 @@ default = []
 axum = ["dep:axum"]
 
 [dependencies]
-axum = { features = ["matched-path", "macros"], version = "0.8", default-features = false, optional = true }
+# The `tokio` feature carries `ConnectInfo`, which holds the peer address of a
+# connection. Every Axum server enables it, because `axum::serve` needs it.
+axum = { features = ["matched-path", "macros", "tokio"], version = "0.8", default-features = false, optional = true }
 http = { version = "1", features = ["std"], default-features = false }
 http-body = { version = "1", default-features = false }
 opentelemetry = { workspace = true, features = ["futures", "metrics", "trace"] }

--- a/opentelemetry-instrumentation-tower/README.md
+++ b/opentelemetry-instrumentation-tower/README.md
@@ -20,6 +20,43 @@ Tonic, etc.). The middleware emits the standard `http.server.*` metrics and a
 server span per request, following the OpenTelemetry
 [HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/).
 
+## Implemented specification
+
+The middleware implements these documents:
+
+- [HTTP spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/),
+  and the
+  [span examples](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#examples)
+  in particular.
+- [HTTP metrics](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/).
+- [Recording errors](https://opentelemetry.io/docs/specs/semconv/general/recording-errors/).
+- [Attribute requirement levels](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/).
+
+The server span carries every `Required`, `Conditionally Required`, and
+`Recommended` attribute that a Tower service can read. Three points need
+attention:
+
+- **Attributes of the original client request.** A reverse proxy rewrites the
+  connection and the `Host` header. The middleware therefore reads
+  `client.address`, `server.address`, `server.port`, and `url.scheme` from the
+  [`Forwarded`](https://www.rfc-editor.org/rfc/rfc7239) header first, then from
+  the `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto` headers, and
+  falls back to the connection. A client can send these headers too, so a server
+  that no proxy protects can receive any value in them.
+- **`url.scheme` without a proxy.** A server receives a request target that
+  carries no scheme, so the middleware reports `http` unless a forwarding header
+  states otherwise. A server that terminates TLS itself therefore reports `http`.
+- **Peer address.** A Tower service reads the request only, which carries no
+  connection. With the `axum` feature, the middleware reads the peer address from
+  `ConnectInfo`, which Axum records when the application serves with
+  [`Router::into_make_service_with_connect_info`](https://docs.rs/axum/latest/axum/struct.Router.html#method.into_make_service_with_connect_info).
+  Without it, `client.address` holds a forwarded address only, and
+  `network.peer.address` stays unset.
+
+`Opt-In` attributes, such as `http.request.header.<key>` and `client.port`, are
+not emitted. Add them with
+`http::server::LayerBuilder::with_request_extractor`.
+
 ## Quick start
 
 With the default `axum` feature, applying the middleware is a single layer call:

--- a/opentelemetry-instrumentation-tower/examples/live-check-app/src/main.rs
+++ b/opentelemetry-instrumentation-tower/examples/live-check-app/src/main.rs
@@ -19,6 +19,7 @@ use opentelemetry_sdk::{
     trace::SdkTracerProvider,
     Resource,
 };
+use std::net::SocketAddr;
 use std::sync::OnceLock;
 use tower_http::catch_panic::CatchPanicLayer;
 
@@ -161,10 +162,16 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind("0.0.0.0:5000")
         .await
         .expect("bind 0.0.0.0:5000");
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .expect("server error");
+    // `into_make_service_with_connect_info` records the peer address of every
+    // connection, which the layer reports as `client.address` and
+    // `network.peer.address`.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
+    .expect("server error");
 
     let _ = meter_provider.shutdown();
     let _ = tracer_provider.shutdown();

--- a/opentelemetry-instrumentation-tower/src/common/attributes.rs
+++ b/opentelemetry-instrumentation-tower/src/common/attributes.rs
@@ -1,12 +1,23 @@
 //! Common HTTP attribute helpers.
+//!
+//! The helpers here follow the OpenTelemetry HTTP semantic conventions:
+//! <https://opentelemetry.io/docs/specs/semconv/http/http-spans/>
 
 use opentelemetry::KeyValue;
 use opentelemetry_semantic_conventions as semconv;
 
-/// Maps common HTTP methods to a `&'static str` so the resulting `KeyValue`
-/// stores the method as a static string (no heap allocation, allocation-free
-/// `KeyValue::clone()`). Returns `None` for custom/extension methods, which
-/// fall back to an owned `String`.
+/// Value of `http.request.method` for a method the instrumentation does not know.
+const HTTP_REQUEST_METHOD_OTHER: &str = "_OTHER";
+
+/// Maps the HTTP methods known to the semantic conventions to a `&'static str`
+/// so the resulting `KeyValue` stores the method as a static string (no heap
+/// allocation, allocation-free `KeyValue::clone()`).
+///
+/// The known set is the methods of
+/// [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods), `PATCH`
+/// from [RFC 5789](https://www.rfc-editor.org/rfc/rfc5789.html), and `QUERY`.
+/// Method names are case sensitive, so a method that differs only in case is
+/// unknown. Returns `None` for every other method.
 #[inline]
 pub(crate) fn method_as_static(m: &http::Method) -> Option<&'static str> {
     match *m {
@@ -19,19 +30,30 @@ pub(crate) fn method_as_static(m: &http::Method) -> Option<&'static str> {
         http::Method::PATCH => Some("PATCH"),
         http::Method::CONNECT => Some("CONNECT"),
         http::Method::TRACE => Some("TRACE"),
+        _ if m.as_str() == "QUERY" => Some("QUERY"),
         _ => None,
     }
 }
 
-/// Builds the `http.request.method` [`KeyValue`], promoting well-known methods
-/// to a `&'static str` for an allocation-free clone in the hot path.
+/// Builds the `http.request.method` [`KeyValue`] and, for a method the
+/// instrumentation does not know, the `http.request.method_original`
+/// [`KeyValue`] that keeps the value from the request line.
 #[inline]
-pub(crate) fn method_kv(method: &http::Method) -> KeyValue {
+pub(crate) fn method_kvs(method: &http::Method) -> (KeyValue, Option<KeyValue>) {
     match method_as_static(method) {
-        Some(s) => KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, s),
-        None => KeyValue::new(
-            semconv::attribute::HTTP_REQUEST_METHOD,
-            method.as_str().to_owned(),
+        Some(known) => (
+            KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, known),
+            None,
+        ),
+        None => (
+            KeyValue::new(
+                semconv::attribute::HTTP_REQUEST_METHOD,
+                HTTP_REQUEST_METHOD_OTHER,
+            ),
+            Some(KeyValue::new(
+                semconv::attribute::HTTP_REQUEST_METHOD_ORIGINAL,
+                method.as_str().to_owned(),
+            )),
         ),
     }
 }
@@ -39,28 +61,398 @@ pub(crate) fn method_kv(method: &http::Method) -> KeyValue {
 /// Builds the `url.scheme` [`KeyValue`], promoting the common `http`/`https`
 /// schemes to a `&'static str`.
 #[inline]
-pub(crate) fn url_scheme_kv(uri: &http::Uri) -> KeyValue {
-    match uri.scheme_str() {
-        Some("http") => KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
-        Some("https") => KeyValue::new(semconv::attribute::URL_SCHEME, "https"),
-        Some(other) => KeyValue::new(semconv::attribute::URL_SCHEME, other.to_owned()),
-        None => KeyValue::new(semconv::attribute::URL_SCHEME, ""),
+pub(crate) fn url_scheme_kv(scheme: &str) -> KeyValue {
+    match scheme {
+        "http" => KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+        "https" => KeyValue::new(semconv::attribute::URL_SCHEME, "https"),
+        other => KeyValue::new(semconv::attribute::URL_SCHEME, other.to_owned()),
     }
 }
 
-/// Splits an HTTP version into its `network.protocol.name` and
-/// `network.protocol.version` values.
+/// Maps an HTTP version to its `network.protocol.version` value.
+///
+/// Returns `None` for a version the instrumentation does not know, because the
+/// conventions ask instrumentations to leave the attribute unset when the
+/// protocol version is unknown.
 #[inline]
-pub(crate) fn split_and_format_protocol_version(
-    http_version: http::Version,
-) -> (&'static str, &'static str) {
-    let version_str = match http_version {
-        http::Version::HTTP_09 => "0.9",
-        http::Version::HTTP_10 => "1.0",
-        http::Version::HTTP_11 => "1.1",
-        http::Version::HTTP_2 => "2.0",
-        http::Version::HTTP_3 => "3.0",
-        _ => "",
+pub(crate) fn protocol_version(http_version: http::Version) -> Option<&'static str> {
+    match http_version {
+        http::Version::HTTP_09 => Some("0.9"),
+        http::Version::HTTP_10 => Some("1.0"),
+        http::Version::HTTP_11 => Some("1.1"),
+        http::Version::HTTP_2 => Some("2"),
+        http::Version::HTTP_3 => Some("3"),
+        _ => None,
+    }
+}
+
+/// Reads a directive from the first element of the
+/// [RFC 7239](https://www.rfc-editor.org/rfc/rfc7239) `Forwarded` header.
+///
+/// The first element holds the values closest to the original client. Directive
+/// names are case insensitive, and values may be quoted.
+pub(crate) fn forwarded_directive<'h>(
+    headers: &'h http::HeaderMap,
+    directive: &str,
+) -> Option<&'h str> {
+    let header = headers.get("forwarded")?.to_str().ok()?;
+    let first_element = header.split(',').next()?;
+
+    for pair in first_element.split(';') {
+        let mut parts = pair.splitn(2, '=');
+        let name = parts.next().unwrap_or_default().trim();
+        if !name.eq_ignore_ascii_case(directive) {
+            continue;
+        }
+        let value = parts.next().unwrap_or_default().trim().trim_matches('"');
+        if value.is_empty() {
+            return None;
+        }
+        return Some(value);
+    }
+
+    None
+}
+
+/// Reads the first, and therefore most original, value of a comma-separated
+/// `X-Forwarded-*` header.
+pub(crate) fn first_forwarded_value<'h>(
+    headers: &'h http::HeaderMap,
+    header: &str,
+) -> Option<&'h str> {
+    let value = headers
+        .get(header)?
+        .to_str()
+        .ok()?
+        .split(',')
+        .next()?
+        .trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(value)
+}
+
+/// Splits an authority into its host and port, dropping the brackets of an IPv6
+/// literal so that the host reads like the address examples in the conventions.
+pub(crate) fn split_host_port(authority: &str) -> Option<(&str, Option<u16>)> {
+    let authority = authority.trim();
+    if authority.is_empty() {
+        return None;
+    }
+
+    let (host, port) = match authority.strip_prefix('[') {
+        // IPv6 literal: the port, if any, follows the closing bracket.
+        Some(rest) => {
+            let (host, after) = rest.split_once(']')?;
+            (host, after.strip_prefix(':'))
+        }
+        None => match authority.split_once(':') {
+            Some((host, port)) => (host, Some(port)),
+            None => (authority, None),
+        },
     };
-    ("http", version_str)
+
+    if host.is_empty() {
+        return None;
+    }
+
+    Some((host, port.and_then(|port| port.parse().ok())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn method_kvs_maps_known_and_unknown_methods() {
+        struct TestCase {
+            name: &'static str,
+            method: &'static str,
+            expected_method: KeyValue,
+            expected_original: Option<KeyValue>,
+        }
+
+        let method_kv = |value: &'static str| {
+            KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, value.to_owned())
+        };
+        let original_kv = |value: &'static str| {
+            KeyValue::new(
+                semconv::attribute::HTTP_REQUEST_METHOD_ORIGINAL,
+                value.to_owned(),
+            )
+        };
+
+        let test_cases = [
+            TestCase {
+                name: "known method",
+                method: "GET",
+                expected_method: method_kv("GET"),
+                expected_original: None,
+            },
+            TestCase {
+                name: "patch is known",
+                method: "PATCH",
+                expected_method: method_kv("PATCH"),
+                expected_original: None,
+            },
+            TestCase {
+                name: "query is known",
+                method: "QUERY",
+                expected_method: method_kv("QUERY"),
+                expected_original: None,
+            },
+            TestCase {
+                name: "method names are case sensitive",
+                method: "GeT",
+                expected_method: method_kv("_OTHER"),
+                expected_original: Some(original_kv("GeT")),
+            },
+            TestCase {
+                name: "extension method is unknown",
+                method: "ACL",
+                expected_method: method_kv("_OTHER"),
+                expected_original: Some(original_kv("ACL")),
+            },
+        ];
+
+        for test_case in test_cases {
+            let method = http::Method::from_bytes(test_case.method.as_bytes()).unwrap();
+
+            let result = method_kvs(&method);
+
+            assert_eq!(
+                result,
+                (test_case.expected_method, test_case.expected_original),
+                "{}",
+                test_case.name
+            );
+        }
+    }
+
+    #[test]
+    fn protocol_version_maps_known_versions() {
+        struct TestCase {
+            name: &'static str,
+            version: http::Version,
+            expected: Option<&'static str>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "http 0.9",
+                version: http::Version::HTTP_09,
+                expected: Some("0.9"),
+            },
+            TestCase {
+                name: "http 1.0",
+                version: http::Version::HTTP_10,
+                expected: Some("1.0"),
+            },
+            TestCase {
+                name: "http 1.1",
+                version: http::Version::HTTP_11,
+                expected: Some("1.1"),
+            },
+            TestCase {
+                name: "http 2 has no minor version",
+                version: http::Version::HTTP_2,
+                expected: Some("2"),
+            },
+            TestCase {
+                name: "http 3 has no minor version",
+                version: http::Version::HTTP_3,
+                expected: Some("3"),
+            },
+        ];
+
+        for test_case in test_cases {
+            let result = protocol_version(test_case.version);
+
+            assert_eq!(result, test_case.expected, "{}", test_case.name);
+        }
+    }
+
+    #[test]
+    fn forwarded_directive_reads_the_first_element() {
+        struct TestCase {
+            name: &'static str,
+            header: Option<&'static str>,
+            directive: &'static str,
+            expected: Option<&'static str>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "missing header",
+                header: None,
+                directive: "for",
+                expected: None,
+            },
+            TestCase {
+                name: "single directive",
+                header: Some("for=203.0.113.7"),
+                directive: "for",
+                expected: Some("203.0.113.7"),
+            },
+            TestCase {
+                name: "directive names are case insensitive",
+                header: Some("For=203.0.113.7"),
+                directive: "for",
+                expected: Some("203.0.113.7"),
+            },
+            TestCase {
+                name: "quoted value",
+                header: Some(r#"for="[2001:db8::17]:4711""#),
+                directive: "for",
+                expected: Some("[2001:db8::17]:4711"),
+            },
+            TestCase {
+                name: "several directives",
+                header: Some("by=198.51.100.1;for=203.0.113.7;host=example.com;proto=https"),
+                directive: "host",
+                expected: Some("example.com"),
+            },
+            TestCase {
+                name: "first element wins",
+                header: Some("for=203.0.113.7, for=198.51.100.17"),
+                directive: "for",
+                expected: Some("203.0.113.7"),
+            },
+            TestCase {
+                name: "directive of a later element is ignored",
+                header: Some("for=203.0.113.7, host=example.com"),
+                directive: "host",
+                expected: None,
+            },
+            TestCase {
+                name: "absent directive",
+                header: Some("for=203.0.113.7"),
+                directive: "proto",
+                expected: None,
+            },
+        ];
+
+        for test_case in test_cases {
+            let mut headers = http::HeaderMap::new();
+            if let Some(header) = test_case.header {
+                headers.insert("forwarded", http::HeaderValue::from_static(header));
+            }
+
+            let result = forwarded_directive(&headers, test_case.directive);
+
+            assert_eq!(result, test_case.expected, "{}", test_case.name);
+        }
+    }
+
+    #[test]
+    fn first_forwarded_value_reads_the_first_entry() {
+        struct TestCase {
+            name: &'static str,
+            header: Option<&'static str>,
+            expected: Option<&'static str>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "missing header",
+                header: None,
+                expected: None,
+            },
+            TestCase {
+                name: "single entry",
+                header: Some("203.0.113.7"),
+                expected: Some("203.0.113.7"),
+            },
+            TestCase {
+                name: "proxy chain",
+                header: Some("203.0.113.7, 198.51.100.17, 10.0.0.1"),
+                expected: Some("203.0.113.7"),
+            },
+            TestCase {
+                name: "empty value",
+                header: Some(""),
+                expected: None,
+            },
+        ];
+
+        for test_case in test_cases {
+            let mut headers = http::HeaderMap::new();
+            if let Some(header) = test_case.header {
+                headers.insert("x-forwarded-for", http::HeaderValue::from_static(header));
+            }
+
+            let result = first_forwarded_value(&headers, "x-forwarded-for");
+
+            assert_eq!(result, test_case.expected, "{}", test_case.name);
+        }
+    }
+
+    #[test]
+    fn split_host_port_splits_authorities() {
+        struct TestCase {
+            name: &'static str,
+            authority: &'static str,
+            expected: Option<(&'static str, Option<u16>)>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "host only",
+                authority: "example.com",
+                expected: Some(("example.com", None)),
+            },
+            TestCase {
+                name: "host and port",
+                authority: "example.com:8443",
+                expected: Some(("example.com", Some(8443))),
+            },
+            TestCase {
+                name: "default port is kept",
+                authority: "example.com:80",
+                expected: Some(("example.com", Some(80))),
+            },
+            TestCase {
+                name: "ipv4 and port",
+                authority: "10.1.2.80:8080",
+                expected: Some(("10.1.2.80", Some(8080))),
+            },
+            TestCase {
+                name: "ipv6 literal loses its brackets",
+                authority: "[2001:db8::17]",
+                expected: Some(("2001:db8::17", None)),
+            },
+            TestCase {
+                name: "ipv6 literal and port",
+                authority: "[2001:db8::17]:4711",
+                expected: Some(("2001:db8::17", Some(4711))),
+            },
+            TestCase {
+                name: "surrounding spaces",
+                authority: " example.com:8443 ",
+                expected: Some(("example.com", Some(8443))),
+            },
+            TestCase {
+                name: "empty authority",
+                authority: "",
+                expected: None,
+            },
+            TestCase {
+                name: "port only",
+                authority: ":8443",
+                expected: None,
+            },
+            TestCase {
+                name: "unparsable port",
+                authority: "example.com:https",
+                expected: Some(("example.com", None)),
+            },
+        ];
+
+        for test_case in test_cases {
+            let result = split_host_port(test_case.authority);
+
+            assert_eq!(result, test_case.expected, "{}", test_case.name);
+        }
+    }
 }

--- a/opentelemetry-instrumentation-tower/src/http/mod.rs
+++ b/opentelemetry-instrumentation-tower/src/http/mod.rs
@@ -7,3 +7,4 @@
 
 pub mod extractors;
 pub mod server;
+pub(crate) mod server_attributes;

--- a/opentelemetry-instrumentation-tower/src/http/server.rs
+++ b/opentelemetry-instrumentation-tower/src/http/server.rs
@@ -23,11 +23,12 @@ use pin_project_lite::pin_project;
 use tower_layer::Layer as TowerLayer;
 use tower_service::Service as TowerService;
 
-use crate::common::attributes::{method_kv, split_and_format_protocol_version, url_scheme_kv};
+use crate::common::attributes::{method_as_static, method_kvs, protocol_version};
 use crate::http::extractors::{
     DefaultRouteExtractor, NoOpExtractor, RequestAttributeExtractor, ResponseAttributeExtractor,
     RouteExtractor,
 };
+use crate::http::server_attributes::{server_request_attributes, ServerRequestAttributes};
 use crate::Result;
 
 const HTTP_SERVER_DURATION_UNIT: &str = "s";
@@ -367,8 +368,7 @@ struct RequestData {
     duration_start: Instant,
     req_body_size: Option<u64>,
 
-    protocol_name_kv: KeyValue,
-    protocol_version_kv: KeyValue,
+    protocol_version_kv_opt: Option<KeyValue>,
     url_scheme_kv: KeyValue,
     method_kv: KeyValue,
     route_kv_opt: Option<KeyValue>,
@@ -447,15 +447,19 @@ where
             .get(http::header::CONTENT_LENGTH)
             .and_then(|value| value.to_str().ok()?.parse::<u64>().ok());
 
-        let (protocol, version) = split_and_format_protocol_version(req.version());
-        let protocol_name_kv = KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_NAME, protocol);
-        let protocol_version_kv =
-            KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, version);
+        let protocol_version_kv_opt = protocol_version(req.version())
+            .map(|version| KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, version));
 
-        let url_scheme_kv = url_scheme_kv(req.uri());
+        let (method_kv, method_original_kv_opt) = method_kvs(req.method());
 
-        let method = req.method().as_str().to_owned();
-        let method_kv = method_kv(req.method());
+        let ServerRequestAttributes {
+            url_scheme_kv,
+            url_query_kv_opt,
+            client_address_kv_opt,
+            network_peer_kv_opt,
+            server_address_kv_opt,
+            server_port_kv_opt,
+        } = server_request_attributes(&req);
 
         // Extract route using the configured extractor
         let route = self.route_extractor.extract_route(&req);
@@ -463,10 +467,13 @@ where
             .as_ref()
             .map(|r| KeyValue::new(semconv::attribute::HTTP_ROUTE, r.clone()));
 
-        // Build span name: "{method} {route}" or just "{method}"
+        // Build span name: "{method} {route}" or just "{method}". A method the
+        // instrumentation does not know is reported as "HTTP", because the
+        // method itself would make the span name high cardinality.
+        let span_method = method_as_static(req.method()).unwrap_or("HTTP");
         let span_name = match &route {
-            Some(r) => format!("{} {}", method, r),
-            None => method.clone(),
+            Some(r) => format!("{span_method} {r}"),
+            None => span_method.to_owned(),
         };
 
         // Extract custom request attributes
@@ -477,16 +484,26 @@ where
             propagator.extract(&HeaderExtractor(req.headers()))
         });
 
-        let mut span_attributes = vec![
-            KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, method.clone()),
-            url_scheme_kv.clone(),
-            KeyValue::new(semconv::attribute::URL_PATH, req.uri().path().to_string()),
-            KeyValue::new(semconv::attribute::URL_FULL, req.uri().to_string()),
-        ];
+        let mut span_attributes = vec![method_kv.clone()];
+        span_attributes.extend(method_original_kv_opt);
+        span_attributes.push(url_scheme_kv.clone());
+        span_attributes.push(KeyValue::new(
+            semconv::attribute::URL_PATH,
+            req.uri().path().to_string(),
+        ));
+        span_attributes.extend(url_query_kv_opt);
+        span_attributes.extend(protocol_version_kv_opt.clone());
+        span_attributes.extend(client_address_kv_opt);
+        if let Some((peer_address_kv, peer_port_kv)) = network_peer_kv_opt {
+            span_attributes.push(peer_address_kv);
+            span_attributes.push(peer_port_kv);
+        }
+        span_attributes.extend(server_address_kv_opt);
+        span_attributes.extend(server_port_kv_opt);
 
         if let Some(user_agent) = req
             .headers()
-            .get("user-agent")
+            .get(http::header::USER_AGENT)
             .and_then(|v| v.to_str().ok())
         {
             span_attributes.push(KeyValue::new(
@@ -495,9 +512,7 @@ where
             ));
         }
 
-        if let Some(r) = &route {
-            span_attributes.push(KeyValue::new(semconv::attribute::HTTP_ROUTE, r.clone()));
-        }
+        span_attributes.extend(route_kv_opt.clone());
 
         span_attributes.extend(custom_request_attributes.clone());
 
@@ -517,8 +532,7 @@ where
         let request_data = RequestData {
             duration_start,
             req_body_size: content_length,
-            protocol_name_kv,
-            protocol_version_kv,
+            protocol_version_kv_opt,
             url_scheme_kv,
             method_kv,
             route_kv_opt,
@@ -556,8 +570,7 @@ fn finalize_request<ResBody, E, ResExt>(
     let RequestData {
         duration_start,
         req_body_size,
-        protocol_name_kv,
-        protocol_version_kv,
+        protocol_version_kv_opt,
         url_scheme_kv,
         method_kv,
         route_kv_opt,
@@ -586,26 +599,35 @@ fn finalize_request<ResBody, E, ResExt>(
 
             // Set span status based on HTTP status code. Per the HTTP semantic
             // conventions, a server span is only an error for 5xx responses.
-            if http_status.is_server_error() {
-                span.set_status(Status::Error {
-                    description: format!("HTTP {}", http_status.as_u16()).into(),
-                });
+            // The failure then also carries `error.type`, which holds the status
+            // code, so the status description would only repeat it.
+            let error_type_kv_opt = http_status.is_server_error().then(|| {
+                KeyValue::new(
+                    semconv::attribute::ERROR_TYPE,
+                    http_status.as_u16().to_string(),
+                )
+            });
+            if let Some(error_type_kv) = &error_type_kv_opt {
+                span.set_attribute(error_type_kv.clone());
+                span.set_status(Status::error(""));
             }
 
             // Build label superset by moving owned values where possible.
             // `url_scheme_kv` and `method_kv` are cloned for the active-requests
             // decrement; their underlying strings are typically `&'static str`
             // so the clones are allocation-free.
-            let cap = 5
+            let cap = 3
+                + protocol_version_kv_opt.is_some() as usize
+                + error_type_kv_opt.is_some() as usize
                 + route_kv_opt.is_some() as usize
                 + custom_request_attributes.len()
                 + custom_response_attributes.len();
             let mut label_superset = Vec::with_capacity(cap);
-            label_superset.push(protocol_name_kv);
-            label_superset.push(protocol_version_kv);
+            label_superset.extend(protocol_version_kv_opt);
             label_superset.push(url_scheme_kv.clone());
             label_superset.push(method_kv.clone());
             label_superset.push(status_code_kv);
+            label_superset.extend(error_type_kv_opt);
             if let Some(route_kv) = route_kv_opt {
                 label_superset.push(route_kv);
             }
@@ -634,18 +656,25 @@ fn finalize_request<ResBody, E, ResExt>(
                 .add(-1, &[url_scheme_kv, method_kv]);
         }
         Err(error) => {
-            // Mark span as error
+            // The inner service failed before it produced a response. The type
+            // of the error identifies the failure and keeps `error.type` low
+            // cardinality, while the debug output goes to the status
+            // description, which has no cardinality constraint.
+            let error_type_kv = KeyValue::new(
+                semconv::attribute::ERROR_TYPE,
+                std::any::type_name::<E>().to_owned(),
+            );
+            span.set_attribute(error_type_kv.clone());
             span.set_status(Status::Error {
-                description: format!("{:?}", error).into(),
+                description: format!("{error:?}").into(),
             });
 
             // Still record duration metric (without status code).
-            let label_superset = [
-                protocol_name_kv,
-                protocol_version_kv,
-                url_scheme_kv.clone(),
-                method_kv.clone(),
-            ];
+            let mut label_superset = Vec::with_capacity(4);
+            label_superset.extend(protocol_version_kv_opt);
+            label_superset.push(url_scheme_kv.clone());
+            label_superset.push(method_kv.clone());
+            label_superset.push(error_type_kv);
 
             layer_state
                 .server_request_duration
@@ -761,12 +790,13 @@ mod tests {
         );
         // Build expected attributes
         let expected_attributes = vec![
-            KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET".to_string()),
-            KeyValue::new(semconv::attribute::URL_SCHEME, "http".to_string()),
+            KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET"),
+            KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
             KeyValue::new(semconv::attribute::URL_PATH, "/api/users/123".to_string()),
+            KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
             KeyValue::new(
-                semconv::attribute::URL_FULL,
-                "http://example.com/api/users/123".to_string(),
+                semconv::attribute::SERVER_ADDRESS,
+                "example.com".to_string(),
             ),
             KeyValue::new(
                 semconv::attribute::USER_AGENT_ORIGINAL,
@@ -779,191 +809,450 @@ mod tests {
         assert_eq!(http_span.attributes, expected_attributes);
     }
 
+    /// Behaviour of the instrumented service for a single table test case.
+    #[derive(Clone, Copy)]
+    enum Handler {
+        /// Answer with 200 and echo the request body.
+        Echo,
+        /// Answer with the given status code.
+        Status(StatusCode),
+        /// Fail before producing a response.
+        Fail,
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn server_span_follows_the_conventions() {
+        struct TestCase {
+            name: &'static str,
+            method: &'static str,
+            target: &'static str,
+            headers: &'static [(&'static str, &'static str)],
+            handler: Handler,
+            expected_span_name: &'static str,
+            expected_status: Status,
+            expected_attributes: Vec<KeyValue>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "request with a query component",
+                method: "GET",
+                target: "/users/456?fields=name&verbose=true",
+                headers: &[("host", "example.com:8443")],
+                handler: Handler::Echo,
+                expected_span_name: "GET /users/456",
+                expected_status: Status::Unset,
+                expected_attributes: vec![
+                    KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET"),
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_PATH, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::URL_QUERY, "fields=name&verbose=true"),
+                    KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
+                    KeyValue::new(
+                        semconv::attribute::SERVER_ADDRESS,
+                        "example.com".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::SERVER_PORT, 8443),
+                    KeyValue::new(semconv::attribute::HTTP_ROUTE, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 200),
+                ],
+            },
+            TestCase {
+                name: "request through a reverse proxy",
+                method: "GET",
+                target: "/users/456",
+                headers: &[
+                    ("host", "backend.internal:5000"),
+                    (
+                        "forwarded",
+                        "for=203.0.113.7;host=public.example.com;proto=https",
+                    ),
+                ],
+                handler: Handler::Echo,
+                expected_span_name: "GET /users/456",
+                expected_status: Status::Unset,
+                expected_attributes: vec![
+                    KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET"),
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "https"),
+                    KeyValue::new(semconv::attribute::URL_PATH, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
+                    KeyValue::new(
+                        semconv::attribute::CLIENT_ADDRESS,
+                        "203.0.113.7".to_string(),
+                    ),
+                    KeyValue::new(
+                        semconv::attribute::SERVER_ADDRESS,
+                        "public.example.com".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::HTTP_ROUTE, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 200),
+                ],
+            },
+            TestCase {
+                name: "client error keeps the span status unset",
+                method: "GET",
+                target: "/users/456",
+                headers: &[("host", "example.com")],
+                handler: Handler::Status(StatusCode::NOT_FOUND),
+                expected_span_name: "GET /users/456",
+                expected_status: Status::Unset,
+                expected_attributes: vec![
+                    KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET"),
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_PATH, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
+                    KeyValue::new(
+                        semconv::attribute::SERVER_ADDRESS,
+                        "example.com".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::HTTP_ROUTE, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 404),
+                ],
+            },
+            TestCase {
+                name: "server error carries the status code as the error type",
+                method: "GET",
+                target: "/users/456",
+                headers: &[("host", "example.com")],
+                handler: Handler::Status(StatusCode::INTERNAL_SERVER_ERROR),
+                expected_span_name: "GET /users/456",
+                expected_status: Status::error(""),
+                expected_attributes: vec![
+                    KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET"),
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_PATH, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
+                    KeyValue::new(
+                        semconv::attribute::SERVER_ADDRESS,
+                        "example.com".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::HTTP_ROUTE, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 500),
+                    KeyValue::new(semconv::attribute::ERROR_TYPE, "500".to_string()),
+                ],
+            },
+            TestCase {
+                name: "failed request carries the error type of the failure",
+                method: "GET",
+                target: "/users/456",
+                headers: &[("host", "example.com")],
+                handler: Handler::Fail,
+                expected_span_name: "GET /users/456",
+                expected_status: Status::error("opentelemetry_instrumentation_tower::Error"),
+                expected_attributes: vec![
+                    KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET"),
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_PATH, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
+                    KeyValue::new(
+                        semconv::attribute::SERVER_ADDRESS,
+                        "example.com".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::HTTP_ROUTE, "/users/456".to_string()),
+                    KeyValue::new(
+                        semconv::attribute::ERROR_TYPE,
+                        "opentelemetry_instrumentation_tower::Error".to_string(),
+                    ),
+                ],
+            },
+            TestCase {
+                name: "unknown method keeps the span name low cardinality",
+                method: "CUSTOM",
+                target: "/users/456",
+                headers: &[("host", "example.com")],
+                handler: Handler::Echo,
+                expected_span_name: "HTTP /users/456",
+                expected_status: Status::Unset,
+                expected_attributes: vec![
+                    KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "_OTHER"),
+                    KeyValue::new(
+                        semconv::attribute::HTTP_REQUEST_METHOD_ORIGINAL,
+                        "CUSTOM".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_PATH, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1"),
+                    KeyValue::new(
+                        semconv::attribute::SERVER_ADDRESS,
+                        "example.com".to_string(),
+                    ),
+                    KeyValue::new(semconv::attribute::HTTP_ROUTE, "/users/456".to_string()),
+                    KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 200),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            let trace_exporter = InMemorySpanExporterBuilder::new().build();
+            let tracer_provider = SdkTracerProvider::builder()
+                .with_simple_exporter(trace_exporter.clone())
+                .build();
+            let layer = LayerBuilder::builder()
+                .with_route_extractor(PathExtractor)
+                .with_tracer_provider(tracer_provider.clone())
+                .build()
+                .unwrap();
+            let handler = test_case.handler;
+            let mut service =
+                layer.layer(tower::service_fn(move |req: Request<String>| async move {
+                    respond(handler, req)
+                }));
+
+            let mut request = Request::builder()
+                .method(test_case.method)
+                .uri(test_case.target);
+            for (name, value) in test_case.headers {
+                request = request.header(*name, *value);
+            }
+            let _result = service
+                .call(request.body(String::from("body")).unwrap())
+                .await;
+
+            tracer_provider.force_flush().unwrap();
+            let spans = trace_exporter.get_finished_spans().unwrap();
+            assert_eq!(spans.len(), 1, "{}", test_case.name);
+            let span = &spans[0];
+
+            assert_eq!(
+                (
+                    span.name.as_ref(),
+                    span.span_kind.clone(),
+                    span.status.clone(),
+                    span.attributes.clone()
+                ),
+                (
+                    test_case.expected_span_name,
+                    SpanKind::Server,
+                    test_case.expected_status,
+                    test_case.expected_attributes
+                ),
+                "{}",
+                test_case.name
+            );
+        }
+    }
+
+    fn respond(handler: Handler, req: Request<String>) -> Result<http::Response<String>, Error> {
+        match handler {
+            Handler::Echo => Ok(http::Response::new(req.into_body())),
+            Handler::Status(status) => Ok(Response::builder()
+                .status(status)
+                .body(String::from("body"))
+                .unwrap()),
+            Handler::Fail => Err(Error {
+                inner: crate::ErrorKind::Other(String::from("inner service failure")),
+            }),
+        }
+    }
+
     async fn echo(req: http::Request<String>) -> Result<http::Response<String>, Error> {
         Ok(http::Response::new(req.into_body()))
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_metrics_labels() {
-        let exporter = InMemoryMetricExporter::default();
-        let reader = PeriodicReader::builder(exporter.clone())
-            .with_interval(Duration::from_millis(100))
-            .build();
-        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
-
-        let layer = LayerBuilder::builder()
-            .with_meter_provider(meter_provider.clone())
-            .build()
-            .unwrap();
-
-        let service = tower::service_fn(|_req: Request<String>| async {
-            Ok::<_, std::convert::Infallible>(
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .body(String::from("Hello, World!"))
-                    .unwrap(),
-            )
-        });
-
-        let mut service = layer.layer(service);
-
-        let request = Request::builder()
-            .method("GET")
-            .uri("https://example.com/test")
-            .body("test body".to_string())
-            .unwrap();
-
-        let _response = service.call(request).await.unwrap();
-
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let metrics = exporter.get_finished_metrics().unwrap();
-        assert!(!metrics.is_empty());
-
-        let resource_metrics = &metrics[0];
-        let scope_metrics = resource_metrics
-            .scope_metrics()
-            .next()
-            .expect("Should have scope metrics");
-
-        let duration_metric = scope_metrics
-            .metrics()
-            .find(|m| m.name() == semconv::metric::HTTP_SERVER_REQUEST_DURATION)
-            .expect("Duration metric should exist");
-
-        if let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = duration_metric.data() {
-            let data_point = histogram
-                .data_points()
-                .next()
-                .expect("Should have data point");
-            let attributes: Vec<_> = data_point.attributes().collect();
-
-            // Duration metric should have 5 attributes: protocol_name, protocol_version, url_scheme, method, status_code
-            assert_eq!(
-                attributes.len(),
-                5,
-                "Duration metric should have exactly 5 attributes"
-            );
-
-            let protocol_name = attributes
-                .iter()
-                .find(|kv| kv.key.as_str() == semconv::attribute::NETWORK_PROTOCOL_NAME)
-                .expect("Protocol name should be present");
-            assert_eq!(protocol_name.value.as_str(), "http");
-
-            let protocol_version = attributes
-                .iter()
-                .find(|kv| kv.key.as_str() == semconv::attribute::NETWORK_PROTOCOL_VERSION)
-                .expect("Protocol version should be present");
-            assert_eq!(protocol_version.value.as_str(), "1.1");
-
-            let url_scheme = attributes
-                .iter()
-                .find(|kv| kv.key.as_str() == semconv::attribute::URL_SCHEME)
-                .expect("URL scheme should be present");
-            assert_eq!(url_scheme.value.as_str(), "https");
-
-            let method = attributes
-                .iter()
-                .find(|kv| kv.key.as_str() == semconv::attribute::HTTP_REQUEST_METHOD)
-                .expect("HTTP method should be present");
-            assert_eq!(method.value.as_str(), "GET");
-
-            let status_code = attributes
-                .iter()
-                .find(|kv| kv.key.as_str() == semconv::attribute::HTTP_RESPONSE_STATUS_CODE)
-                .expect("Status code should be present");
-            if let opentelemetry::Value::I64(code) = &status_code.value {
-                assert_eq!(*code, 200);
-            } else {
-                panic!("Expected i64 status code");
-            }
-        } else {
-            panic!("Expected histogram data for duration metric");
+    async fn server_metrics_follow_the_conventions() {
+        struct TestCase {
+            name: &'static str,
+            handler: Handler,
+            expected_metrics: Vec<(&'static str, Vec<KeyValue>)>,
         }
 
-        let request_body_size_metric = scope_metrics
-            .metrics()
-            .find(|m| m.name() == semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE);
+        let method_kv = KeyValue::new(semconv::attribute::HTTP_REQUEST_METHOD, "GET");
+        let scheme_kv = KeyValue::new(semconv::attribute::URL_SCHEME, "http");
+        let version_kv = KeyValue::new(semconv::attribute::NETWORK_PROTOCOL_VERSION, "1.1");
 
-        if let Some(metric) = request_body_size_metric {
-            if let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = metric.data() {
-                let data_point = histogram
-                    .data_points()
-                    .next()
-                    .expect("Should have data point");
-                let attributes: Vec<_> = data_point.attributes().collect();
+        let test_cases = [
+            TestCase {
+                name: "successful request",
+                handler: Handler::Echo,
+                expected_metrics: vec![
+                    (
+                        semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS,
+                        vec![method_kv.clone(), scheme_kv.clone()],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE,
+                        vec![
+                            method_kv.clone(),
+                            KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 200),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_REQUEST_DURATION,
+                        vec![
+                            method_kv.clone(),
+                            KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 200),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE,
+                        vec![
+                            method_kv.clone(),
+                            KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 200),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                ],
+            },
+            TestCase {
+                name: "server error carries the status code as the error type",
+                handler: Handler::Status(StatusCode::INTERNAL_SERVER_ERROR),
+                expected_metrics: vec![
+                    (
+                        semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS,
+                        vec![method_kv.clone(), scheme_kv.clone()],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE,
+                        vec![
+                            KeyValue::new(semconv::attribute::ERROR_TYPE, "500".to_string()),
+                            method_kv.clone(),
+                            KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 500),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_REQUEST_DURATION,
+                        vec![
+                            KeyValue::new(semconv::attribute::ERROR_TYPE, "500".to_string()),
+                            method_kv.clone(),
+                            KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 500),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE,
+                        vec![
+                            KeyValue::new(semconv::attribute::ERROR_TYPE, "500".to_string()),
+                            method_kv.clone(),
+                            KeyValue::new(semconv::attribute::HTTP_RESPONSE_STATUS_CODE, 500),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                ],
+            },
+            TestCase {
+                name: "failed request has no status code and no body sizes",
+                handler: Handler::Fail,
+                expected_metrics: vec![
+                    (
+                        semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS,
+                        vec![method_kv.clone(), scheme_kv.clone()],
+                    ),
+                    (
+                        semconv::metric::HTTP_SERVER_REQUEST_DURATION,
+                        vec![
+                            KeyValue::new(
+                                semconv::attribute::ERROR_TYPE,
+                                "opentelemetry_instrumentation_tower::Error".to_string(),
+                            ),
+                            method_kv.clone(),
+                            version_kv.clone(),
+                            scheme_kv.clone(),
+                        ],
+                    ),
+                ],
+            },
+        ];
 
-                assert_eq!(
-                    attributes.len(),
-                    5,
-                    "Request body size metric should have exactly 5 attributes"
-                );
+        for test_case in test_cases {
+            let exporter = InMemoryMetricExporter::default();
+            let reader = PeriodicReader::builder(exporter.clone())
+                .with_interval(Duration::from_millis(100))
+                .build();
+            let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+            let layer = LayerBuilder::builder()
+                .with_meter_provider(meter_provider.clone())
+                .build()
+                .unwrap();
+            let handler = test_case.handler;
+            let mut service =
+                layer.layer(tower::service_fn(move |req: Request<String>| async move {
+                    respond(handler, req)
+                }));
 
-                let method = attributes
-                    .iter()
-                    .find(|kv| kv.key.as_str() == semconv::attribute::HTTP_REQUEST_METHOD)
-                    .expect("HTTP method should be present in request body size");
-                assert_eq!(method.value.as_str(), "GET");
+            let body = String::from("test body");
+            let request = Request::builder()
+                .method("GET")
+                .uri("/test")
+                .header(http::header::HOST, "example.com")
+                .header(http::header::CONTENT_LENGTH, body.len().to_string())
+                .body(body)
+                .unwrap();
+            let _result = service.call(request).await;
+
+            meter_provider.force_flush().unwrap();
+
+            let result = recorded_metrics(&exporter);
+
+            assert_eq!(result, test_case.expected_metrics, "{}", test_case.name);
+        }
+    }
+
+    /// Collects the name and the attributes of every recorded data point, both
+    /// sorted by name, so that a test can assert the full set.
+    fn recorded_metrics(exporter: &InMemoryMetricExporter) -> Vec<(&'static str, Vec<KeyValue>)> {
+        let mut recorded = Vec::new();
+
+        for resource_metrics in exporter.get_finished_metrics().unwrap() {
+            for scope_metrics in resource_metrics.scope_metrics() {
+                for metric in scope_metrics.metrics() {
+                    let name = match metric.name() {
+                        semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS => {
+                            semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS
+                        }
+                        semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE => {
+                            semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE
+                        }
+                        semconv::metric::HTTP_SERVER_REQUEST_DURATION => {
+                            semconv::metric::HTTP_SERVER_REQUEST_DURATION
+                        }
+                        semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE => {
+                            semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE
+                        }
+                        other => panic!("unexpected metric {other}"),
+                    };
+
+                    let attribute_sets: Vec<Vec<KeyValue>> = match metric.data() {
+                        AggregatedMetrics::F64(MetricData::Histogram(histogram)) => {
+                            attribute_sets(histogram.data_points().map(|dp| dp.attributes()))
+                        }
+                        AggregatedMetrics::U64(MetricData::Histogram(histogram)) => {
+                            attribute_sets(histogram.data_points().map(|dp| dp.attributes()))
+                        }
+                        AggregatedMetrics::I64(MetricData::Sum(sum)) => {
+                            attribute_sets(sum.data_points().map(|dp| dp.attributes()))
+                        }
+                        _ => panic!("unexpected data for metric {name}"),
+                    };
+
+                    recorded.extend(attribute_sets.into_iter().map(|set| (name, set)));
+                }
             }
         }
 
-        // Test response body size metric
-        let response_body_size_metric = scope_metrics
-            .metrics()
-            .find(|m| m.name() == semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE);
+        recorded.sort_by(|left, right| left.0.cmp(right.0));
+        recorded
+    }
 
-        if let Some(metric) = response_body_size_metric {
-            if let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = metric.data() {
-                let data_point = histogram
-                    .data_points()
-                    .next()
-                    .expect("Should have data point");
-                let attributes: Vec<_> = data_point.attributes().collect();
-
-                assert_eq!(
-                    attributes.len(),
-                    5,
-                    "Response body size metric should have exactly 5 attributes"
-                );
-
-                let method = attributes
-                    .iter()
-                    .find(|kv| kv.key.as_str() == semconv::attribute::HTTP_REQUEST_METHOD)
-                    .expect("HTTP method should be present in response body size");
-                assert_eq!(method.value.as_str(), "GET");
-            }
-        }
-
-        // Test active requests metric
-        let active_requests_metric = scope_metrics
-            .metrics()
-            .find(|m| m.name() == semconv::metric::HTTP_SERVER_ACTIVE_REQUESTS);
-
-        if let Some(metric) = active_requests_metric {
-            if let AggregatedMetrics::I64(MetricData::Sum(sum)) = metric.data() {
-                let data_point = sum.data_points().next().expect("Should have data point");
-                let attributes: Vec<_> = data_point.attributes().collect();
-
-                assert_eq!(
-                    attributes.len(),
-                    2,
-                    "Active requests metric should have exactly 2 attributes"
-                );
-
-                let method = attributes
-                    .iter()
-                    .find(|kv| kv.key.as_str() == semconv::attribute::HTTP_REQUEST_METHOD)
-                    .expect("HTTP method should be present in active requests");
-                assert_eq!(method.value.as_str(), "GET");
-
-                let url_scheme = attributes
-                    .iter()
-                    .find(|kv| kv.key.as_str() == semconv::attribute::URL_SCHEME)
-                    .expect("URL scheme should be present in active requests");
-                assert_eq!(url_scheme.value.as_str(), "https");
-            }
-        }
+    fn attribute_sets<'a>(
+        data_points: impl Iterator<Item = impl Iterator<Item = &'a KeyValue>>,
+    ) -> Vec<Vec<KeyValue>> {
+        data_points
+            .map(|attributes| {
+                let mut set: Vec<KeyValue> = attributes.cloned().collect();
+                set.sort_by(|left, right| left.key.cmp(&right.key));
+                set
+            })
+            .collect()
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/opentelemetry-instrumentation-tower/src/http/server_attributes.rs
+++ b/opentelemetry-instrumentation-tower/src/http/server_attributes.rs
@@ -1,0 +1,377 @@
+//! Server-side resolution of the HTTP semantic convention attributes that
+//! describe the client, this server, and the request target.
+//!
+//! An HTTP server can sit behind one or more reverse proxies, which rewrite the
+//! connection and the `Host` header. The conventions therefore prefer the
+//! forwarding headers over the values of the immediate connection:
+//! <https://opentelemetry.io/docs/specs/semconv/http/http-spans/#setting-serveraddress-and-serverport-attributes>
+
+use std::net::SocketAddr;
+
+use opentelemetry::KeyValue;
+use opentelemetry_semantic_conventions as semconv;
+
+use crate::common::attributes::{
+    first_forwarded_value, forwarded_directive, split_host_port, url_scheme_kv,
+};
+
+/// Value that RFC 7239 reserves for a client the proxy does not disclose.
+const FORWARDED_UNKNOWN: &str = "unknown";
+
+/// Attributes of an incoming request that describe the client, this server, and
+/// the request target.
+pub(crate) struct ServerRequestAttributes {
+    /// `url.scheme`, which the server layer also records as a metric attribute.
+    pub(crate) url_scheme_kv: KeyValue,
+    /// `url.query`, set when the request target carries a query component.
+    pub(crate) url_query_kv_opt: Option<KeyValue>,
+    /// `client.address` of the original client, behind all proxies.
+    pub(crate) client_address_kv_opt: Option<KeyValue>,
+    /// `network.peer.address` and `network.peer.port` of the immediate peer,
+    /// which is the closest proxy when the request passed through one.
+    pub(crate) network_peer_kv_opt: Option<(KeyValue, KeyValue)>,
+    /// `server.address` and `server.port` that the client addressed.
+    pub(crate) server_address_kv_opt: Option<KeyValue>,
+    pub(crate) server_port_kv_opt: Option<KeyValue>,
+}
+
+/// Resolves the attributes of an incoming request.
+pub(crate) fn server_request_attributes<B>(req: &http::Request<B>) -> ServerRequestAttributes {
+    let headers = req.headers();
+    let uri = req.uri();
+    let peer = peer_socket_addr(req);
+
+    let (server_address, server_port) = match server_authority(req) {
+        Some((address, port)) => (
+            Some(KeyValue::new(
+                semconv::attribute::SERVER_ADDRESS,
+                address.to_owned(),
+            )),
+            port.map(|port| KeyValue::new(semconv::attribute::SERVER_PORT, i64::from(port))),
+        ),
+        None => (None, None),
+    };
+
+    ServerRequestAttributes {
+        url_scheme_kv: url_scheme_kv(scheme(headers, uri)),
+        url_query_kv_opt: uri
+            .query()
+            .map(|query| KeyValue::new(semconv::attribute::URL_QUERY, query.to_owned())),
+        client_address_kv_opt: client_address(headers, peer)
+            .map(|address| KeyValue::new(semconv::attribute::CLIENT_ADDRESS, address)),
+        network_peer_kv_opt: peer.map(|peer| {
+            (
+                KeyValue::new(
+                    semconv::attribute::NETWORK_PEER_ADDRESS,
+                    peer.ip().to_string(),
+                ),
+                KeyValue::new(
+                    semconv::attribute::NETWORK_PEER_PORT,
+                    i64::from(peer.port()),
+                ),
+            )
+        }),
+        server_address_kv_opt: server_address,
+        server_port_kv_opt: server_port,
+    }
+}
+
+/// Reads the scheme of the original client request, and falls back to `http`
+/// when neither a forwarding header nor the request target carries one.
+///
+/// A server receives a request target in origin form, which has no scheme, so
+/// the fallback applies to most requests. A server that terminates TLS itself
+/// therefore reports `http` unless a proxy sends the scheme.
+fn scheme<'h>(headers: &'h http::HeaderMap, uri: &'h http::Uri) -> &'h str {
+    forwarded_directive(headers, "proto")
+        .or_else(|| first_forwarded_value(headers, "x-forwarded-proto"))
+        .or_else(|| uri.scheme_str())
+        .unwrap_or("http")
+}
+
+/// Reads the address of the original client, behind all proxies, and falls back
+/// to the address of the immediate peer.
+fn client_address(headers: &http::HeaderMap, peer: Option<SocketAddr>) -> Option<String> {
+    let forwarded = forwarded_directive(headers, "for")
+        .or_else(|| first_forwarded_value(headers, "x-forwarded-for"))
+        .filter(|value| !value.eq_ignore_ascii_case(FORWARDED_UNKNOWN))
+        // RFC 7239 lets a proxy send an obfuscated identifier instead of an
+        // address. Such a value is no address, so it is of no use here.
+        .filter(|value| !value.starts_with('_'))
+        .and_then(|value| split_host_port(value).map(|(host, _)| host.to_owned()));
+
+    forwarded.or_else(|| peer.map(|peer| peer.ip().to_string()))
+}
+
+/// Reads the address and port of the server that the client addressed.
+fn server_authority<B>(req: &http::Request<B>) -> Option<(&str, Option<u16>)> {
+    let headers = req.headers();
+
+    let authority = forwarded_directive(headers, "host")
+        .or_else(|| first_forwarded_value(headers, "x-forwarded-host"))
+        // The `:authority` pseudo-header of HTTP/2 and HTTP/3, and the
+        // absolute-form request target of HTTP/1.1, both land here.
+        .or_else(|| req.uri().authority().map(|authority| authority.as_str()))
+        .or_else(|| headers.get(http::header::HOST)?.to_str().ok())?;
+
+    split_host_port(authority)
+}
+
+/// Reads the socket address of the immediate peer, which Axum records in the
+/// request extensions when the application serves with
+/// `Router::into_make_service_with_connect_info`.
+#[cfg(feature = "axum")]
+fn peer_socket_addr<B>(req: &http::Request<B>) -> Option<SocketAddr> {
+    req.extensions()
+        .get::<axum::extract::ConnectInfo<SocketAddr>>()
+        .map(|connect_info| connect_info.0)
+}
+
+/// A Tower service reads the request only, which carries no connection. Without
+/// the `axum` feature there is no peer address to report.
+#[cfg(not(feature = "axum"))]
+fn peer_socket_addr<B>(_req: &http::Request<B>) -> Option<SocketAddr> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a request the way a server receives it: an origin-form target,
+    /// and the addressed authority only in the `Host` header.
+    fn request(target: &str, headers: &[(&str, &str)]) -> http::Request<()> {
+        let mut builder = http::Request::builder().uri(target);
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        builder.body(()).unwrap()
+    }
+
+    #[test]
+    fn server_request_attributes_follow_the_forwarding_headers() {
+        struct TestCase {
+            name: &'static str,
+            target: &'static str,
+            headers: &'static [(&'static str, &'static str)],
+            expected: Vec<KeyValue>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "host header only",
+                target: "/users/456",
+                headers: &[("host", "example.com:8443")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                    KeyValue::new(semconv::attribute::SERVER_PORT, 8443),
+                ],
+            },
+            TestCase {
+                name: "query component",
+                target: "/users/456?fields=name&verbose=true",
+                headers: &[("host", "example.com")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_QUERY, "fields=name&verbose=true"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+            TestCase {
+                name: "empty query component",
+                target: "/users/456?",
+                headers: &[("host", "example.com")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::URL_QUERY, ""),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+            TestCase {
+                name: "rfc 7239 forwarded header",
+                target: "/users/456",
+                headers: &[
+                    ("host", "backend.internal:5000"),
+                    (
+                        "forwarded",
+                        "for=203.0.113.7;host=public.example.com:8443;proto=https",
+                    ),
+                ],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "https"),
+                    KeyValue::new(semconv::attribute::CLIENT_ADDRESS, "203.0.113.7"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "public.example.com"),
+                    KeyValue::new(semconv::attribute::SERVER_PORT, 8443),
+                ],
+            },
+            TestCase {
+                name: "x-forwarded headers",
+                target: "/users/456",
+                headers: &[
+                    ("host", "backend.internal:5000"),
+                    ("x-forwarded-for", "203.0.113.7, 198.51.100.17"),
+                    ("x-forwarded-host", "public.example.com"),
+                    ("x-forwarded-proto", "https"),
+                ],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "https"),
+                    KeyValue::new(semconv::attribute::CLIENT_ADDRESS, "203.0.113.7"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "public.example.com"),
+                ],
+            },
+            TestCase {
+                name: "forwarded header wins over x-forwarded headers",
+                target: "/users/456",
+                headers: &[
+                    ("host", "backend.internal:5000"),
+                    ("forwarded", "for=203.0.113.7;host=first.example.com"),
+                    ("x-forwarded-for", "198.51.100.17"),
+                    ("x-forwarded-host", "second.example.com"),
+                ],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::CLIENT_ADDRESS, "203.0.113.7"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "first.example.com"),
+                ],
+            },
+            TestCase {
+                name: "forwarded client with port and ipv6 literal",
+                target: "/users/456",
+                headers: &[
+                    ("host", "example.com"),
+                    ("forwarded", r#"for="[2001:db8::17]:4711""#),
+                ],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::CLIENT_ADDRESS, "2001:db8::17"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+            TestCase {
+                name: "undisclosed forwarded client",
+                target: "/users/456",
+                headers: &[("host", "example.com"), ("forwarded", "for=unknown")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+            TestCase {
+                name: "obfuscated forwarded client",
+                target: "/users/456",
+                headers: &[("host", "example.com"), ("forwarded", "for=_hidden")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+            TestCase {
+                name: "no host information at all",
+                target: "/users/456",
+                headers: &[],
+                expected: vec![KeyValue::new(semconv::attribute::URL_SCHEME, "http")],
+            },
+        ];
+
+        for test_case in test_cases {
+            let req = request(test_case.target, test_case.headers);
+
+            let result = flatten(server_request_attributes(&req));
+
+            assert_eq!(result, test_case.expected, "{}", test_case.name);
+        }
+    }
+
+    #[test]
+    fn server_request_attributes_read_the_absolute_form_target() {
+        let req = http::Request::builder()
+            .uri("http://example.com:8080/users/456?fields=name")
+            .body(())
+            .unwrap();
+
+        let result = flatten(server_request_attributes(&req));
+
+        assert_eq!(
+            result,
+            vec![
+                KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                KeyValue::new(semconv::attribute::URL_QUERY, "fields=name"),
+                KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                KeyValue::new(semconv::attribute::SERVER_PORT, 8080),
+            ]
+        );
+    }
+
+    #[cfg(feature = "axum")]
+    #[test]
+    fn server_request_attributes_read_the_peer_address() {
+        struct TestCase {
+            name: &'static str,
+            headers: &'static [(&'static str, &'static str)],
+            expected: Vec<KeyValue>,
+        }
+
+        let test_cases = [
+            TestCase {
+                name: "peer is the client",
+                headers: &[("host", "example.com")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::CLIENT_ADDRESS, "198.51.100.17"),
+                    KeyValue::new(semconv::attribute::NETWORK_PEER_ADDRESS, "198.51.100.17"),
+                    KeyValue::new(semconv::attribute::NETWORK_PEER_PORT, 41234),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+            TestCase {
+                name: "peer is a proxy",
+                headers: &[("host", "example.com"), ("x-forwarded-for", "203.0.113.7")],
+                expected: vec![
+                    KeyValue::new(semconv::attribute::URL_SCHEME, "http"),
+                    KeyValue::new(semconv::attribute::CLIENT_ADDRESS, "203.0.113.7"),
+                    KeyValue::new(semconv::attribute::NETWORK_PEER_ADDRESS, "198.51.100.17"),
+                    KeyValue::new(semconv::attribute::NETWORK_PEER_PORT, 41234),
+                    KeyValue::new(semconv::attribute::SERVER_ADDRESS, "example.com"),
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            let mut req = request("/users/456", test_case.headers);
+            req.extensions_mut()
+                .insert(axum::extract::ConnectInfo(SocketAddr::from((
+                    [198, 51, 100, 17],
+                    41234,
+                ))));
+
+            let result = flatten(server_request_attributes(&req));
+
+            assert_eq!(result, test_case.expected, "{}", test_case.name);
+        }
+    }
+
+    /// Collects the resolved attributes in the order the server layer records
+    /// them on a span.
+    fn flatten(attributes: ServerRequestAttributes) -> Vec<KeyValue> {
+        let ServerRequestAttributes {
+            url_scheme_kv,
+            url_query_kv_opt,
+            client_address_kv_opt,
+            network_peer_kv_opt,
+            server_address_kv_opt,
+            server_port_kv_opt,
+        } = attributes;
+
+        let mut flattened = vec![url_scheme_kv];
+        flattened.extend(url_query_kv_opt);
+        flattened.extend(client_address_kv_opt);
+        if let Some((peer_address_kv, peer_port_kv)) = network_peer_kv_opt {
+            flattened.push(peer_address_kv);
+            flattened.push(peer_port_kv);
+        }
+        flattened.extend(server_address_kv_opt);
+        flattened.extend(server_port_kv_opt);
+        flattened
+    }
+}

--- a/opentelemetry-instrumentation-tower/src/lib.rs
+++ b/opentelemetry-instrumentation-tower/src/lib.rs
@@ -20,9 +20,19 @@
 //!
 //! # Tracing
 //!
-//! A server span (`SpanKind::Server`) is created per request, with attributes such
-//! as `http.request.method`, `url.scheme`, `url.path`, `url.full`,
-//! `user_agent.original`, `http.route`, and `http.response.status_code`.
+//! A server span (`SpanKind::Server`) is created per request. It carries every
+//! `Required`, `Conditionally Required`, and `Recommended` attribute of the
+//! [HTTP server span] that a Tower service can read: `http.request.method`,
+//! `http.request.method_original`, `url.scheme`, `url.path`, `url.query`,
+//! `network.protocol.version`, `client.address`, `network.peer.address`,
+//! `network.peer.port`, `server.address`, `server.port`, `user_agent.original`,
+//! `http.route`, `http.response.status_code`, and `error.type`.
+//!
+//! The README of the crate describes how the middleware reads the attributes of
+//! the original client request from the forwarding headers, and which values it
+//! cannot know.
+//!
+//! [HTTP server span]: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span
 //!
 //! # Quick start
 //!


### PR DESCRIPTION
Fixes #777
Design discussion issue (if applicable)

## Changes

A conformance run against the published HTTP semantic conventions found that the server span lacked `url.query`, `client.address`, `server.address`, `network.protocol.version`, and `error.type`. A failed request was therefore hard
to attribute, and a span could not be matched to the client that sent the request. The middleware now reads these attributes, and it also reports `server.port`, `network.peer.address`, and `network.peer.port`.

A server can sit behind a reverse proxy, which rewrites the connection and the `Host` header. The conventions therefore prefer the forwarding headers. The middleware reads the `Forwarded` header first, then `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto`, and falls back to the connection. A client can send these headers too, which the README states. A Tower service reads the request only, so the peer address comes from Axum `ConnectInfo`, which needs `Router::into_make_service_with_connect_info`.

Four further gaps came up while reading the specification for the reported ones:

* `url.scheme` was always empty. It read the request target, but a server receives a target in origin form, which carries no scheme. It now reports the forwarded scheme, and `http` when no header states one.
* `url.full` belongs to the client span, and the emitted value was a relative path rather than an absolute URL. It is gone from the server span.
* `network.protocol.name` was always `http`, while the conventions ask for it only when the protocol is not `http`. It is gone from the metrics.
* An unknown request method passed through verbatim, into both the attribute and the span name. It now reports `_OTHER`, keeps the original value in `http.request.method_original`, and produces a span name of `HTTP {route}`.

The span status of a 5xx response no longer repeats the status code in its description, because `error.type` carries it, and the description of a failed request no longer doubles as the error type.

`network.protocol.version` reports `2` and `3` in place of `2.0` and `3.0`, which matches the examples in the conventions and the actix-web instrumentation.

The live-check workload now sends a request with a query string and requests with both forms of forwarding header, so a missing attribute fails CI. Running the shared conformance advice policies here is a larger piece of work and belongs to the live-check effort in #530. An override of the known-method list through `OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS`, and the redaction of sensitive query parameters, are both still open.

The client layer in #700 shares the attribute code and needs the same sweep. It follows once this lands, as agreed in #777.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)