### PR TITLE
feat: add opentelemetry-context-macro for context propagation across await points

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -41,6 +41,7 @@ body:
       options:
         - opentelemetry-aws
         - opentelemetry-config
+        - opentelemetry-context-macro
         - opentelemetry-contrib
         - opentelemetry-datadog
         - opentelemetry-etw-logs

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -30,6 +30,7 @@ body:
       options:
         - opentelemetry-aws
         - opentelemetry-config
+        - opentelemetry-context-macro
         - opentelemetry-contrib
         - opentelemetry-datadog
         - opentelemetry-etw-logs

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -22,6 +22,9 @@ components:
   opentelemetry-config/:
     - andborja
 
+  opentelemetry-context-macro/:
+    - jan-xyz
+
   # TBD - seeking owners. Issues fall back to @open-telemetry/rust-approvers.
   opentelemetry-contrib/: []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "opentelemetry-aws",
     "opentelemetry-config",
+    "opentelemetry-context-macro",
     "opentelemetry-contrib",
     "opentelemetry-datadog",
     "opentelemetry-etw-logs",

--- a/opentelemetry-context-macro/CHANGELOG.md
+++ b/opentelemetry-context-macro/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Initial release of `#[propagate_context]`, an attribute macro that attaches the OpenTelemetry
   context of an async function to every future the function awaits, so work after a suspension
   point stays in the trace it started in. The macro creates no span.
