### PR TITLE
chore(geneva-uploader): prepare 0.7.1 release

### DIFF
--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.1] - 2026-09-07
+
+### Changed
+- Update `geneva-uploader` to 0.7.1.
+
 ## [0.7.0] - 2026-09-03
 
 ### Changed

--- a/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geneva-uploader-ffi"
 description = "FFI bindings for Geneva uploader"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader-ffi"
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-geneva-uploader = { path = "../geneva-uploader", version = "0.7.0", default-features = false }
+geneva-uploader = { path = "../geneva-uploader", version = "0.7.1", default-features = false }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace", "gen-tonic-messages"] }
 otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.54.1" }
 otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.54.1", optional = true }

--- a/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/geneva-uploader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [vNext]
+## [0.7.1] - 2026-09-07
 
 ### Fixed
 - Emit compatible Common Schema metadata for OTLP logs and spans, including `env_ver=4.0`, event-based `env_name`, uppercase `TIMESTAMP`, canonical log severity field casing, and a default Part B log name.

--- a/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
+++ b/opentelemetry-exporter-geneva/geneva-uploader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geneva-uploader"
 description = "Upload telemetry data to Geneva logs service"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/geneva-uploader"

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.1] - 2026-09-07
+
+### Changed
+- Update `geneva-uploader` to 0.7.1.
+
 ## [0.7.0] - 2026-09-03
 
 ### Changed

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-exporter-geneva"
 description = "OpenTelemetry exporter for Geneva logs and traces"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
 repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["logs", "trace"] }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "trace"] }
-geneva-uploader = { path = "../geneva-uploader", version = "0.7.0", default-features = false }
+geneva-uploader = { path = "../geneva-uploader", version = "0.7.1", default-features = false }
 futures = "0.3"
 otap-df-pdata-views = { package = "otel-arrow-dfe-pdata-views", version = "0.54.1" }
 

--- a/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/README.md
+++ b/opentelemetry-exporter-geneva/opentelemetry-exporter-geneva/README.md
@@ -23,7 +23,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opentelemetry-exporter-geneva = "0.7.0"
+opentelemetry-exporter-geneva = "0.7.1"
 ```
 
 See `examples/basic.rs` for a logs example and `examples/trace_basic.rs` for

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -36,7 +36,7 @@ opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs" }
 opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
-geneva-uploader = { version = "0.7.0", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
+geneva-uploader = { version = "0.7.1", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}
 otap-df-pdata = { package = "otel-arrow-dfe-pdata", version = "0.54.1" }
 prost = "0.14"
 


### PR DESCRIPTION
## Changes

- bump `geneva-uploader`, `geneva-uploader-ffi`, and `opentelemetry-exporter-geneva` to 0.7.1
- update internal Geneva and stress dependency versions
- finalize the 0.7.1 changelog entries for the Common Schema fixes and log resource/scope enrichment
- update the exporter README example to 0.7.1
- keep `otel-arrow-dfe-pdata` and `otel-arrow-dfe-pdata-views` at 0.54.1

## Validation

- `cargo check -p geneva-uploader -p geneva-uploader-ffi -p opentelemetry-exporter-geneva -p stress --all-targets --all-features`
- `git diff --check`

No crates should be published until this PR is approved and merged. Publishing will be performed manually after merge.