### PR TITLE
test: Add trace exporter scalability stress tests

### DIFF
--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -17,6 +17,16 @@ path = "src/etw_logs.rs"
 doc = false
 
 [[bin]]
+name = "user_events_traces"
+path = "src/user_events_traces.rs"
+doc = false
+
+[[bin]]
+name = "etw_traces"
+path = "src/etw_traces.rs"
+doc = false
+
+[[bin]]
 name = "geneva_exporter"
 path = "src/geneva_exporter.rs"
 
@@ -30,10 +40,13 @@ wiremock = "0.6"
 futures = "0.3"
 
 opentelemetry-appender-tracing = { version = "0.32" }
-opentelemetry_sdk = { version = "0.32", features = ["logs"] }
+opentelemetry = { version = "0.32", features = ["trace"] }
+opentelemetry_sdk = { version = "0.32", features = ["logs", "trace"] }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["logs", "gen-tonic-messages"] }
 opentelemetry-user-events-logs = { path = "../opentelemetry-user-events-logs" }
+opentelemetry-user-events-trace = { path = "../opentelemetry-user-events-trace" }
 opentelemetry-etw-logs = { path = "../opentelemetry-etw-logs"}
+opentelemetry-etw-traces = { path = "../opentelemetry-etw-traces" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["env-filter","registry", "std"] }
 geneva-uploader = { version = "0.7.1", path = "../opentelemetry-exporter-geneva/geneva-uploader", features = ["mock_auth"]}

--- a/stress/src/etw_traces.rs
+++ b/stress/src/etw_traces.rs
@@ -1,0 +1,26 @@
+//! Run with `cargo run --bin etw_traces --release -- <num-threads>`.
+//!
+//! Use an ETW session for provider `stress_traces` to measure with a listener
+//! enabled. Run with several thread counts, such as 1, 2, 4, 8, and the number
+//! of logical processors, to verify throughput scales with available CPUs.
+
+use opentelemetry::trace::{Span, Tracer, TracerProvider};
+use opentelemetry_etw_traces::Processor;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+
+mod throughput;
+
+fn main() {
+    let processor = Processor::builder("stress_traces").build().unwrap();
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let tracer = provider.tracer("stress");
+
+    println!("Starting stress test for ETW traces...");
+    throughput::test_throughput(move || {
+        let mut span = tracer.start("stress-span");
+        span.end();
+    });
+    println!("Stress test completed.");
+}

--- a/stress/src/user_events_traces.rs
+++ b/stress/src/user_events_traces.rs
@@ -1,0 +1,28 @@
+//! Run with `sudo -E cargo run --bin user_events_traces --release -- <num-threads>`.
+//!
+//! To measure with a listener enabled:
+//! `echo 1 | sudo tee /sys/kernel/debug/tracing/events/user_events/stress_traces_L4K1/enable`
+//!
+//! Run with several thread counts, such as 1, 2, 4, 8, and the number of
+//! logical processors, to verify throughput scales with available CPUs.
+
+use opentelemetry::trace::{Span, Tracer, TracerProvider};
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_user_events_trace::Processor;
+
+mod throughput;
+
+fn main() {
+    let processor = Processor::builder("stress_traces").build().unwrap();
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+    let tracer = provider.tracer("stress");
+
+    println!("Starting stress test for user_events traces...");
+    throughput::test_throughput(move || {
+        let mut span = tracer.start("stress-span");
+        span.end();
+    });
+    println!("Stress test completed.");
+}


### PR DESCRIPTION
## Changes

Add manual multithreaded throughput stress tests for the user-events trace and ETW trace exporters. Both binaries exercise the full OpenTelemetry SDK span path with the same minimal workload and accept a thread-count argument, allowing throughput to be compared at 1, 2, 4, 8, and the available logical processor count with listeners enabled or disabled.

These scenarios cover a gap in the existing stress harness, which measured CPU scaling for logs but only had a single-threaded benchmark for traces. They are intended to reveal shared hot-path contention that prevents export throughput from scaling across cores.

This builds on the public user-events trace `Processor` API added in #793.

## Running

```sh
sudo -E cargo run --bin user_events_traces --release -- <num-threads>
cargo run --bin etw_traces --release -- <num-threads>
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)