+  [#792](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/792)

--- a/opentelemetry-context-macro/CHANGELOG.md
+++ b/opentelemetry-context-macro/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## vNext
+
+- Initial release of `#[propagate_context]`, an attribute macro that attaches the OpenTelemetry
+  context of an async function to every future the function awaits, so work after a suspension
+  point stays in the trace it started in. The macro creates no span.

--- a/opentelemetry-context-macro/Cargo.toml
+++ b/opentelemetry-context-macro/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "opentelemetry-context-macro"
+description = "Attribute macro that propagates the OpenTelemetry context across await points"
+version = "0.1.0"
+edition = "2021"
+homepage = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-context-macro"
+repository = "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-context-macro"
+readme = "README.md"
+rust-version = "1.75.0"
+keywords = ["opentelemetry", "context", "async", "macro"]
+license = "Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = { version = "2", features = ["full", "fold"] }
+
+[dev-dependencies]
+async-trait = "0.1"
+opentelemetry = { workspace = true, features = ["futures", "trace"] }
+opentelemetry_sdk = { workspace = true, features = ["trace"] }
+tokio = { version = "1.0", features = ["rt"] }
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[lints]
+workspace = true

--- a/opentelemetry-context-macro/Cargo.toml
+++ b/opentelemetry-context-macro/Cargo.toml
@@ -19,6 +19,7 @@ syn = { version = "2", features = ["full", "fold"] }
 
 [dev-dependencies]
 async-trait = "0.1"
+criterion = { workspace = true, features = ["async_tokio"] }
 opentelemetry = { workspace = true, features = ["futures", "trace"] }
 opentelemetry_sdk = { workspace = true, features = ["trace"] }
 tokio = { version = "1.0", features = ["rt"] }
@@ -26,6 +27,10 @@ tokio = { version = "1.0", features = ["rt"] }
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
+
+[[bench]]
+name = "propagation"
+harness = false
 
 [lints]
 workspace = true

--- a/opentelemetry-context-macro/README.md
+++ b/opentelemetry-context-macro/README.md
@@ -1,0 +1,144 @@
+# OpenTelemetry Context Propagation Macro
+
+![OpenTelemetry — An observability framework for cloud-native software.][splash]
+
+[splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
+
+| Status        |                                              |
+| ------------- |----------------------------------------------|
+| Stability     | alpha                                        |
+| Owners        | [Jan Steinke](https://github.com/jan-xyz)    |
+
+An attribute macro that carries the OpenTelemetry context across the await points of an async
+function, so work that happens after a suspension stays in the trace it started in.
+
+[![Crates.io: opentelemetry-context-macro](https://img.shields.io/crates/v/opentelemetry-context-macro.svg)](https://crates.io/crates/opentelemetry-context-macro)
+[![Documentation](https://docs.rs/opentelemetry-context-macro/badge.svg)](https://docs.rs/opentelemetry-context-macro)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
+
+## The problem
+
+`opentelemetry::Context` lives in a thread-local, and nothing restores that thread-local when an
+async runtime polls a suspended future again. The context is therefore current for the first poll of
+a future and gone for every later one. Work after the first `.await` then reads an empty context: an
+outgoing request carries no `traceparent` header, and a child span attaches to nothing.
+
+The fix is `FutureExt::with_context` at every call site, which is easy to forget and noisy to read:
+
+```rust,ignore
+use opentelemetry::{context::FutureExt, Context};
+
+async fn place_order(order: u64) -> u64 {
+    let cx = Context::current();
+
+    charge(order).with_context(cx.clone()).await;
+    ship(order).with_context(cx).await
+}
+```
+
+## Usage
+
+Add the dependency:
+
+```toml
+[dependencies]
+opentelemetry = "0.32"
+opentelemetry-context-macro = "0.1"
+```
+
+Then annotate the function:
+
+```rust,ignore
+use opentelemetry_context_macro::propagate_context;
+
+#[propagate_context]
+async fn place_order(order: u64) -> u64 {
+    charge(order).await;
+    ship(order).await
+}
+```
+
+The annotated crate needs `opentelemetry` as a dependency, because the expansion names it. The
+`futures` feature carries `FutureExt` and is on by default.
+
+The macro also accepts the shape [`async_trait`](https://docs.rs/async-trait) generates, which is a
+synchronous function returning `Box::pin(async move { .. })`:
+
+```rust,ignore
+#[async_trait]
+impl Warehouse for Postgres {
+    #[propagate_context]
+    async fn reserve(&self, order: u64) -> u64 {
+        self.query(order).await
+    }
+}
+```
+
+Run the worked example, which prints the outgoing `traceparent` with and without the macro:
+
+```sh
+cargo run --example basic -p opentelemetry-context-macro
+```
+
+## How it works
+
+The macro makes two changes to the body:
+
+1. It binds `__otel_cx` to `Context::current()` as the first statement of the async body. The body
+   of an `async fn` runs on first poll, so this reads the context of the caller that polls the
+   future, not of the code that created it.
+2. It rewrites every `.await` in that body from `future.await` to
+   `FutureExt::with_context(future, __otel_cx.clone()).await`, which attaches the captured context
+   for each poll of that future and detaches it again when the poll returns.
+
+Capturing once and reusing the clone is the point. Reading the current context at each await instead
+would read an empty context after the first suspension, which is the problem the macro exists to
+fix.
+
+The expansion writes every path in full, as `<_ as ::opentelemetry::context::FutureExt>::with_context(..)`
+rather than a method call on an imported trait, and it imports nothing into the annotated function.
+Instrumented code is free to import a different `with_context`, such as the one on `anyhow::Context`,
+without the two becoming ambiguous. Application code has no such constraint, so the examples here
+import `FutureExt` and call the method directly.
+
+### `#[async_trait]` methods
+
+`async_trait` desugars an `async fn` into a synchronous function that returns
+`Box::pin(async move { .. })`. The capture goes inside that async block, not at the top of the
+synchronous function, because the arguments of a call are evaluated before the call. In
+`warehouse.reserve(order).await` the synchronous `reserve()` runs before the surrounding
+`with_context(..)` attaches anything, so a capture at the top of it would read the context of
+whoever polls the caller, which is empty after the caller's first suspension.
+
+## What it does not do
+
+- **It never creates a span.** Nothing is added to the trace, and the current span inside the body
+  stays the caller's span. Create and activate a span yourself where you want one.
+- **It does not cover the body's own statements**, only the futures the body awaits. A log line
+  between two awaits still reads whatever context the runtime left attached. Attach the context for
+  a whole body with `FutureExt::with_context` on the outermost future when you need that.
+- **The captured context wins at the await points**, even over a context the body attached itself.
+  Call `FutureExt::with_context` at the call site when a single call has to run under a different
+  context.
+- **Nested `async` blocks, closures and macro bodies are left alone.** An `async` block that is
+  awaited inline is covered anyway, because the enclosing `.await` attaches the context for the whole
+  poll. One that is spawned is not, and neither are the arms of `select!` or `join!`, since a macro
+  body is opaque tokens at expansion time.
+- **Nested `fn`, `impl`, `mod` and other item definitions are left alone.** Their bodies run with
+  their own callers' contexts.
+- **A spawned task starts with an empty context.** Pass the context in explicitly:
+
+```rust,ignore
+use opentelemetry::{context::FutureExt, Context};
+
+let task_cx = Context::current();
+tokio::spawn(async move { work().await }.with_context(task_cx));
+```
+
+## Related work
+
+- [`tracing::instrument`](https://docs.rs/tracing/latest/tracing/attr.instrument.html) does the
+  same job for `tracing` spans, and creates a span as well.
+- [`opentelemetry-instrumentation-tower`](../opentelemetry-instrumentation-tower) attaches the
+  context for each poll of the future it wraps, which covers the handlers it polls directly. This
+  macro covers the calls that middleware cannot reach.

--- a/opentelemetry-context-macro/README.md
+++ b/opentelemetry-context-macro/README.md
@@ -74,7 +74,7 @@ impl Warehouse for Postgres {
 }
 ```
 
-Run the worked example, which prints the outgoing `traceparent` with and without the macro:
+Run the worked example, which sends an inbound trace on in an outgoing header after a wait:
 
 ```sh
 cargo run --example basic -p opentelemetry-context-macro

--- a/opentelemetry-context-macro/benches/propagation.rs
+++ b/opentelemetry-context-macro/benches/propagation.rs
@@ -1,0 +1,212 @@
+//! What `#[propagate_context]` costs at runtime, against no instrumentation and against the same
+//! propagation written by hand.
+//!
+//! **Purpose**: track the overhead over time and catch regressions. The absolute numbers matter
+//! less than the relative distance between the scenarios, and than the macro staying level with the
+//! hand-written equivalent it replaces.
+//!
+//! ## Scenarios
+//!
+//! - **baseline**: the function with no propagation at all, as the control.
+//! - **macro**: the same function annotated with `#[propagate_context]`.
+//! - **manual-per-await**: the expansion written by hand, `FutureExt::with_context` on each awaited
+//!   future. This is what the macro replaces, so the two should measure the same. A gap here is a
+//!   bug in the macro rather than a cost of using it.
+//! - **manual-whole-body**: the alternative under discussion in
+//!   [#791](https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/791): one
+//!   `with_context` around the whole body instead of one per await. It attaches once per poll of the
+//!   body rather than once per poll of each awaited future, and it also covers the body's own
+//!   statements, so it is the interesting comparison for that decision.
+//!
+//! Each scenario runs twice, because the cost of carrying a context depends on what is in it:
+//!
+//! - **empty**: nothing is attached, which is what an uninstrumented process does. This isolates
+//!   the machinery, since the context has no span to clone.
+//! - **in-a-trace**: a context holding a span context, which is the case the macro exists for.
+//!
+//! ## What is being measured
+//!
+//! `Context::current()` reads a thread-local and clones, and each `with_context` attaches and
+//! detaches around a poll. The body awaits four futures that are ready on first poll and one that
+//! suspends once, so the measurement covers both a poll that returns immediately and a poll after a
+//! suspension. No SDK, exporter or tracer provider is involved: nothing here creates a span, so a
+//! provider would only add noise from a component the macro does not touch.
+//!
+//! ## Run
+//!
+//! ```sh
+//! cargo bench --bench propagation -p opentelemetry-context-macro
+//! ```
+//!
+//! ## Reference numbers
+//!
+//! Latest measurements (criterion median), for a body with five await points:
+//!
+//! | Scenario          | empty  | vs baseline | in a trace | vs baseline |
+//! | ----------------- | ------ | ----------- | ---------- | ----------- |
+//! | baseline          |  61 ns | —           |      66 ns | —           |
+//! | macro             | 126 ns | +65 ns      |     150 ns | +84 ns      |
+//! | manual-per-await  | 126 ns | +65 ns      |     151 ns | +85 ns      |
+//! | manual-whole-body |  78 ns | +17 ns      |      83 ns | +17 ns      |
+//!
+//! Two things to read from this. The macro measures the same as the hand-written per-await form, so
+//! it costs nothing beyond the propagation it writes for you. And the per-await form costs about
+//! four times the whole-body form, because it attaches once per awaited future rather than once per
+//! poll of the body, which is a point for the whole-body shape in #791 on top of the coverage
+//! argument.
+//!
+//! Captured on: MacBook Pro, Apple M4 Max (12P + 4E cores), 48 GB RAM, macOS 26.6.2,
+//! rustc 1.98.0, OpenTelemetry 0.32.
+
+use std::{
+    future::Future,
+    hint::black_box,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+    time::Instant,
+};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use opentelemetry::{
+    context::FutureExt,
+    trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
+    Context,
+};
+use opentelemetry_context_macro::propagate_context;
+
+/// Suspends once, so the body is polled again after the runtime has taken the context away.
+#[derive(Default)]
+struct SuspendOnce {
+    suspended: bool,
+}
+
+impl Future for SuspendOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        if self.suspended {
+            return Poll::Ready(());
+        }
+        self.suspended = true;
+        task_cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}
+
+/// The unit of work each scenario awaits. Ready on first poll, so the measurement is dominated by
+/// the propagation rather than by the work.
+async fn step(value: u64) -> u64 {
+    value + 1
+}
+
+async fn baseline(value: u64) -> u64 {
+    let value = step(value).await;
+    let value = step(value).await;
+    SuspendOnce::default().await;
+    let value = step(value).await;
+    step(value).await
+}
+
+#[propagate_context]
+async fn with_macro(value: u64) -> u64 {
+    let value = step(value).await;
+    let value = step(value).await;
+    SuspendOnce::default().await;
+    let value = step(value).await;
+    step(value).await
+}
+
+/// The macro's expansion, written out. Kept in step with `capturing_block` and `AwaitTransformer`
+/// in the crate: if the macro changes shape, this changes with it, or the comparison stops meaning
+/// anything.
+async fn manual_per_await(value: u64) -> u64 {
+    let cx = Context::current();
+    let value = step(value).with_context(cx.clone()).await;
+    let value = step(value).with_context(cx.clone()).await;
+    SuspendOnce::default().with_context(cx.clone()).await;
+    let value = step(value).with_context(cx.clone()).await;
+    step(value).with_context(cx).await
+}
+
+/// One attach around the whole body, the alternative shape under discussion.
+async fn manual_whole_body(value: u64) -> u64 {
+    let cx = Context::current();
+    async move {
+        let value = step(value).await;
+        let value = step(value).await;
+        SuspendOnce::default().await;
+        let value = step(value).await;
+        step(value).await
+    }
+    .with_context(cx)
+    .await
+}
+
+/// A context holding a span context, standing in for a caller that is already in a trace.
+///
+/// A fixed span context needs no tracer provider, so nothing in the measurement depends on SDK
+/// sampling or export behaviour.
+fn context_in_a_trace() -> Context {
+    Context::new().with_remote_span_context(SpanContext::new(
+        TraceId::from_bytes([1; 16]),
+        SpanId::from_bytes([2; 8]),
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::NONE,
+    ))
+}
+
+/// The scenarios, as futures behind one pointer type so a single loop can time them all.
+type Scenario = fn(u64) -> Pin<Box<dyn Future<Output = u64>>>;
+
+fn scenarios() -> [(&'static str, Scenario); 4] {
+    [
+        ("baseline", |value| Box::pin(baseline(value))),
+        ("macro", |value| Box::pin(with_macro(value))),
+        ("manual-per-await", |value| {
+            Box::pin(manual_per_await(value))
+        }),
+        ("manual-whole-body", |value| {
+            Box::pin(manual_whole_body(value))
+        }),
+    ]
+}
+
+fn benchmark_propagation(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("the runtime builds");
+
+    let mut group = c.benchmark_group("context-propagation");
+    group.throughput(Throughput::Elements(1));
+
+    for (context_name, context) in [
+        ("empty", Context::new()),
+        ("in-a-trace", context_in_a_trace()),
+    ] {
+        for (scenario_name, scenario) in scenarios() {
+            let id = BenchmarkId::new(scenario_name, context_name);
+            group.bench_function(id, |bencher| {
+                bencher.to_async(&runtime).iter_custom(|iterations| {
+                    let context = context.clone();
+                    async move {
+                        // The caller's context is attached outside the timed section, the way a
+                        // server's middleware attaches it before a handler runs.
+                        let _guard = context.attach();
+
+                        let start = Instant::now();
+                        for iteration in 0..iterations {
+                            black_box(scenario(black_box(iteration)).await);
+                        }
+                        start.elapsed()
+                    }
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_propagation);
+criterion_main!(benches);

--- a/opentelemetry-context-macro/examples/basic.rs
+++ b/opentelemetry-context-macro/examples/basic.rs
@@ -1,0 +1,173 @@
+//! Shows what `#[propagate_context]` does for work that happens after an await point.
+//!
+//! Run with `cargo run --example basic -p opentelemetry-context-macro`.
+//!
+//! The example plays the two halves of a service. A request arrives with a `traceparent` header,
+//! so the work belongs to a trace that started elsewhere. The handler waits on something slow and
+//! then calls another service, which has to send that same trace on in a header of its own.
+//!
+//! The wait is what makes this interesting. The OpenTelemetry context lives in a thread-local, and
+//! nothing restores that thread-local when a suspended future is polled again. The handler
+//! therefore resumes with an empty context unless something puts the context back. The macro does
+//! that: it captures the context on the handler's first poll and attaches it again for every future
+//! the handler awaits.
+//!
+//! Both handlers below are identical apart from the attribute, and the output shows the difference.
+//! The plain handler sends no `traceparent` at all, so the other service starts a trace of its own
+//! and the two halves of the request never join up. The third line shows what the macro saves you:
+//! the same result written by hand, with `FutureExt::with_context` at the call site.
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context as TaskContext, Poll, Wake, Waker},
+};
+
+use opentelemetry::{
+    context::FutureExt,
+    propagation::{Extractor, Injector, TextMapPropagator},
+    Context,
+};
+use opentelemetry_context_macro::propagate_context;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+
+/// The headers of the request that arrives, already part of a trace.
+fn inbound_headers() -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    headers.insert(
+        "traceparent".to_owned(),
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_owned(),
+    );
+    headers
+}
+
+/// A `HashMap` the propagator can read from and write to.
+struct HeaderMap(HashMap<String, String>);
+
+impl Extractor for HeaderMap {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}
+
+impl Injector for HeaderMap {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_owned(), value);
+    }
+}
+
+/// Stands in for an HTTP client: reads the current context and writes it into request headers.
+///
+/// A real client does the same thing, which is why the context has to be right at the moment the
+/// call is made, and not only at the moment the handler started.
+async fn call_other_service() -> String {
+    let mut headers = HeaderMap(HashMap::new());
+    TraceContextPropagator::new().inject_context(&Context::current(), &mut headers);
+
+    headers
+        .0
+        .get("traceparent")
+        .cloned()
+        .unwrap_or_else(|| "<none>".to_owned())
+}
+
+/// The handler that carries the context past the wait.
+///
+/// The macro creates no span. Whether a function deserves a span of its own stays a decision for
+/// the code, so create and activate one where you want one.
+#[propagate_context]
+async fn handle_request() -> String {
+    slow_work().await;
+    call_other_service().await
+}
+
+/// The same handler without the attribute, for comparison.
+async fn handle_request_without_the_macro() -> String {
+    slow_work().await;
+    call_other_service().await
+}
+
+/// Suspends once, the way a database query or a queue would.
+#[derive(Default)]
+struct SlowWork {
+    suspended: bool,
+}
+
+impl Future for SlowWork {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        if self.suspended {
+            return Poll::Ready(());
+        }
+        self.suspended = true;
+        task_cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}
+
+fn slow_work() -> SlowWork {
+    SlowWork::default()
+}
+
+struct NoopWake;
+
+impl Wake for NoopWake {
+    fn wake(self: Arc<Self>) {}
+}
+
+/// Runs `future` the way work runs when nothing re-attaches the context: attached while the work
+/// starts, gone from every poll after that.
+///
+/// Middleware such as `opentelemetry-instrumentation-tower` attaches the context for each poll of
+/// the future it wraps, which covers the handlers it polls directly. Work it cannot reach, such as
+/// a future a combinator holds or a task that took the context in by hand, is polled like this.
+fn run_losing_the_context<F: Future>(future: F, cx: Context) -> F::Output {
+    let waker = Waker::from(Arc::new(NoopWake));
+    let mut task_cx = TaskContext::from_waker(&waker);
+    let mut future = Box::pin(future);
+
+    let first_poll = {
+        let _guard = cx.attach();
+        future.as_mut().poll(&mut task_cx)
+    };
+    if let Poll::Ready(output) = first_poll {
+        return output;
+    }
+
+    loop {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut task_cx) {
+            return output;
+        }
+    }
+}
+
+fn main() {
+    let headers = HeaderMap(inbound_headers());
+    let inbound_cx = TraceContextPropagator::new().extract(&headers);
+
+    let with_macro = run_losing_the_context(handle_request(), inbound_cx.clone());
+    let without_macro =
+        run_losing_the_context(handle_request_without_the_macro(), inbound_cx.clone());
+
+    // The alternative the macro saves you from writing: the caller attaches the context for every
+    // poll of the handler, which covers the handler's own statements as well as what it awaits.
+    let by_hand = run_losing_the_context(
+        handle_request_without_the_macro().with_context(inbound_cx.clone()),
+        inbound_cx,
+    );
+
+    println!(
+        "inbound  traceparent:            {:?}",
+        headers.get("traceparent")
+    );
+    println!("outbound traceparent (macro):    {with_macro}");
+    println!("outbound traceparent (no macro): {without_macro}");
+    println!("outbound traceparent (by hand):  {by_hand}");
+}

--- a/opentelemetry-context-macro/examples/basic.rs
+++ b/opentelemetry-context-macro/examples/basic.rs
@@ -10,12 +10,7 @@
 //! nothing restores that thread-local when a suspended future is polled again. The handler
 //! therefore resumes with an empty context unless something puts the context back. The macro does
 //! that: it captures the context on the handler's first poll and attaches it again for every future
-//! the handler awaits.
-//!
-//! Both handlers below are identical apart from the attribute, and the output shows the difference.
-//! The plain handler sends no `traceparent` at all, so the other service starts a trace of its own
-//! and the two halves of the request never join up. The third line shows what the macro saves you:
-//! the same result written by hand, with `FutureExt::with_context` at the call site.
+//! the handler awaits, which is why the outgoing header repeats the inbound trace id.
 
 use std::{
     collections::HashMap,
@@ -26,7 +21,6 @@ use std::{
 };
 
 use opentelemetry::{
-    context::FutureExt,
     propagation::{Extractor, Injector, TextMapPropagator},
     Context,
 };
@@ -83,12 +77,6 @@ async fn call_other_service() -> String {
 /// the code, so create and activate one where you want one.
 #[propagate_context]
 async fn handle_request() -> String {
-    slow_work().await;
-    call_other_service().await
-}
-
-/// The same handler without the attribute, for comparison.
-async fn handle_request_without_the_macro() -> String {
     slow_work().await;
     call_other_service().await
 }
@@ -152,22 +140,8 @@ fn main() {
     let headers = HeaderMap(inbound_headers());
     let inbound_cx = TraceContextPropagator::new().extract(&headers);
 
-    let with_macro = run_losing_the_context(handle_request(), inbound_cx.clone());
-    let without_macro =
-        run_losing_the_context(handle_request_without_the_macro(), inbound_cx.clone());
+    let outbound = run_losing_the_context(handle_request(), inbound_cx);
 
-    // The alternative the macro saves you from writing: the caller attaches the context for every
-    // poll of the handler, which covers the handler's own statements as well as what it awaits.
-    let by_hand = run_losing_the_context(
-        handle_request_without_the_macro().with_context(inbound_cx.clone()),
-        inbound_cx,
-    );
-
-    println!(
-        "inbound  traceparent:            {:?}",
-        headers.get("traceparent")
-    );
-    println!("outbound traceparent (macro):    {with_macro}");
-    println!("outbound traceparent (no macro): {without_macro}");
-    println!("outbound traceparent (by hand):  {by_hand}");
+    println!("inbound  traceparent: {:?}", headers.get("traceparent"));
+    println!("outbound traceparent: {outbound}");
 }

--- a/opentelemetry-context-macro/src/lib.rs
+++ b/opentelemetry-context-macro/src/lib.rs
@@ -1,0 +1,273 @@
+//! Propagate the current OpenTelemetry context across the await points of an async function.
+//!
+//! The [`propagate_context`] attribute macro rewrites every `.await` in the annotated body so the
+//! awaited future runs with the context the body started with. It does not create a span and it
+//! does not change which span is current, so a caller stays in control of its own trace.
+//!
+//! # The problem it solves
+//!
+//! [`Context`][context] lives in a thread-local, and an async runtime does not carry that
+//! thread-local across a suspension point. The context is therefore current for the first poll of
+//! a future and gone for every later one. Work after the first `.await` then reads an empty
+//! context: an outgoing request carries no `traceparent` header, and a child span attaches to
+//! nothing.
+//!
+//! The usual fix is [`FutureExt::with_context`][future-ext] at every call site, which is easy to
+//! forget and noisy to read. This macro applies it for you.
+//!
+//! # Usage
+//!
+//! ```
+//! use opentelemetry_context_macro::propagate_context;
+//!
+//! # async fn charge(order: u64) -> u64 { order }
+//! # async fn ship(order: u64) -> u64 { order }
+//! #[propagate_context]
+//! async fn place_order(order: u64) -> u64 {
+//!     // Both calls see the context that `place_order` was called with, even though the runtime
+//!     // drops it at the first suspension point.
+//!     charge(order).await;
+//!     ship(order).await
+//! }
+//! ```
+//!
+//! The annotated crate needs `opentelemetry` as a dependency, because the expansion names it.
+//! The `futures` feature carries [`FutureExt`][future-ext] and is on by default.
+//!
+//! # How it works
+//!
+//! The macro makes two changes to the body:
+//!
+//! 1. It binds `__otel_cx` to [`Context::current()`][current] as the first statement of the async
+//!    body. The body of an `async fn` runs on first poll, so this reads the context of the caller
+//!    that polls the future, not of the code that created it.
+//! 2. It rewrites every `.await` in that body from `future.await` to
+//!    `FutureExt::with_context(future, __otel_cx.clone()).await`, which attaches the captured
+//!    context for each poll of that future and detaches it again when the poll returns.
+//!
+//! Capturing once and reusing the clone is the point. Reading the current context at each await
+//! instead would read an empty context after the first suspension, which is the problem this macro
+//! exists to fix.
+//!
+//! The expansion writes every path in full, as `<_ as ::opentelemetry::context::FutureExt>::
+//! with_context(..)` rather than a method call on an imported trait, and it imports nothing into
+//! the annotated function. Instrumented code is free to import a different `with_context`, such as
+//! the one on `anyhow::Context`, without the two becoming ambiguous. Application code has no such
+//! constraint, so the examples here import [`FutureExt`][future-ext-trait] and call the method
+//! directly.
+//!
+//! # `#[async_trait]` methods
+//!
+//! The macro also accepts the shape [`async_trait`] generates, which is a synchronous function
+//! that returns `Box::pin(async move { .. })`. The capture goes inside that async block, not at
+//! the top of the synchronous function.
+//!
+//! The distinction matters because the arguments of a call are evaluated before the call. In
+//! `service.method().await` the synchronous `method()` runs before the surrounding
+//! `with_context(..)` attaches anything, so a capture at the top of it would read the context of
+//! whoever polls the caller, which is empty after the caller's first suspension. Inside the async
+//! block the capture instead runs on first poll, under the attached context.
+//!
+//! # What it does not cover
+//!
+//! - **A span is never created.** Nothing is added to the trace, and the current span inside the
+//!   body stays the caller's span. Create and activate a span yourself where you want one.
+//! - **The body's own statements are not covered**, only the futures it awaits. A log line
+//!   between two awaits still reads whatever context the runtime left attached. Attach the context
+//!   for a whole body with [`FutureExt::with_context`][future-ext] on the outermost future when you
+//!   need that.
+//! - **The captured context wins at the await points.** A body that attaches a context of its own
+//!   and then awaits sees that context in its own statements, while the awaited future sees the
+//!   captured one. Call [`FutureExt::with_context`][future-ext] at the call site when a single call
+//!   has to run under a different context.
+//! - **Nested `async` blocks, closures and macro bodies are left alone.** An `async` block that is
+//!   awaited inline is covered anyway, because the enclosing `.await` attaches the context for the
+//!   whole poll. One that is spawned is not, and neither are the arms of `select!` or `join!`,
+//!   since a macro body is opaque tokens at expansion time.
+//! - **Nested `fn`, `impl`, `mod` and other item definitions are left alone.** Their bodies run
+//!   with their own callers' contexts, and the captured binding is not in scope there.
+//! - **A spawned task starts with an empty context.** Pass the context in explicitly:
+//!
+//! ```
+//! # use opentelemetry::{context::FutureExt, Context};
+//! # async fn work() {}
+//! # async fn spawning() {
+//! let task_cx = Context::current();
+//! tokio::spawn(async move { work().await }.with_context(task_cx));
+//! # }
+//! ```
+//!
+//! [context]: https://docs.rs/opentelemetry/latest/opentelemetry/struct.Context.html
+//! [current]: https://docs.rs/opentelemetry/latest/opentelemetry/struct.Context.html#method.current
+//! [future-ext]: https://docs.rs/opentelemetry/latest/opentelemetry/context/trait.FutureExt.html#method.with_context
+//! [future-ext-trait]: https://docs.rs/opentelemetry/latest/opentelemetry/context/trait.FutureExt.html
+//! [`async_trait`]: https://docs.rs/async-trait
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    fold::Fold, parse_macro_input, Block, Expr, ExprAsync, ExprAwait, ExprClosure, Item, ItemFn,
+    Stmt,
+};
+
+/// Propagate the current OpenTelemetry context across every await point of an async function.
+///
+/// The macro takes no arguments. It accepts an `async fn`, and the synchronous
+/// `Box::pin(async move { .. })`-returning function that `#[async_trait]` generates from one.
+///
+/// ```
+/// use opentelemetry_context_macro::propagate_context;
+///
+/// # async fn fetch_user(id: u64) -> String { id.to_string() }
+/// # async fn fetch_orders(user: &str) -> usize { user.len() }
+/// #[propagate_context]
+/// async fn load_profile(id: u64) -> usize {
+///     let user = fetch_user(id).await;
+///     fetch_orders(&user).await
+/// }
+/// ```
+///
+/// See the [crate documentation](crate) for what the expansion looks like, and for the cases it
+/// deliberately leaves alone.
+#[proc_macro_attribute]
+pub fn propagate_context(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        let message = "propagate_context takes no arguments";
+        return TokenStream::from(quote! { ::core::compile_error!(#message); });
+    }
+
+    let input = parse_macro_input!(item as ItemFn);
+
+    match transform_function(input) {
+        Ok(output) => TokenStream::from(quote! { #output }),
+        Err(error) => TokenStream::from(error.to_compile_error()),
+    }
+}
+
+fn transform_function(mut func: ItemFn) -> syn::Result<ItemFn> {
+    // The body of an `async fn` *is* the future, so a capture placed at its top runs on first
+    // poll, under the context of whoever polls it.
+    if func.sig.asyncness.is_some() {
+        let body = AwaitTransformer.fold_block(*func.block);
+        func.block = Box::new(capturing_block(&body));
+        return Ok(func);
+    }
+
+    if !returns_boxed_future(&func.sig.output) {
+        return Err(syn::Error::new_spanned(
+            &func.sig,
+            "propagate_context expects an `async fn`, or the `Pin<Box<dyn Future>>`-returning \
+             function that #[async_trait] generates from one",
+        ));
+    }
+
+    // A synchronous function returning `Pin<Box<dyn Future<..>>>`, which is the shape
+    // `#[async_trait]` generates: a single `Box::pin(async move { .. })` statement. Rebuild the
+    // outer block around the rewritten inner one, so the capture lands inside the future.
+    let Some(inner_block) = async_trait_inner_block(&func.block) else {
+        return Err(syn::Error::new_spanned(
+            &func.sig,
+            "propagate_context could not find a `Box::pin(async move { .. })` body in this \
+             Pin<Box<dyn Future>>-returning function (the shape #[async_trait] generates)",
+        ));
+    };
+    let inner_body = AwaitTransformer.fold_block(inner_block.clone());
+    let new_inner = capturing_block(&inner_body);
+    func.block = syn::parse_quote! {
+        {
+            Box::pin(async move #new_inner)
+        }
+    };
+    Ok(func)
+}
+
+/// Whether `output` is (roughly) `Pin<Box<dyn Future<..>>>`, the return type `#[async_trait]`
+/// generates for a desugared `async fn`.
+///
+/// This matches the outer `Pin` alone, whatever the path qualification, because `#[async_trait]`
+/// always writes its generated types in full, as `::core::pin::Pin`, to stay independent of the
+/// call site's imports. An ordinary synchronous function rarely returns a bare `Pin`, so the outer
+/// type is specific enough on its own.
+fn returns_boxed_future(output: &syn::ReturnType) -> bool {
+    let syn::ReturnType::Type(_, ty) = output else {
+        return false;
+    };
+    let syn::Type::Path(type_path) = ty.as_ref() else {
+        return false;
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "Pin")
+}
+
+/// Extracts the inner `async move { .. }` block from a body shaped like
+/// `Box::pin(async move { .. })`, the sole statement `#[async_trait]` generates for a desugared
+/// `async fn`.
+fn async_trait_inner_block(block: &Block) -> Option<&Block> {
+    let [Stmt::Expr(Expr::Call(call), _)] = block.stmts.as_slice() else {
+        return None;
+    };
+    let mut args = call.args.iter();
+    match (args.next(), args.next()) {
+        (Some(Expr::Async(async_expr)), None) => Some(&async_expr.block),
+        _ => None,
+    }
+}
+
+/// Wraps `block` in one that captures the current context as `__otel_cx` first.
+///
+/// The name starts with an underscore so a body without a single await point, where the binding
+/// goes unused, still compiles without a warning.
+fn capturing_block(block: &Block) -> Block {
+    syn::parse_quote! {
+        {
+            let __otel_cx = ::opentelemetry::Context::current();
+            #block
+        }
+    }
+}
+
+/// Rewrites each `.await` to attach the captured context for the poll of the awaited future.
+struct AwaitTransformer;
+
+impl Fold for AwaitTransformer {
+    fn fold_expr_await(&mut self, node: ExprAwait) -> ExprAwait {
+        // Descend first, so an await nested in the awaited expression, as in
+        // `outer(inner().await).await`, is rewritten too.
+        let node = syn::fold::fold_expr_await(self, node);
+        let base = node.base;
+
+        ExprAwait {
+            attrs: node.attrs,
+            base: Box::new(syn::parse_quote! {
+                <_ as ::opentelemetry::context::FutureExt>::with_context(
+                    #base,
+                    ::core::clone::Clone::clone(&__otel_cx),
+                )
+            }),
+            dot_token: node.dot_token,
+            await_token: node.await_token,
+        }
+    }
+
+    /// Leaves a nested item definition, such as a `fn` or an `impl` block, untouched. Its body has
+    /// its own callers and its own context, and the captured binding is not in scope inside it.
+    fn fold_item(&mut self, item: Item) -> Item {
+        item
+    }
+
+    /// Leaves a nested `async` block untouched. One that is awaited inline is already covered by
+    /// the enclosing `.await`, and rewriting an `async move` block would move the captured
+    /// context into it, taking it away from the rest of the body.
+    fn fold_expr_async(&mut self, expr: ExprAsync) -> ExprAsync {
+        expr
+    }
+
+    /// Leaves a closure untouched, for the same reason as an `async` block: a `move` closure would
+    /// take the captured context with it.
+    fn fold_expr_closure(&mut self, expr: ExprClosure) -> ExprClosure {
+        expr
+    }
+}

--- a/opentelemetry-context-macro/tests/propagation.rs
+++ b/opentelemetry-context-macro/tests/propagation.rs
@@ -1,0 +1,372 @@
+//! What `#[propagate_context]` guarantees about context propagation.
+//!
+//! Every test drives its future by hand instead of on an async runtime, because the guarantee is
+//! about what happens when the context is no longer attached. [`drive_after_losing_context`]
+//! reproduces exactly that: the first poll runs with a context attached, every later poll runs
+//! with none, which is what a runtime does to any future that suspends.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context as TaskContext, Poll, Wake, Waker},
+};
+
+use async_trait::async_trait;
+use opentelemetry::{
+    trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
+    Context,
+};
+use opentelemetry_context_macro::propagate_context;
+
+/// The span id of the context the caller starts with, as its `traceparent` form.
+const CALLER_SPAN_ID: &str = "00f067aa0ba902b7";
+
+/// The span id of an empty context, which is what a body reads once the context is lost.
+const NO_SPAN_ID: &str = "0000000000000000";
+
+/// A context naming a fixed remote span, standing in for a caller that is already in a trace.
+///
+/// A fixed span context keeps the expected values in each test literal, and needs no SDK, tracer
+/// provider or exporter to produce one.
+fn caller_context() -> Context {
+    Context::new().with_remote_span_context(SpanContext::new(
+        TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").expect("valid trace id"),
+        SpanId::from_hex(CALLER_SPAN_ID).expect("valid span id"),
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::NONE,
+    ))
+}
+
+/// The span id that `Context::current()` names right now, as its `traceparent` form.
+fn current_span_id() -> String {
+    Context::current()
+        .span()
+        .span_context()
+        .span_id()
+        .to_string()
+}
+
+/// Reports the span id current at the time this future is polled, rather than at the time it is
+/// created, which is what makes it an observer of the attached context.
+async fn observe() -> String {
+    current_span_id()
+}
+
+/// Hands `value` back after a poll, so an observation can be made behind another await point.
+async fn relay(value: String) -> String {
+    value
+}
+
+/// A future that suspends exactly once, so the poll after it stands for the poll a runtime makes
+/// after a suspension: without any context attached.
+#[derive(Default)]
+struct SuspendOnce {
+    suspended: bool,
+}
+
+impl Future for SuspendOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        if self.suspended {
+            return Poll::Ready(());
+        }
+        self.suspended = true;
+        task_cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}
+
+struct NoopWake;
+
+impl Wake for NoopWake {
+    fn wake(self: Arc<Self>) {}
+}
+
+/// Runs `future` to completion with `cx` attached for its first poll only.
+///
+/// An async runtime attaches nothing of its own, so a future that suspends is polled again with an
+/// empty context. Any context the body still sees after that point is one it captured itself,
+/// which is what these tests measure.
+fn drive_after_losing_context<F: Future>(future: F, cx: Context) -> F::Output {
+    let waker = Waker::from(Arc::new(NoopWake));
+    let mut task_cx = TaskContext::from_waker(&waker);
+    let mut future = Box::pin(future);
+
+    let first_poll = {
+        let _guard = cx.attach();
+        future.as_mut().poll(&mut task_cx)
+    };
+    if let Poll::Ready(output) = first_poll {
+        return output;
+    }
+
+    loop {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut task_cx) {
+            return output;
+        }
+    }
+}
+
+/// The context a body starts with must reach every future it awaits, however the body is shaped.
+///
+/// Each case awaits an observer and reports the span id that observer saw. The unannotated case is
+/// the control: it shows that the harness really does take the context away, so a passing
+/// annotated case means the macro carried it and not that the context was never lost.
+#[test]
+fn awaited_futures_see_the_context_the_body_started_with() {
+    struct TestCase {
+        name: &'static str,
+        observe: fn() -> Pin<Box<dyn Future<Output = String>>>,
+        expected_span_id: &'static str,
+    }
+
+    async fn unannotated_after_suspension() -> String {
+        SuspendOnce::default().await;
+        observe().await
+    }
+
+    #[propagate_context]
+    async fn before_suspension() -> String {
+        observe().await
+    }
+
+    #[propagate_context]
+    async fn after_suspension() -> String {
+        SuspendOnce::default().await;
+        observe().await
+    }
+
+    #[propagate_context]
+    async fn without_await_points() -> String {
+        current_span_id()
+    }
+
+    #[propagate_context]
+    async fn await_nested_in_awaited_expression() -> String {
+        SuspendOnce::default().await;
+        relay(observe().await).await
+    }
+
+    #[propagate_context]
+    async fn await_in_loop_and_match() -> String {
+        SuspendOnce::default().await;
+
+        let mut observed = String::new();
+        for _ in 0..2 {
+            observed = observe().await;
+        }
+
+        match observed.is_empty() {
+            true => observe().await,
+            false => observed,
+        }
+    }
+
+    #[propagate_context]
+    async fn await_through_nested_item_and_async_block() -> String {
+        // A nested item is left as written, so its body must not reference the captured binding.
+        // An inline `async` block is left as written too, and is covered anyway by the `.await`
+        // that polls it.
+        async fn nested_item() -> String {
+            observe().await
+        }
+
+        SuspendOnce::default().await;
+        async { nested_item().await }.await
+    }
+
+    #[propagate_context]
+    async fn await_after_two_suspensions() -> String {
+        SuspendOnce::default().await;
+        let first = observe().await;
+        SuspendOnce::default().await;
+        let second = observe().await;
+
+        assert_eq!(first, second, "the captured context must survive reuse");
+        second
+    }
+
+    #[async_trait]
+    trait Probe {
+        async fn observe_through_trait(&self) -> String;
+    }
+
+    struct TraitProbe;
+
+    #[async_trait]
+    impl Probe for TraitProbe {
+        #[propagate_context]
+        async fn observe_through_trait(&self) -> String {
+            SuspendOnce::default().await;
+            observe().await
+        }
+    }
+
+    #[propagate_context]
+    async fn call_trait_method_after_suspension() -> String {
+        SuspendOnce::default().await;
+        TraitProbe.observe_through_trait().await
+    }
+
+    let test_cases = vec![
+        TestCase {
+            name: "unannotated body, awaiting after a suspension",
+            observe: || Box::pin(unannotated_after_suspension()),
+            expected_span_id: NO_SPAN_ID,
+        },
+        TestCase {
+            name: "annotated body, awaiting before any suspension",
+            observe: || Box::pin(before_suspension()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "annotated body, awaiting after a suspension",
+            observe: || Box::pin(after_suspension()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "annotated body without a single await point",
+            observe: || Box::pin(without_await_points()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "await nested in the expression another await consumes",
+            observe: || Box::pin(await_nested_in_awaited_expression()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "await inside a loop and a match arm",
+            observe: || Box::pin(await_in_loop_and_match()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "await reaching through a nested item and an inline async block",
+            observe: || Box::pin(await_through_nested_item_and_async_block()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "await after the body suspended twice",
+            observe: || Box::pin(await_after_two_suspensions()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+        TestCase {
+            name: "async_trait method called after the caller suspended",
+            observe: || Box::pin(call_trait_method_after_suspension()),
+            expected_span_id: CALLER_SPAN_ID,
+        },
+    ];
+
+    for TestCase {
+        name,
+        observe,
+        expected_span_id,
+    } in test_cases
+    {
+        let observed = drive_after_losing_context(observe(), caller_context());
+
+        assert_eq!(observed, expected_span_id, "Failed case: {name}");
+    }
+}
+
+/// The macro must not touch the trace itself: no span is created, and the current span stays the
+/// caller's own.
+///
+/// A created span would show up as a different span id, and a replaced one as a different trace id
+/// or sampling decision, so comparing the whole span context covers both.
+#[test]
+fn the_current_span_stays_the_callers_span() {
+    #[propagate_context]
+    async fn observe_span_context() -> (String, String, bool) {
+        SuspendOnce::default().await;
+        observe_span_context_inner().await
+    }
+
+    async fn observe_span_context_inner() -> (String, String, bool) {
+        let span_context = Context::current().span().span_context().clone();
+        (
+            span_context.trace_id().to_string(),
+            span_context.span_id().to_string(),
+            span_context.is_sampled(),
+        )
+    }
+
+    let observed = drive_after_losing_context(observe_span_context(), caller_context());
+
+    assert_eq!(
+        observed,
+        (
+            "4bf92f3577b34da6a3ce929d0e0e4736".to_owned(),
+            CALLER_SPAN_ID.to_owned(),
+            true
+        )
+    );
+}
+
+/// Rewriting the await points must leave the function's own contract alone: the value it returns,
+/// and the early exit `?` performs on an error.
+#[test]
+fn the_function_keeps_its_return_value_and_early_exits() {
+    #[propagate_context]
+    async fn succeeds() -> Result<String, String> {
+        SuspendOnce::default().await;
+        let observed = fallible(Ok(observe().await)).await?;
+        Ok(observed)
+    }
+
+    #[propagate_context]
+    async fn fails() -> Result<String, String> {
+        SuspendOnce::default().await;
+        let observed = fallible(Err("rejected".to_owned())).await?;
+
+        unreachable!("`?` must return before this point, observed {observed}");
+    }
+
+    async fn fallible(outcome: Result<String, String>) -> Result<String, String> {
+        outcome
+    }
+
+    let succeeded = drive_after_losing_context(succeeds(), caller_context());
+    let failed = drive_after_losing_context(fails(), caller_context());
+
+    assert_eq!(
+        (succeeded, failed),
+        (Ok(CALLER_SPAN_ID.to_owned()), Err("rejected".to_owned()))
+    );
+}
+
+/// The captured context wins at the await points, even over a context the body attached itself.
+///
+/// This is a consequence of capturing once, and worth pinning because it is surprising: a body that
+/// attaches a child context and then awaits sees that child in its own statements, while the future
+/// it awaits sees the captured one. Reach for `FutureExt::with_context` at the call site when a
+/// single call has to run under a different context.
+#[test]
+fn a_context_the_body_attaches_does_not_reach_the_futures_it_awaits() {
+    const LOCAL_SPAN_ID: &str = "00f067aa0ba902b8";
+
+    #[propagate_context]
+    async fn attaches_a_context_of_its_own() -> (String, String) {
+        SuspendOnce::default().await;
+
+        let local_cx = Context::new().with_remote_span_context(SpanContext::new(
+            TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").expect("valid trace id"),
+            SpanId::from_hex(LOCAL_SPAN_ID).expect("valid span id"),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::NONE,
+        ));
+        let _guard = local_cx.attach();
+
+        (current_span_id(), observe().await)
+    }
+
+    let observed = drive_after_losing_context(attaches_a_context_of_its_own(), caller_context());
+
+    assert_eq!(
+        observed,
+        (LOCAL_SPAN_ID.to_owned(), CALLER_SPAN_ID.to_owned())
+    );
+}


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #791

## Changes

This adds `#[propagate_context]`, which carries the context across the await points of the function it annotates.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

AI attribution: Claude Opus 5 (eu.anthropic.claude-opus-5) via Crush.